### PR TITLE
removing crossbeam from http interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Passive Traffic Fingerprinting is a technique that allows you to infer informati
 
 ## 🚀 Quick Start
 
+> **Note:** Live packet capture requires `libpcap` (usually pre-installed on Linux/macOS).
+
 ### Choose Your Approach
 
 **For multi-protocol analysis:**

--- a/benches/bench_http.rs
+++ b/benches/bench_http.rs
@@ -1042,7 +1042,7 @@ fn bench_http_parallel_processing(c: &mut Criterion) {
         let bench_name = format!("parallel_{num_workers}_workers");
         group.bench_function(&bench_name, |b| {
             b.iter(|| {
-                let (tx, rx) = crossbeam_channel::unbounded();
+                let (tx, rx) = std::sync::mpsc::channel();
                 let pool = match huginn_net_http::WorkerPool::new(
                     num_workers,
                     100,
@@ -1074,7 +1074,7 @@ fn bench_http_parallel_processing(c: &mut Criterion) {
     // Measure parallel processing times for reporting
     let parallel_2_workers_time = measure_average_time(
         || {
-            let (tx, rx) = crossbeam_channel::unbounded();
+            let (tx, rx) = std::sync::mpsc::channel();
             let pool = match huginn_net_http::WorkerPool::new(2, 100, tx, Some(db.clone()), 1000) {
                 Ok(p) => p,
                 Err(e) => panic!("Failed to create worker pool: {e}"),
@@ -1090,7 +1090,7 @@ fn bench_http_parallel_processing(c: &mut Criterion) {
 
     let parallel_4_workers_time = measure_average_time(
         || {
-            let (tx, rx) = crossbeam_channel::unbounded();
+            let (tx, rx) = std::sync::mpsc::channel();
             let pool = match huginn_net_http::WorkerPool::new(4, 100, tx, Some(db.clone()), 1000) {
                 Ok(p) => p,
                 Err(e) => panic!("Failed to create worker pool: {e}"),
@@ -1106,7 +1106,7 @@ fn bench_http_parallel_processing(c: &mut Criterion) {
 
     let parallel_8_workers_time = measure_average_time(
         || {
-            let (tx, rx) = crossbeam_channel::unbounded();
+            let (tx, rx) = std::sync::mpsc::channel();
             let pool = match huginn_net_http::WorkerPool::new(8, 100, tx, Some(db.clone()), 1000) {
                 Ok(p) => p,
                 Err(e) => panic!("Failed to create worker pool: {e}"),

--- a/examples/capture-http.rs
+++ b/examples/capture-http.rs
@@ -1,8 +1,8 @@
 use clap::{Parser, Subcommand};
-use crossbeam_channel::{unbounded, Receiver, Sender};
 use huginn_net_db::Database;
 use huginn_net_http::{HttpAnalysisResult, HuginnNetHttp};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Arc;
 use std::thread;
 use tracing::{debug, error, info};
@@ -69,8 +69,7 @@ fn main() {
 
     info!("Starting HTTP-only capture example");
 
-    let (sender, receiver): (Sender<HttpAnalysisResult>, Receiver<HttpAnalysisResult>) =
-        unbounded();
+    let (sender, receiver): (Sender<HttpAnalysisResult>, Receiver<HttpAnalysisResult>) = channel();
 
     let cancel_signal = Arc::new(AtomicBool::new(false));
     let ctrl_c_signal = cancel_signal.clone();

--- a/huginn-net-http/README.md
+++ b/huginn-net-http/README.md
@@ -39,6 +39,8 @@ This crate provides HTTP-based passive fingerprinting capabilities. It analyzes 
 
 ## Quick Start
 
+> **Note:** Live packet capture requires `libpcap` (usually pre-installed on Linux/macOS).
+
 ### Installation
 
 Add this to your `Cargo.toml`:

--- a/huginn-net-http/src/lib.rs
+++ b/huginn-net-http/src/lib.rs
@@ -32,11 +32,11 @@ pub use process::*;
 pub use signature_matcher::*;
 
 use crate::packet_parser::{parse_packet, IpPacket};
-use crossbeam_channel::Sender;
 use pcap_file::pcap::PcapReader;
 use pnet::datalink::{self, Channel, Config};
 use std::fs::File;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::Sender;
 use std::sync::Arc;
 use tracing::{debug, error};
 use ttl_cache::TtlCache;

--- a/huginn-net-http/src/parallel.rs
+++ b/huginn-net-http/src/parallel.rs
@@ -20,7 +20,7 @@ use ttl_cache::TtlCache;
 /// Worker pool for parallel HTTP packet processing.
 pub struct WorkerPool {
     packet_senders: Arc<Mutex<Vec<Sender<Vec<u8>>>>>,
-    result_sender: Arc<Mutex<Option<Sender<HttpAnalysisResult>>>>,
+    result_sender: Arc<Mutex<Option<std::sync::mpsc::Sender<HttpAnalysisResult>>>>,
     dispatched_count: Arc<AtomicU64>,
     dropped_count: Arc<AtomicU64>,
     worker_dropped: Vec<Arc<AtomicU64>>,
@@ -67,7 +67,7 @@ impl WorkerPool {
     pub fn new(
         num_workers: usize,
         queue_size: usize,
-        result_tx: Sender<HttpAnalysisResult>,
+        result_tx: std::sync::mpsc::Sender<HttpAnalysisResult>,
         database: Option<Arc<db::Database>>,
         max_connections: usize,
     ) -> Result<Arc<Self>, HuginnNetHttpError> {
@@ -114,7 +114,7 @@ impl WorkerPool {
     /// Worker thread main loop.
     fn worker_loop(
         rx: crossbeam_channel::Receiver<Vec<u8>>,
-        result_tx: Sender<HttpAnalysisResult>,
+        result_tx: std::sync::mpsc::Sender<HttpAnalysisResult>,
         database: Option<Arc<db::Database>>,
         max_connections: usize,
         dropped: Arc<AtomicU64>,

--- a/huginn-net-http/tests/golden_tests.rs
+++ b/huginn-net-http/tests/golden_tests.rs
@@ -1,9 +1,9 @@
-use crossbeam_channel::unbounded;
 use huginn_net_db::Database;
 use huginn_net_http::{HttpAnalysisResult, HuginnNetHttp};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
+use std::sync::mpsc::channel;
 use std::sync::Arc;
 
 // Snapshot structures for JSON serialization
@@ -63,7 +63,7 @@ fn analyze_pcap_file(pcap_path: &str) -> Vec<HttpAnalysisResult> {
     let mut analyzer = HuginnNetHttp::new(Some(Arc::new(db)), 1000)
         .unwrap_or_else(|e| panic!("Failed to create analyzer: {e}"));
 
-    let (sender, receiver) = unbounded();
+    let (sender, receiver) = channel();
 
     // Run PCAP analysis in the same thread to avoid lifetime issues
     if let Err(e) = analyzer.analyze_pcap(pcap_path, sender, None) {

--- a/huginn-net-tcp/README.md
+++ b/huginn-net-tcp/README.md
@@ -40,6 +40,8 @@ This crate provides TCP-based passive fingerprinting capabilities using p0f-styl
 
 ## Quick Start
 
+> **Note:** Live packet capture requires `libpcap` (usually pre-installed on Linux/macOS).
+
 ### Installation
 
 Add this to your `Cargo.toml`:

--- a/huginn-net-tls/README.md
+++ b/huginn-net-tls/README.md
@@ -39,6 +39,8 @@ This crate provides JA4 TLS client fingerprinting capabilities for passive netwo
 
 ## Quick Start
 
+> **Note:** Live packet capture requires `libpcap` (usually pre-installed on Linux/macOS).
+
 ### Installation
 
 Add this to your `Cargo.toml`:


### PR DESCRIPTION
To unify libraries and avoid additional dependencies, Crossbeam is removed from the HTTP interface.