### PR TITLE
fix: pcap-file version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ dependencies = [
  "lazy_static",
  "pcap-file",
  "pnet",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -487,7 +487,7 @@ version = "1.7.5"
 dependencies = [
  "lazy_static",
  "nom 8.0.0",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
@@ -507,7 +507,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -527,7 +527,7 @@ dependencies = [
  "pnet",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -547,7 +547,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror 2.0.18",
+ "thiserror",
  "tls-parser",
  "tracing",
  "tracing-appender",
@@ -820,14 +820,14 @@ dependencies = [
 
 [[package]]
 name = "pcap-file"
-version = "3.0.0-rc1"
+version = "3.0.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc44e44ff0157dd4a876d81d83ae1bdb3b031873ca042116977908b987092f44"
+checksum = "9552aee583a05913b6c6345e3c5f69a746787fd60c8fd39ca82ef882de0613b4"
 dependencies = [
  "byteorder_slice",
  "derive-into-owned",
  "once_cell",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -1237,31 +1237,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1388,7 +1368,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ huginn-net-tls = { path = "huginn-net-tls", version = "1.7.5" }
 lazy_static = "1.5.0"
 
 nom = "8.0.0"
-pcap-file = "3.0.0-rc1"
+pcap-file = "3.0.0-rc.2"
 pnet = "0.35.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/benches/bench_http.rs
+++ b/benches/bench_http.rs
@@ -313,7 +313,7 @@ fn load_packets_from_pcap(pcap_path: &str) -> Result<Vec<Vec<u8>>, Box<dyn Error
     let mut pcap_reader = PcapReader::new(file)?;
     let mut packets = Vec::new();
     while let Some(pkt) = pcap_reader.next_packet() {
-        packets.push(pkt?.data.into());
+        packets.push(pkt?.data().into());
     }
     Ok(packets)
 }

--- a/benches/bench_tcp.rs
+++ b/benches/bench_tcp.rs
@@ -327,7 +327,7 @@ fn load_packets_from_pcap(pcap_path: &str) -> Result<Vec<Vec<u8>>, Box<dyn Error
     let mut pcap_reader = PcapReader::new(file)?;
     let mut packets = Vec::new();
     while let Some(pkt) = pcap_reader.next_packet() {
-        packets.push(pkt?.data.into());
+        packets.push(pkt?.data().into());
     }
     Ok(packets)
 }

--- a/benches/bench_tls.rs
+++ b/benches/bench_tls.rs
@@ -314,7 +314,7 @@ fn load_packets_from_pcap(pcap_path: &str) -> Result<Vec<Vec<u8>>, Box<dyn Error
     let mut pcap_reader = PcapReader::new(file)?;
     let mut packets = Vec::new();
     while let Some(pkt) = pcap_reader.next_packet() {
-        packets.push(pkt?.data.into());
+        packets.push(pkt?.data().into());
     }
     Ok(packets)
 }

--- a/huginn-net-http/src/lib.rs
+++ b/huginn-net-http/src/lib.rs
@@ -382,7 +382,7 @@ impl HuginnNetHttp {
 
         self.process_with(
             move || match pcap_reader.next_packet() {
-                Some(Ok(packet)) => Some(Ok(packet.data.to_vec())),
+                Some(Ok(packet)) => Some(Ok(packet.data().to_vec())),
                 Some(Err(e)) => {
                     Some(Err(HuginnNetHttpError::Parse(format!("Error reading PCAP packet: {e}"))))
                 }

--- a/huginn-net-tcp/src/lib.rs
+++ b/huginn-net-tcp/src/lib.rs
@@ -386,7 +386,7 @@ impl HuginnNetTcp {
 
         self.process_with(
             move || match pcap_reader.next_packet() {
-                Some(Ok(packet)) => Some(Ok(packet.data.to_vec())),
+                Some(Ok(packet)) => Some(Ok(packet.data().to_vec())),
                 Some(Err(e)) => {
                     Some(Err(HuginnNetTcpError::Parse(format!("Error reading PCAP packet: {e}"))))
                 }

--- a/huginn-net-tls/src/lib.rs
+++ b/huginn-net-tls/src/lib.rs
@@ -422,7 +422,7 @@ impl HuginnNetTls {
 
         self.process_with(
             move || match pcap_reader.next_packet() {
-                Some(Ok(packet)) => Some(Ok(packet.data.to_vec())),
+                Some(Ok(packet)) => Some(Ok(packet.data().to_vec())),
                 Some(Err(e)) => {
                     Some(Err(HuginnNetTlsError::Parse(format!("Error reading PCAP packet: {e}"))))
                 }

--- a/huginn-net/src/lib.rs
+++ b/huginn-net/src/lib.rs
@@ -339,7 +339,7 @@ impl<'a> HuginnNet<'a> {
 
         self.process_with(
             move || match pcap_reader.next_packet() {
-                Some(Ok(packet)) => Some(Ok(packet.data.to_vec())),
+                Some(Ok(packet)) => Some(Ok(packet.data().to_vec())),
                 Some(Err(e)) => Some(Err(HuginnNetError::MissConfiguration(format!(
                     "Error reading PCAP packet: {e}"
                 )))),


### PR DESCRIPTION
Fix for #268

## How has this been tested?
Ran tests from the checklist.

OS: NixOS 25.11
Rust version: rustc 1.95.0 (59807616e 2026-04-14)
## Checklist

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings -D clippy::expect_used -D clippy::unwrap_used -D clippy::unreachable -D clippy::todo -D clippy::unimplemented -D clippy::arithmetic_side_effects -D clippy::redundant_clone -D clippy::missing_panics_doc -D clippy::redundant_field_names` passes
- [x] `cargo test --all` passes
- [x] No breaking changes
