### PR TITLE
Enhanced HTTP observability by exposing complete raw headers

### DIFF
--- a/src/observable_signals.rs
+++ b/src/observable_signals.rs
@@ -2,6 +2,7 @@ use crate::http::{Header, Version};
 use crate::tcp::{IpVersion, PayloadSize, Quirk, TcpOption, WindowSize};
 use crate::tls::{Ja4Payload, TlsVersion};
 use crate::Ttl;
+use std::collections::HashMap;
 
 // Observable TCP signals
 #[derive(Debug, Clone)]
@@ -61,6 +62,12 @@ pub struct ObservableHttpRequest {
     pub habsent: Vec<Header>,
     /// expected substring in 'User-Agent' or 'Server'.
     pub expsw: String,
+    /// Complete raw headers with all values for IP extraction and correlation
+    pub raw_headers: std::collections::HashMap<String, String>,
+    /// HTTP method (GET, POST, PUT, etc.)
+    pub method: Option<String>,
+    /// Request URI/path
+    pub uri: Option<String>,
 }
 
 // Observable HTTP response signals
@@ -74,6 +81,10 @@ pub struct ObservableHttpResponse {
     pub habsent: Vec<Header>,
     /// expected substring in 'User-Agent' or 'Server'.
     pub expsw: String,
+    /// Complete raw headers with all values
+    pub raw_headers: std::collections::HashMap<String, String>,
+    /// HTTP status code
+    pub status_code: Option<u16>,
 }
 
 // Observable MTU signals

--- a/src/observable_signals.rs
+++ b/src/observable_signals.rs
@@ -2,7 +2,6 @@ use crate::http::{Header, Version};
 use crate::tcp::{IpVersion, PayloadSize, Quirk, TcpOption, WindowSize};
 use crate::tls::{Ja4Payload, TlsVersion};
 use crate::Ttl;
-use std::collections::HashMap;
 
 // Observable TCP signals
 #[derive(Debug, Clone)]

--- a/src/signature_matcher.rs
+++ b/src/signature_matcher.rs
@@ -169,6 +169,9 @@ mod tests {
             ],
             habsent: vec![],
             expsw: "Firefox/".to_string(),
+            raw_headers: std::collections::HashMap::new(),
+            method: Some("GET".to_string()),
+            uri: Some("/".to_string()),
         };
 
         let matcher = SignatureMatcher::new(db);
@@ -210,6 +213,8 @@ mod tests {
             ],
             habsent: vec![],
             expsw: "Apache".to_string(),
+            raw_headers: std::collections::HashMap::new(),
+            status_code: Some(200),
         };
 
         let matcher = SignatureMatcher::new(db);
@@ -249,6 +254,9 @@ mod tests {
                 http::Header::new("Keep-Alive"),
             ],
             expsw: "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Mobile Safari/537.36".to_string(),
+            raw_headers: std::collections::HashMap::new(),
+            method: Some("GET".to_string()),
+            uri: Some("/".to_string()),
         };
 
         let matcher = SignatureMatcher::new(db);


### PR DESCRIPTION
Enhanced HTTP observability by exposing complete raw headers in ObservableHttpRequest and ObservableHttpResponse structs, enabling real IP extraction and advanced correlation analysis.

When deploying huginn-net behind proxies (e.g., Traefik, Nginx, Cloudflare), HTTP traffic analysis becomes challenging due to TLS encryption. The library can only inspect HTTP data after TLS termination, but crucial information like real client IPs are contained in proxy headers (X-Real-IP, X-Forwarded-For, CF-Connecting-IP, etc.).
