### PR TITLE
HTTP - Adding optional filters 

### DIFF
--- a/benches/bench_http.rs
+++ b/benches/bench_http.rs
@@ -1041,6 +1041,7 @@ fn bench_http_parallel_processing(c: &mut Criterion) {
                     tx,
                     Some(db.clone()),
                     1000,
+                    None,
                 ) {
                     Ok(p) => p,
                     Err(e) => panic!("Failed to create worker pool: {e}"),
@@ -1075,6 +1076,7 @@ fn bench_http_parallel_processing(c: &mut Criterion) {
                 tx,
                 Some(db.clone()),
                 1000,
+                None,
             ) {
                 Ok(p) => p,
                 Err(e) => panic!("Failed to create worker pool: {e}"),
@@ -1099,6 +1101,7 @@ fn bench_http_parallel_processing(c: &mut Criterion) {
                 tx,
                 Some(db.clone()),
                 1000,
+                None,
             ) {
                 Ok(p) => p,
                 Err(e) => panic!("Failed to create worker pool: {e}"),
@@ -1123,6 +1126,7 @@ fn bench_http_parallel_processing(c: &mut Criterion) {
                 tx,
                 Some(db.clone()),
                 1000,
+                None,
             ) {
                 Ok(p) => p,
                 Err(e) => panic!("Failed to create worker pool: {e}"),

--- a/examples/README.md
+++ b/examples/README.md
@@ -86,6 +86,16 @@ sudo RUST_LOG=info RUST_BACKTRACE=1 ./target/release/examples/capture-http -l ht
 
 # Example for 10 Gbps traffic (2 workers recommended)
 sudo RUST_LOG=info RUST_BACKTRACE=1 ./target/release/examples/capture-http -l http-capture.log parallel -i <INTERFACE> -w 2 -q 100
+
+# Filtering examples
+# Filter by destination port (HTTP on port 80)
+sudo RUST_LOG=info RUST_BACKTRACE=1 ./target/release/examples/capture-http -l http-capture.log -p 80 single -i <INTERFACE>
+
+# Filter by IP address
+sudo RUST_LOG=info RUST_BACKTRACE=1 ./target/release/examples/capture-http -l http-capture.log -I 192.168.1.100 single -i <INTERFACE>
+
+# Filter by both port and IP (both conditions must match)
+sudo RUST_LOG=info RUST_BACKTRACE=1 ./target/release/examples/capture-http -l http-capture.log -p 80 -I 192.168.1.100 parallel -i <INTERFACE> -w 2
 ```
 
 #### Differences between examples:

--- a/huginn-net-http/src/filter.rs
+++ b/huginn-net-http/src/filter.rs
@@ -1,0 +1,625 @@
+use pnet::ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+/// Filter mode: Allow (allowlist) or Deny (denylist)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FilterMode {
+    /// Allow only matching packets (allowlist mode)
+    #[default]
+    Allow,
+    /// Deny matching packets (denylist mode)
+    Deny,
+}
+
+/// Port filter configuration
+///
+/// Filters packets based on TCP source and/or destination ports.
+/// Supports individual ports, ranges, and lists.
+///
+/// # Examples
+///
+/// ```rust
+/// use huginn_net_http::PortFilter;
+///
+/// // Single port
+/// let filter = PortFilter::new().destination(443);
+///
+/// // Multiple ports
+/// let filter = PortFilter::new().destination_list(vec![80, 443, 8080]);
+///
+/// // Port range
+/// let filter = PortFilter::new().destination_range(8000..9000);
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct PortFilter {
+    /// Source ports to match
+    pub source_ports: Vec<u16>,
+    /// Destination ports to match
+    pub destination_ports: Vec<u16>,
+    /// Source port ranges (inclusive)
+    pub source_ranges: Vec<(u16, u16)>,
+    /// Destination port ranges (inclusive)
+    pub destination_ranges: Vec<(u16, u16)>,
+    /// Match ANY port (source OR destination)?
+    pub match_any: bool,
+}
+
+impl PortFilter {
+    /// Create a new empty port filter
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a destination port
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use huginn_net_http::PortFilter;
+    ///
+    /// let filter = PortFilter::new().destination(443);
+    /// ```
+    pub fn destination(mut self, port: u16) -> Self {
+        self.destination_ports.push(port);
+        self
+    }
+
+    /// Add a source port
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use huginn_net_http::PortFilter;
+    ///
+    /// let filter = PortFilter::new().source(12345);
+    /// ```
+    pub fn source(mut self, port: u16) -> Self {
+        self.source_ports.push(port);
+        self
+    }
+
+    /// Add a destination port range (inclusive)
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use huginn_net_http::PortFilter;
+    ///
+    /// let filter = PortFilter::new().destination_range(8000..9000);
+    /// // Matches ports 8000 through 8999
+    /// ```
+    pub fn destination_range(mut self, range: std::ops::Range<u16>) -> Self {
+        self.destination_ranges
+            .push((range.start, range.end.saturating_sub(1)));
+        self
+    }
+
+    /// Add a source port range (inclusive)
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use huginn_net_http::PortFilter;
+    ///
+    /// let filter = PortFilter::new().source_range(10000..20000);
+    /// // Matches ports 10000 through 19999
+    /// ```
+    pub fn source_range(mut self, range: std::ops::Range<u16>) -> Self {
+        self.source_ranges
+            .push((range.start, range.end.saturating_sub(1)));
+        self
+    }
+
+    /// Add multiple destination ports
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use huginn_net_http::PortFilter;
+    ///
+    /// let filter = PortFilter::new().destination_list(vec![80, 443, 8080, 8443]);
+    /// ```
+    pub fn destination_list(mut self, ports: Vec<u16>) -> Self {
+        self.destination_ports.extend(ports);
+        self
+    }
+
+    /// Add multiple source ports
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use huginn_net_http::PortFilter;
+    ///
+    /// let filter = PortFilter::new().source_list(vec![12345, 54321, 9999]);
+    /// ```
+    pub fn source_list(mut self, ports: Vec<u16>) -> Self {
+        self.source_ports.extend(ports);
+        self
+    }
+
+    /// Match if ANY port matches (source OR destination)
+    ///
+    /// By default, all specified filters must match. With `match_any()`,
+    /// the packet passes if either source OR destination matches.
+    pub fn any_port(mut self) -> Self {
+        self.match_any = true;
+        self
+    }
+
+    /// Check if packet matches port filter
+    ///
+    /// # Returns
+    ///
+    /// `true` if the packet matches the filter criteria
+    pub fn matches(&self, src_port: u16, dst_port: u16) -> bool {
+        if self.match_any {
+            let all_ports: Vec<u16> = self
+                .source_ports
+                .iter()
+                .chain(self.destination_ports.iter())
+                .copied()
+                .collect();
+
+            let all_ranges: Vec<(u16, u16)> = self
+                .source_ranges
+                .iter()
+                .chain(self.destination_ranges.iter())
+                .copied()
+                .collect();
+
+            let port_match = all_ports.contains(&src_port)
+                || all_ports.contains(&dst_port)
+                || all_ranges
+                    .iter()
+                    .any(|(start, end)| src_port >= *start && src_port <= *end)
+                || all_ranges
+                    .iter()
+                    .any(|(start, end)| dst_port >= *start && dst_port <= *end);
+
+            port_match
+        } else {
+            let src_match = self.source_ports.contains(&src_port)
+                || self
+                    .source_ranges
+                    .iter()
+                    .any(|(start, end)| src_port >= *start && src_port <= *end);
+
+            let dst_match = self.destination_ports.contains(&dst_port)
+                || self
+                    .destination_ranges
+                    .iter()
+                    .any(|(start, end)| dst_port >= *start && dst_port <= *end);
+
+            let src_ok = self.source_ports.is_empty() && self.source_ranges.is_empty() || src_match;
+            let dst_ok = self.destination_ports.is_empty() && self.destination_ranges.is_empty()
+                || dst_match;
+            src_ok && dst_ok
+        }
+    }
+}
+
+/// IP address filter configuration
+///
+/// Filters packets based on specific IPv4 or IPv6 addresses.
+///
+/// # Examples
+///
+/// ```rust
+/// use huginn_net_http::IpFilter;
+///
+/// let filter = IpFilter::new()
+///     .allow("8.8.8.8")
+///     .unwrap()
+///     .allow("2001:4860:4860::8888")
+///     .unwrap();
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct IpFilter {
+    /// IPv4 addresses to match
+    pub ipv4_addresses: Vec<Ipv4Addr>,
+    /// IPv6 addresses to match
+    pub ipv6_addresses: Vec<Ipv6Addr>,
+    /// Check source, destination, or both?
+    pub check_source: bool,
+    pub check_destination: bool,
+}
+
+impl IpFilter {
+    /// Create a new IP filter that checks both source and destination by default
+    pub fn new() -> Self {
+        Self { check_source: true, check_destination: true, ..Default::default() }
+    }
+
+    /// Add an IP address (auto-detects IPv4/IPv6)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the IP address string is invalid
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use huginn_net_http::IpFilter;
+    ///
+    /// let filter = IpFilter::new()
+    ///     .allow("192.168.1.1").unwrap()
+    ///     .allow("2001:db8::1").unwrap();
+    /// ```
+    pub fn allow(mut self, ip: &str) -> Result<Self, String> {
+        let addr: IpAddr = ip.parse().map_err(|e| format!("Invalid IP: {e}"))?;
+        match addr {
+            IpAddr::V4(v4) => self.ipv4_addresses.push(v4),
+            IpAddr::V6(v6) => self.ipv6_addresses.push(v6),
+        }
+        Ok(self)
+    }
+
+    /// Add multiple IP addresses
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any IP address string is invalid
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use huginn_net_http::IpFilter;
+    ///
+    /// let filter = IpFilter::new()
+    ///     .allow_list(vec!["8.8.8.8", "1.1.1.1", "2001:4860:4860::8888"])
+    ///     .unwrap();
+    /// ```
+    pub fn allow_list(mut self, ips: Vec<&str>) -> Result<Self, String> {
+        for ip in ips {
+            self = self.allow(ip)?;
+        }
+        Ok(self)
+    }
+
+    /// Only check source addresses
+    ///
+    /// By default, both source and destination are checked.
+    pub fn source_only(mut self) -> Self {
+        self.check_source = true;
+        self.check_destination = false;
+        self
+    }
+
+    /// Only check destination addresses
+    ///
+    /// By default, both source and destination are checked.
+    pub fn destination_only(mut self) -> Self {
+        self.check_source = false;
+        self.check_destination = true;
+        self
+    }
+
+    /// Check if packet matches IP filter
+    ///
+    /// # Returns
+    ///
+    /// `true` if either source or destination IP matches (if enabled)
+    pub fn matches(&self, src_ip: &IpAddr, dst_ip: &IpAddr) -> bool {
+        let src_match = if self.check_source {
+            match src_ip {
+                IpAddr::V4(v4) => self.ipv4_addresses.contains(v4),
+                IpAddr::V6(v6) => self.ipv6_addresses.contains(v6),
+            }
+        } else {
+            false
+        };
+
+        let dst_match = if self.check_destination {
+            match dst_ip {
+                IpAddr::V4(v4) => self.ipv4_addresses.contains(v4),
+                IpAddr::V6(v6) => self.ipv6_addresses.contains(v6),
+            }
+        } else {
+            false
+        };
+
+        src_match || dst_match
+    }
+}
+
+/// Subnet filter configuration (CIDR notation)
+///
+/// Filters packets based on subnet membership using CIDR notation.
+/// Supports both IPv4 and IPv6 subnets.
+///
+/// # Examples
+///
+/// ```rust
+/// use huginn_net_http::SubnetFilter;
+///
+/// // Allow only private networks
+/// let filter = SubnetFilter::new()
+///     .allow("192.168.0.0/16").unwrap()
+///     .allow("10.0.0.0/8").unwrap();
+///
+/// // IPv6 subnet
+/// let filter = SubnetFilter::new()
+///     .allow("2001:db8::/32").unwrap();
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct SubnetFilter {
+    /// IPv4 subnets to match
+    pub ipv4_subnets: Vec<Ipv4Network>,
+    /// IPv6 subnets to match
+    pub ipv6_subnets: Vec<Ipv6Network>,
+    /// Check source, destination, or both?
+    pub check_source: bool,
+    pub check_destination: bool,
+}
+
+impl SubnetFilter {
+    /// Create a new subnet filter that checks both source and destination by default
+    pub fn new() -> Self {
+        Self { check_source: true, check_destination: true, ..Default::default() }
+    }
+
+    /// Add a subnet in CIDR notation
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the CIDR notation is invalid
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use huginn_net_http::SubnetFilter;
+    ///
+    /// let filter = SubnetFilter::new()
+    ///     .allow("192.168.1.0/24").unwrap();
+    /// ```
+    pub fn allow(mut self, cidr: &str) -> Result<Self, String> {
+        let network: IpNetwork = cidr.parse().map_err(|e| format!("Invalid CIDR: {e}"))?;
+        match network {
+            IpNetwork::V4(v4) => self.ipv4_subnets.push(v4),
+            IpNetwork::V6(v6) => self.ipv6_subnets.push(v6),
+        }
+        Ok(self)
+    }
+
+    /// Add multiple subnets
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any CIDR notation is invalid
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use huginn_net_http::SubnetFilter;
+    ///
+    /// let filter = SubnetFilter::new()
+    ///     .allow_list(vec!["192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12"])
+    ///     .unwrap();
+    /// ```
+    pub fn allow_list(mut self, cidrs: Vec<&str>) -> Result<Self, String> {
+        for cidr in cidrs {
+            self = self.allow(cidr)?;
+        }
+        Ok(self)
+    }
+
+    /// Only check source addresses
+    ///
+    /// By default, both source and destination are checked.
+    pub fn source_only(mut self) -> Self {
+        self.check_source = true;
+        self.check_destination = false;
+        self
+    }
+
+    /// Only check destination addresses
+    ///
+    /// By default, both source and destination are checked.
+    pub fn destination_only(mut self) -> Self {
+        self.check_source = false;
+        self.check_destination = true;
+        self
+    }
+
+    /// Check if packet matches subnet filter
+    ///
+    /// # Returns
+    ///
+    /// `true` if either source or destination IP is in any of the subnets (if enabled)
+    pub fn matches(&self, src_ip: &IpAddr, dst_ip: &IpAddr) -> bool {
+        let src_match = if self.check_source {
+            match src_ip {
+                IpAddr::V4(v4) => self.ipv4_subnets.iter().any(|net| net.contains(*v4)),
+                IpAddr::V6(v6) => self.ipv6_subnets.iter().any(|net| net.contains(*v6)),
+            }
+        } else {
+            false
+        };
+
+        let dst_match = if self.check_destination {
+            match dst_ip {
+                IpAddr::V4(v4) => self.ipv4_subnets.iter().any(|net| net.contains(*v4)),
+                IpAddr::V6(v6) => self.ipv6_subnets.iter().any(|net| net.contains(*v6)),
+            }
+        } else {
+            false
+        };
+
+        src_match || dst_match
+    }
+}
+
+/// Combined filter configuration
+///
+/// Combines port, IP, and subnet filters with a filter mode (Allow/Deny).
+/// All enabled filters must pass for a packet to be processed.
+///
+/// # Examples
+///
+/// ```rust
+/// use huginn_net_http::{FilterConfig, FilterMode, PortFilter, SubnetFilter};
+///
+/// let filter = FilterConfig::new()
+///     .mode(FilterMode::Allow)
+///     .with_port_filter(PortFilter::new().destination(443))
+///     .with_subnet_filter(
+///         SubnetFilter::new()
+///             .allow("192.168.0.0/16")
+///             .unwrap()
+///     );
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct FilterConfig {
+    pub port_filter: Option<PortFilter>,
+    pub ip_filter: Option<IpFilter>,
+    pub subnet_filter: Option<SubnetFilter>,
+    pub mode: FilterMode,
+}
+
+impl FilterConfig {
+    /// Create a new empty filter configuration
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set filter mode (Allow/Deny)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use huginn_net_http::{FilterConfig, FilterMode};
+    ///
+    /// // Allowlist mode (default) - only matching packets pass
+    /// let filter = FilterConfig::new().mode(FilterMode::Allow);
+    ///
+    /// // Denylist mode - matching packets are blocked
+    /// let filter = FilterConfig::new().mode(FilterMode::Deny);
+    /// ```
+    pub fn mode(mut self, mode: FilterMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Add port filter
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use huginn_net_http::{FilterConfig, PortFilter};
+    ///
+    /// let filter = FilterConfig::new()
+    ///     .with_port_filter(PortFilter::new().destination(443));
+    /// ```
+    pub fn with_port_filter(mut self, filter: PortFilter) -> Self {
+        self.port_filter = Some(filter);
+        self
+    }
+
+    /// Add IP filter
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use huginn_net_http::{FilterConfig, IpFilter};
+    ///
+    /// let filter = FilterConfig::new()
+    ///     .with_ip_filter(
+    ///         IpFilter::new()
+    ///             .allow("8.8.8.8")
+    ///             .unwrap()
+    ///     );
+    /// ```
+    pub fn with_ip_filter(mut self, filter: IpFilter) -> Self {
+        self.ip_filter = Some(filter);
+        self
+    }
+
+    /// Add subnet filter
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use huginn_net_http::{FilterConfig, SubnetFilter};
+    ///
+    /// let filter = FilterConfig::new()
+    ///     .with_subnet_filter(
+    ///         SubnetFilter::new()
+    ///             .allow("192.168.0.0/16")
+    ///             .unwrap()
+    ///     );
+    /// ```
+    pub fn with_subnet_filter(mut self, filter: SubnetFilter) -> Self {
+        self.subnet_filter = Some(filter);
+        self
+    }
+
+    /// Check if packet should be processed based on filters (userspace filtering)
+    ///
+    /// This method performs filtering in userspace after packets reach the application.
+    /// It extracts IP addresses and ports from packet headers and applies the configured
+    /// filters (port, IP, subnet) according to the filter mode (Allow/Deny).
+    ///
+    /// # Returns
+    ///
+    /// - `true`: Packet passes all filters (should be processed)
+    /// - `false`: Packet blocked by filters (should be dropped)
+    ///
+    /// # Logic
+    ///
+    /// - If no filters are configured, all packets pass
+    /// - In Allow mode: packet must match ALL configured filters
+    /// - In Deny mode: packet must NOT match ALL configured filters
+    pub fn should_process(
+        &self,
+        src_ip: &IpAddr,
+        dst_ip: &IpAddr,
+        src_port: u16,
+        dst_port: u16,
+    ) -> bool {
+        if self.port_filter.is_none() && self.ip_filter.is_none() && self.subnet_filter.is_none() {
+            return true;
+        }
+
+        match self.mode {
+            FilterMode::Allow => {
+                if let Some(ref filter) = self.port_filter {
+                    if !filter.matches(src_port, dst_port) {
+                        return false;
+                    }
+                }
+
+                if let Some(ref filter) = self.ip_filter {
+                    if !filter.matches(src_ip, dst_ip) {
+                        return false;
+                    }
+                }
+
+                if let Some(ref filter) = self.subnet_filter {
+                    if !filter.matches(src_ip, dst_ip) {
+                        return false;
+                    }
+                }
+
+                true
+            }
+            FilterMode::Deny => {
+                let mut all_match = true;
+
+                if let Some(ref filter) = self.port_filter {
+                    all_match = all_match && filter.matches(src_port, dst_port);
+                }
+
+                if let Some(ref filter) = self.ip_filter {
+                    all_match = all_match && filter.matches(src_ip, dst_ip);
+                }
+
+                if let Some(ref filter) = self.subnet_filter {
+                    all_match = all_match && filter.matches(src_ip, dst_ip);
+                }
+
+                !all_match
+            }
+        }
+    }
+}

--- a/huginn-net-http/src/raw_filter.rs
+++ b/huginn-net-http/src/raw_filter.rs
@@ -1,0 +1,179 @@
+use crate::filter::FilterConfig;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use tracing::debug;
+
+/// Apply raw filter check on raw packet bytes
+///
+/// Extracts only IPs and ports without creating full packet structures.
+/// This is much faster than parsing the entire packet first.
+///
+/// # Returns
+///
+/// - `true`: Packet should be processed (passed filter or no filter)
+/// - `false`: Packet should be dropped (failed filter)
+pub fn apply(packet: &[u8], filter: &FilterConfig) -> bool {
+    if let Some((src_ip, dst_ip, src_port, dst_port)) = extract_quick_info(packet) {
+        filter.should_process(&src_ip, &dst_ip, src_port, dst_port)
+    } else {
+        debug!("Could not extract quick info from packet");
+        true
+    }
+}
+
+/// Extract IPs and ports without full parsing
+///
+/// Tries multiple datalink formats (Ethernet, Raw IP, NULL) to find IP header.
+/// Only extracts the minimum fields needed for filtering.
+fn extract_quick_info(packet: &[u8]) -> Option<(IpAddr, IpAddr, u16, u16)> {
+    // Try Ethernet (most common)
+    if let Some(info) = try_ethernet(packet) {
+        return Some(info);
+    }
+
+    // Try Raw IP
+    if let Some(info) = try_raw_ip(packet) {
+        return Some(info);
+    }
+
+    // Try NULL/Loopback
+    if let Some(info) = try_null_datalink(packet) {
+        return Some(info);
+    }
+
+    None
+}
+
+/// Try to extract from Ethernet frame
+fn try_ethernet(packet: &[u8]) -> Option<(IpAddr, IpAddr, u16, u16)> {
+    if packet.len() < 14 {
+        return None;
+    }
+
+    // EtherType at offset 12-13
+    let ethertype = u16::from_be_bytes([packet[12], packet[13]]);
+
+    match ethertype {
+        0x0800 => extract_ipv4_info(&packet[14..]), // IPv4
+        0x86DD => extract_ipv6_info(&packet[14..]), // IPv6
+        _ => None,
+    }
+}
+
+/// Try to extract from Raw IP
+fn try_raw_ip(packet: &[u8]) -> Option<(IpAddr, IpAddr, u16, u16)> {
+    if packet.is_empty() {
+        return None;
+    }
+
+    // Check IP version (first 4 bits)
+    let version = packet[0] >> 4;
+
+    match version {
+        4 => extract_ipv4_info(packet),
+        6 => extract_ipv6_info(packet),
+        _ => None,
+    }
+}
+
+/// Try to extract from NULL/Loopback datalink
+fn try_null_datalink(packet: &[u8]) -> Option<(IpAddr, IpAddr, u16, u16)> {
+    if packet.len() < 4 {
+        return None;
+    }
+
+    // NULL datalink has 4-byte header with address family
+    // AF_INET = 2, AF_INET6 = 30 (on most systems)
+    let family = u32::from_ne_bytes([packet[0], packet[1], packet[2], packet[3]]);
+
+    match family {
+        2 => extract_ipv4_info(&packet[4..]),       // AF_INET
+        30 | 28 => extract_ipv6_info(&packet[4..]), // AF_INET6 (varies by OS)
+        _ => None,
+    }
+}
+
+/// Extract IPv4 src/dst IPs and TCP ports (minimal parsing)
+fn extract_ipv4_info(packet: &[u8]) -> Option<(IpAddr, IpAddr, u16, u16)> {
+    // IPv4 header minimum: 20 bytes
+    if packet.len() < 20 {
+        return None;
+    }
+
+    // Check protocol (offset 9): must be TCP (6)
+    if packet[9] != 6 {
+        return None;
+    }
+
+    // Extract source IP (offset 12-15)
+    let src_ip = IpAddr::V4(Ipv4Addr::new(packet[12], packet[13], packet[14], packet[15]));
+
+    // Extract destination IP (offset 16-19)
+    let dst_ip = IpAddr::V4(Ipv4Addr::new(packet[16], packet[17], packet[18], packet[19]));
+
+    // Get IP header length (first 4 bits of byte 0, in 32-bit words)
+    let ihl = (packet[0] & 0x0F) as usize;
+    let ip_header_len = ihl.saturating_mul(4);
+
+    // TCP header starts after IP header
+    let tcp_offset = ip_header_len;
+    if packet.len() < tcp_offset.saturating_add(4) {
+        return None;
+    }
+
+    // Extract TCP ports (first 4 bytes of TCP header)
+    let src_port = u16::from_be_bytes([packet[tcp_offset], packet[tcp_offset.saturating_add(1)]]);
+    let dst_port = u16::from_be_bytes([
+        packet[tcp_offset.saturating_add(2)],
+        packet[tcp_offset.saturating_add(3)],
+    ]);
+
+    Some((src_ip, dst_ip, src_port, dst_port))
+}
+
+/// Extract IPv6 src/dst IPs and TCP ports (minimal parsing)
+fn extract_ipv6_info(packet: &[u8]) -> Option<(IpAddr, IpAddr, u16, u16)> {
+    // IPv6 header: 40 bytes minimum
+    if packet.len() < 40 {
+        return None;
+    }
+
+    // Check next header (offset 6): must be TCP (6)
+    if packet[6] != 6 {
+        return None;
+    }
+
+    // Extract source IP (offset 8-23)
+    let src_ip = IpAddr::V6(Ipv6Addr::new(
+        u16::from_be_bytes([packet[8], packet[9]]),
+        u16::from_be_bytes([packet[10], packet[11]]),
+        u16::from_be_bytes([packet[12], packet[13]]),
+        u16::from_be_bytes([packet[14], packet[15]]),
+        u16::from_be_bytes([packet[16], packet[17]]),
+        u16::from_be_bytes([packet[18], packet[19]]),
+        u16::from_be_bytes([packet[20], packet[21]]),
+        u16::from_be_bytes([packet[22], packet[23]]),
+    ));
+
+    // Extract destination IP (offset 24-39)
+    let dst_ip = IpAddr::V6(Ipv6Addr::new(
+        u16::from_be_bytes([packet[24], packet[25]]),
+        u16::from_be_bytes([packet[26], packet[27]]),
+        u16::from_be_bytes([packet[28], packet[29]]),
+        u16::from_be_bytes([packet[30], packet[31]]),
+        u16::from_be_bytes([packet[32], packet[33]]),
+        u16::from_be_bytes([packet[34], packet[35]]),
+        u16::from_be_bytes([packet[36], packet[37]]),
+        u16::from_be_bytes([packet[38], packet[39]]),
+    ));
+
+    // TCP header starts at offset 40 (IPv6 header is fixed 40 bytes)
+    if packet.len() < 44 {
+        return None;
+    }
+
+    // Extract TCP ports
+    let src_port = u16::from_be_bytes([packet[40], packet[41]]);
+    let dst_port = u16::from_be_bytes([packet[42], packet[43]]);
+
+    Some((src_ip, dst_ip, src_port, dst_port))
+}


### PR DESCRIPTION
Optional filtering system for packet analysis that allows filtering by TCP port, IP address, or CIDR subnet before full processing.
The system implements three independent filter types that can be combined: 
- PortFilter for filtering by source or destination ports with support for individual ports, port lists, and port ranges. 
- IpFilter for filtering by specific IPv4 or IPv6 addresses with option to check only source, only destination, or both,.
- SubnetFilter for filtering by subnets using CIDR notation with support for IPv4 and IPv6. 

Filters are configured through FilterConfig which combines all three filter types and allows selecting the operation mode Allow to permit only packets matching all configured filters or Deny to block packets matching the filters. Filter application is performed in userspace through the raw_filter module which extracts only IP addresses and ports from packet headers without performing full parsing, enabling efficient filtering before expensive processing. Filtering is applied both in live capture through analyze_network and in PCAP file analysis through analyze_pcap, and also works in parallel mode where each worker thread applies filters before processing each packet. If no filters are configured all packets are processed normally, and if a packet cannot be filtered due to failure in information extraction it is allowed through to avoid false negatives.