### PR TITLE
Add `[features]` to `huginn-net-tcp`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,68 @@ jobs:
       - name: Check benchmarks
         run: cargo check --benches -p huginn-net
 
+  # Validates every meaningful feature combination of `huginn-net-tcp` to
+  # guarantee that disabling any feature still produces a clean (warning-free)
+  # library build. The full-features combo additionally runs the test and
+  # bench-link steps.
+  tcp-feature-matrix:
+    name: TCP feature matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        features:
+          # Single features
+          - ""
+          - "syn"
+          - "syn-ack"
+          - "mtu"
+          - "uptime"
+          # Useful pairs
+          - "syn,syn-ack"
+          - "syn,mtu"
+          - "syn,uptime"
+          - "syn-ack,mtu"
+          - "syn-ack,uptime"
+          - "mtu,uptime"
+          # Three-feature combos
+          - "syn,syn-ack,mtu"
+          - "syn,syn-ack,uptime"
+          - "syn,mtu,uptime"
+          - "syn-ack,mtu,uptime"
+          # All features (equivalent to default)
+          - "syn,syn-ack,mtu,uptime"
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.rust_stable }}
+          components: clippy
+      - name: Build huginn-net-tcp (features='${{ matrix.features }}')
+        run: |
+          if [ -z "${{ matrix.features }}" ]; then
+            cargo build -p huginn-net-tcp --no-default-features --lib
+          else
+            cargo build -p huginn-net-tcp --no-default-features \
+              --features "${{ matrix.features }}" --lib
+          fi
+      - name: Clippy huginn-net-tcp (features='${{ matrix.features }}')
+        run: |
+          if [ -z "${{ matrix.features }}" ]; then
+            cargo clippy -p huginn-net-tcp --no-default-features --lib -- -D warnings
+          else
+            cargo clippy -p huginn-net-tcp --no-default-features \
+              --features "${{ matrix.features }}" --lib -- -D warnings
+          fi
+      - name: Tests + bench link (full combo only)
+        if: matrix.features == 'syn,syn-ack,mtu,uptime'
+        run: |
+          cargo test  -p huginn-net-tcp --no-default-features \
+            --features "${{ matrix.features }}" --tests
+          cargo bench -p huginn-net-tcp --no-default-features \
+            --features "${{ matrix.features }}" --no-run
+
   test:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,13 +137,6 @@ jobs:
       - name: Check benchmarks
         run: cargo check --benches -p huginn-net
 
-  # Validates every meaningful feature combination of each crate that exposes
-  # Cargo features. Guarantees that disabling any feature still produces a
-  # clean (warning-free) library build. For `huginn-net-tcp`, the full-features
-  # combo additionally runs the test suite and the bench-link step.
-  #
-  # `huginn-net-http` is intentionally absent — it exposes no Cargo features
-  # and is fully covered by the workspace-wide `build`/`lint` jobs.
   feature-matrix:
     name: Feature matrix - ${{ matrix.crate }} (${{ matrix.label }})
     runs-on: ubuntu-latest
@@ -184,12 +177,21 @@ jobs:
           - { crate: huginn-net-db,  features: "http",                   label: "http" }
           - { crate: huginn-net-db,  features: "tcp,http",               label: "all (default)" }
           # ---------------------------------------------------------------
-          # huginn-net (umbrella) — features: db (default), tls-stable-v1
+          # huginn-net (umbrella) — features:
+          #   db, tcp-syn, tcp-syn-ack, tcp-mtu, tcp-uptime (all default)
+          #   tls-stable-v1 (opt-in)
+          # 10 curated entries exercise every toggle plus tls-stable-v1.
           # ---------------------------------------------------------------
-          - { crate: huginn-net,     features: "",                       label: "none" }
-          - { crate: huginn-net,     features: "db",                     label: "db (default)" }
-          - { crate: huginn-net,     features: "tls-stable-v1",          label: "tls-stable-v1" }
-          - { crate: huginn-net,     features: "db,tls-stable-v1",       label: "db+tls-stable-v1" }
+          - { crate: huginn-net,     features: "",                                                       label: "none" }
+          - { crate: huginn-net,     features: "db",                                                     label: "db only" }
+          - { crate: huginn-net,     features: "tcp-syn",                                                label: "tcp-syn only" }
+          - { crate: huginn-net,     features: "tcp-mtu",                                                label: "tcp-mtu only" }
+          - { crate: huginn-net,     features: "tcp-uptime",                                             label: "tcp-uptime only" }
+          - { crate: huginn-net,     features: "db,tcp-syn,tcp-syn-ack",                                 label: "db+tcp-syn+tcp-syn-ack" }
+          - { crate: huginn-net,     features: "db,tcp-mtu,tcp-uptime",                                  label: "db+tcp-mtu+tcp-uptime" }
+          - { crate: huginn-net,     features: "db,tcp-syn,tcp-syn-ack,tcp-mtu,tcp-uptime",              label: "all defaults" }
+          - { crate: huginn-net,     features: "tls-stable-v1",                                          label: "tls-stable-v1" }
+          - { crate: huginn-net,     features: "db,tcp-syn,tcp-syn-ack,tcp-mtu,tcp-uptime,tls-stable-v1", label: "all + tls-stable-v1" }
     steps:
       - uses: actions/checkout@v6
       - name: Install Rust ${{ env.rust_stable }}
@@ -220,6 +222,11 @@ jobs:
             --features "${{ matrix.features }}" --tests
           cargo bench -p huginn-net-tcp --no-default-features \
             --features "${{ matrix.features }}" --no-run
+      - name: Tests (huginn-net umbrella full combo only)
+        if: matrix.crate == 'huginn-net' && matrix.features == 'db,tcp-syn,tcp-syn-ack,tcp-mtu,tcp-uptime'
+        run: |
+          cargo test -p huginn-net --no-default-features \
+            --features "${{ matrix.features }}" --tests
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,37 +137,59 @@ jobs:
       - name: Check benchmarks
         run: cargo check --benches -p huginn-net
 
-  # Validates every meaningful feature combination of `huginn-net-tcp` to
-  # guarantee that disabling any feature still produces a clean (warning-free)
-  # library build. The full-features combo additionally runs the test and
-  # bench-link steps.
-  tcp-feature-matrix:
-    name: TCP feature matrix
+  # Validates every meaningful feature combination of each crate that exposes
+  # Cargo features. Guarantees that disabling any feature still produces a
+  # clean (warning-free) library build. For `huginn-net-tcp`, the full-features
+  # combo additionally runs the test suite and the bench-link step.
+  #
+  # `huginn-net-http` is intentionally absent — it exposes no Cargo features
+  # and is fully covered by the workspace-wide `build`/`lint` jobs.
+  feature-matrix:
+    name: Feature matrix - ${{ matrix.crate }} (${{ matrix.label }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        features:
-          # Single features
-          - ""
-          - "syn"
-          - "syn-ack"
-          - "mtu"
-          - "uptime"
-          # Useful pairs
-          - "syn,syn-ack"
-          - "syn,mtu"
-          - "syn,uptime"
-          - "syn-ack,mtu"
-          - "syn-ack,uptime"
-          - "mtu,uptime"
-          # Three-feature combos
-          - "syn,syn-ack,mtu"
-          - "syn,syn-ack,uptime"
-          - "syn,mtu,uptime"
-          - "syn-ack,mtu,uptime"
-          # All features (equivalent to default)
-          - "syn,syn-ack,mtu,uptime"
+        include:
+          # ---------------------------------------------------------------
+          # huginn-net-tcp — features: syn, syn-ack, mtu, uptime (all default)
+          # 16 combinations: empty + 15 useful subsets.
+          # ---------------------------------------------------------------
+          - { crate: huginn-net-tcp, features: "",                       label: "none" }
+          - { crate: huginn-net-tcp, features: "syn",                    label: "syn" }
+          - { crate: huginn-net-tcp, features: "syn-ack",                label: "syn-ack" }
+          - { crate: huginn-net-tcp, features: "mtu",                    label: "mtu" }
+          - { crate: huginn-net-tcp, features: "uptime",                 label: "uptime" }
+          - { crate: huginn-net-tcp, features: "syn,syn-ack",            label: "syn+syn-ack" }
+          - { crate: huginn-net-tcp, features: "syn,mtu",                label: "syn+mtu" }
+          - { crate: huginn-net-tcp, features: "syn,uptime",             label: "syn+uptime" }
+          - { crate: huginn-net-tcp, features: "syn-ack,mtu",            label: "syn-ack+mtu" }
+          - { crate: huginn-net-tcp, features: "syn-ack,uptime",         label: "syn-ack+uptime" }
+          - { crate: huginn-net-tcp, features: "mtu,uptime",             label: "mtu+uptime" }
+          - { crate: huginn-net-tcp, features: "syn,syn-ack,mtu",        label: "syn+syn-ack+mtu" }
+          - { crate: huginn-net-tcp, features: "syn,syn-ack,uptime",     label: "syn+syn-ack+uptime" }
+          - { crate: huginn-net-tcp, features: "syn,mtu,uptime",         label: "syn+mtu+uptime" }
+          - { crate: huginn-net-tcp, features: "syn-ack,mtu,uptime",     label: "syn-ack+mtu+uptime" }
+          - { crate: huginn-net-tcp, features: "syn,syn-ack,mtu,uptime", label: "all (default)" }
+          # ---------------------------------------------------------------
+          # huginn-net-tls — feature: stable-v1 (NOT default)
+          # ---------------------------------------------------------------
+          - { crate: huginn-net-tls, features: "",                       label: "none (default)" }
+          - { crate: huginn-net-tls, features: "stable-v1",              label: "stable-v1" }
+          # ---------------------------------------------------------------
+          # huginn-net-db — features: tcp, http (both default)
+          # ---------------------------------------------------------------
+          - { crate: huginn-net-db,  features: "",                       label: "none" }
+          - { crate: huginn-net-db,  features: "tcp",                    label: "tcp" }
+          - { crate: huginn-net-db,  features: "http",                   label: "http" }
+          - { crate: huginn-net-db,  features: "tcp,http",               label: "all (default)" }
+          # ---------------------------------------------------------------
+          # huginn-net (umbrella) — features: db (default), tls-stable-v1
+          # ---------------------------------------------------------------
+          - { crate: huginn-net,     features: "",                       label: "none" }
+          - { crate: huginn-net,     features: "db",                     label: "db (default)" }
+          - { crate: huginn-net,     features: "tls-stable-v1",          label: "tls-stable-v1" }
+          - { crate: huginn-net,     features: "db,tls-stable-v1",       label: "db+tls-stable-v1" }
     steps:
       - uses: actions/checkout@v6
       - name: Install Rust ${{ env.rust_stable }}
@@ -175,24 +197,24 @@ jobs:
         with:
           toolchain: ${{ env.rust_stable }}
           components: clippy
-      - name: Build huginn-net-tcp (features='${{ matrix.features }}')
+      - name: Build ${{ matrix.crate }} (features='${{ matrix.features }}')
         run: |
           if [ -z "${{ matrix.features }}" ]; then
-            cargo build -p huginn-net-tcp --no-default-features --lib
+            cargo build -p ${{ matrix.crate }} --no-default-features --lib
           else
-            cargo build -p huginn-net-tcp --no-default-features \
+            cargo build -p ${{ matrix.crate }} --no-default-features \
               --features "${{ matrix.features }}" --lib
           fi
-      - name: Clippy huginn-net-tcp (features='${{ matrix.features }}')
+      - name: Clippy ${{ matrix.crate }} (features='${{ matrix.features }}')
         run: |
           if [ -z "${{ matrix.features }}" ]; then
-            cargo clippy -p huginn-net-tcp --no-default-features --lib -- -D warnings
+            cargo clippy -p ${{ matrix.crate }} --no-default-features --lib -- -D warnings
           else
-            cargo clippy -p huginn-net-tcp --no-default-features \
+            cargo clippy -p ${{ matrix.crate }} --no-default-features \
               --features "${{ matrix.features }}" --lib -- -D warnings
           fi
-      - name: Tests + bench link (full combo only)
-        if: matrix.features == 'syn,syn-ack,mtu,uptime'
+      - name: Tests + bench link (huginn-net-tcp full combo only)
+        if: matrix.crate == 'huginn-net-tcp' && matrix.features == 'syn,syn-ack,mtu,uptime'
         run: |
           cargo test  -p huginn-net-tcp --no-default-features \
             --features "${{ matrix.features }}" --tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ ctrlc = "3.5.2"
 hpack-patched = "0.3.0"
 huginn-net-db = { path = "huginn-net-db", version = "1.7.5" }
 huginn-net-http = { path = "huginn-net-http", version = "1.7.5" }
-huginn-net-tcp = { path = "huginn-net-tcp", version = "1.7.5" }
+huginn-net-tcp = { path = "huginn-net-tcp", version = "1.7.5", default-features = false }
 huginn-net-tls = { path = "huginn-net-tls", version = "1.7.5" }
 lazy_static = "1.5.0"
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -241,11 +241,37 @@ just one.
 
 | Crate | New features (v2.0) |
 |---|---|
-| `huginn-net-tcp` | none (always standalone) |
+| `huginn-net-tcp` | `syn` (default), `mtu` (default), `uptime` (default) |
 | `huginn-net-http` | none (always standalone) |
 | `huginn-net-tls` | `stable-v1` (unchanged) |
 | `huginn-net-db` | `tcp` (default), `http` (default) |
 | `huginn-net` | `db` (default), `tls-stable-v1` |
+
+### New: optional TCP analysis features in `huginn-net-tcp`
+
+`huginn-net-tcp` now exposes three opt-out features — all enabled by default, so existing
+`Cargo.toml` entries require no change.
+
+| Feature | What it enables | Extra dependency |
+|---|---|---|
+| `syn` | TCP SYN / SYN+ACK OS fingerprinting | — |
+| `mtu` | MTU extraction from MSS option | — |
+| `uptime` | uptime estimation from TCP timestamps | `ttl_cache` |
+
+Builds that disable `uptime` drop the `ttl_cache` dependency entirely. To opt out of one or more
+features:
+
+```toml
+# SYN fingerprinting only — no MTU, no uptime, no ttl_cache dependency
+huginn-net-tcp = { version = "2.0", default-features = false, features = ["syn"] }
+
+# SYN + MTU, no uptime
+huginn-net-tcp = { version = "2.0", default-features = false, features = ["syn", "mtu"] }
+```
+
+`TcpAnalysisResult` keeps all fields (`mtu`, `client_uptime`, `server_uptime`) in every build —
+they are always `Option<_>` and will be `None` when the corresponding feature is disabled, so no
+match arms or field accesses need to change.
 
 ---
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -245,7 +245,7 @@ just one.
 | `huginn-net-http` | none (always standalone) |
 | `huginn-net-tls` | `stable-v1` (unchanged) |
 | `huginn-net-db` | `tcp` (default), `http` (default) |
-| `huginn-net` | `db` (default), `tls-stable-v1` |
+| `huginn-net` | `db` (default), `tcp-syn` (default), `tcp-syn-ack` (default), `tcp-mtu` (default), `tcp-uptime` (default), `tls-stable-v1` |
 
 ### New: optional TCP analysis features in `huginn-net-tcp`
 
@@ -257,7 +257,7 @@ just one.
 | `syn` | TCP SYN OS fingerprinting (client → server, request side) | — |
 | `syn-ack` | TCP SYN+ACK OS fingerprinting (server → client, response side) | — |
 | `mtu` | MTU extraction from MSS option | — |
-| `uptime` | uptime estimation from TCP timestamps | `ttl_cache` |
+| `uptime` | uptime estimation from TCP timestamps for **both client and server** sides | `ttl_cache` |
 
 Builds that disable `uptime` drop the `ttl_cache` dependency entirely. To opt out of one or more
 features:
@@ -282,6 +282,51 @@ locality. Consumers that construct `TcpAnalysisResult` literals or destructure e
 Internally, when a build disables every feature that consumes a packet's side, `visit_tcp` returns
 immediately without parsing TCP options — so SYN-only builds pay zero per-packet cost for SYN+ACK
 packets, and the bare `--no-default-features` build pays only the IP-header quirks cost.
+
+### New: TCP feature pass-through in `huginn-net`
+
+The umbrella crate `huginn-net` re-exposes the four `huginn-net-tcp` toggles as
+`tcp-syn`, `tcp-syn-ack`, `tcp-mtu`, and `tcp-uptime` — **all default**. Disabling
+one removes the corresponding field from `FingerprintResult` at compile time
+and forwards the opt-out to `huginn-net-tcp` (the underlying parser skips the
+work; see the section above).
+
+| `huginn-net` feature | Enables in `huginn-net-tcp` | Gates field on `FingerprintResult` |
+|---|---|---|
+| `tcp-syn` | `syn` | `tcp_syn` |
+| `tcp-syn-ack` | `syn-ack` | `tcp_syn_ack` |
+| `tcp-mtu` | `mtu` | `tcp_mtu` |
+| `tcp-uptime` | `uptime` | `tcp_client_uptime` + `tcp_server_uptime` |
+
+Behaviour matrix for the most common combinations:
+
+| Build flags | `tcp_syn` | `tcp_syn_ack` | `tcp_mtu` | `tcp_client_uptime` / `tcp_server_uptime` | `ttl_cache` dep |
+|---|---|---|---|---|---|
+| default | yes | yes | yes | yes | yes |
+| `--no-default-features --features db` | — | — | — | — | no |
+| `--no-default-features --features "db,tcp-syn"` | yes | — | — | — | no |
+| `--no-default-features --features "db,tcp-syn,tcp-syn-ack,tcp-mtu"` | yes | yes | yes | — | no |
+| `--no-default-features --features "db,tcp-uptime"` | — | — | — | yes | yes |
+
+Migration:
+
+```diff
+-huginn-net = "2.0"
++huginn-net = { version = "2.0", default-features = false, features = [
++    "db", "tcp-syn", # add the tcp-* fields you actually consume
++] }
+```
+
+If you keep the defaults, **nothing changes** — the umbrella behaves exactly like before.
+
+The compatibility caveat below applies to any consumer of `huginn-net-db` that
+still relies on TCP types being unconditionally available:
+
+> `huginn-net-db` now depends on `huginn-net-tcp` with `default-features = false`,
+> so that feature toggles flow through both crates. Downstream code that uses
+> `huginn-net-db` directly **and** assumed the four TCP features were always on
+> must enable them explicitly (or rely on the umbrella, which does so via
+> its `default` set).
 
 ---
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -241,7 +241,7 @@ just one.
 
 | Crate | New features (v2.0) |
 |---|---|
-| `huginn-net-tcp` | `syn` (default), `mtu` (default), `uptime` (default) |
+| `huginn-net-tcp` | `syn` (default), `syn-ack` (default), `mtu` (default), `uptime` (default) |
 | `huginn-net-http` | none (always standalone) |
 | `huginn-net-tls` | `stable-v1` (unchanged) |
 | `huginn-net-db` | `tcp` (default), `http` (default) |
@@ -249,12 +249,13 @@ just one.
 
 ### New: optional TCP analysis features in `huginn-net-tcp`
 
-`huginn-net-tcp` now exposes three opt-out features — all enabled by default, so existing
+`huginn-net-tcp` now exposes four opt-out features — all enabled by default, so existing
 `Cargo.toml` entries require no change.
 
 | Feature | What it enables | Extra dependency |
 |---|---|---|
-| `syn` | TCP SYN / SYN+ACK OS fingerprinting | — |
+| `syn` | TCP SYN OS fingerprinting (client → server, request side) | — |
+| `syn-ack` | TCP SYN+ACK OS fingerprinting (server → client, response side) | — |
 | `mtu` | MTU extraction from MSS option | — |
 | `uptime` | uptime estimation from TCP timestamps | `ttl_cache` |
 
@@ -262,16 +263,25 @@ Builds that disable `uptime` drop the `ttl_cache` dependency entirely. To opt ou
 features:
 
 ```toml
-# SYN fingerprinting only — no MTU, no uptime, no ttl_cache dependency
+# Only fingerprint clients connecting to you, no MTU, no uptime, no ttl_cache dependency
 huginn-net-tcp = { version = "2.0", default-features = false, features = ["syn"] }
 
-# SYN + MTU, no uptime
-huginn-net-tcp = { version = "2.0", default-features = false, features = ["syn", "mtu"] }
+# Recon: only fingerprint servers you connect to, with MTU detection
+huginn-net-tcp = { version = "2.0", default-features = false, features = ["syn-ack", "mtu"] }
+
+# Full OS fingerprinting, no MTU/uptime
+huginn-net-tcp = { version = "2.0", default-features = false, features = ["syn", "syn-ack"] }
 ```
 
-`TcpAnalysisResult` keeps all fields (`mtu`, `client_uptime`, `server_uptime`) in every build —
-they are always `Option<_>` and will be `None` when the corresponding feature is disabled, so no
-match arms or field accesses need to change.
+The fields on `TcpAnalysisResult` (`syn`, `syn_ack`, `mtu`, `client_uptime`, `server_uptime`) are
+**gated by their respective features**. When you disable a feature, the field disappears from the
+struct entirely (rather than always being `None`), reducing struct size and improving cache
+locality. Consumers that construct `TcpAnalysisResult` literals or destructure exhaustively must
+`#[cfg]` their code to match the enabled features.
+
+Internally, when a build disables every feature that consumes a packet's side, `visit_tcp` returns
+immediately without parsing TCP options — so SYN-only builds pay zero per-packet cost for SYN+ACK
+packets, and the bare `--no-default-features` build pays only the IP-header quirks cost.
 
 ---
 

--- a/benches/bench_tcp.rs
+++ b/benches/bench_tcp.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use huginn_net_db::{Database, SharedTcpSignatureMatcher, TcpSignatureMatcher};
 use huginn_net_tcp::matcher_api::TcpMatcher;
-use huginn_net_tcp::{process_ipv4_packet, process_ipv6_packet, ConnectionKey, TcpTimestamp};
+use huginn_net_tcp::{process_ipv4_packet, process_ipv6_packet, ConnectionTracker};
 use std::sync::Arc;
 
 fn shared_matcher(db: Arc<Database>) -> Arc<dyn TcpMatcher + Send + Sync> {
@@ -12,7 +12,6 @@ use std::error::Error;
 use std::fs::File;
 use std::sync::Mutex;
 use std::time::Duration;
-use ttl_cache::TtlCache;
 
 /// Number of times to repeat the PCAP dataset for stable benchmarks
 const REPEAT_COUNT: usize = 1000;
@@ -355,7 +354,7 @@ fn load_packets_repeated(pcap_path: &str, repeat: usize) -> Result<Vec<Vec<u8>>,
 /// Process a packet using the public TCP API
 fn process_tcp_packet(
     packet: &[u8],
-    connection_tracker: &mut TtlCache<ConnectionKey, TcpTimestamp>,
+    connection_tracker: &mut ConnectionTracker,
     matcher: Option<&dyn TcpMatcher>,
 ) -> Option<huginn_net_tcp::TcpAnalysisResult> {
     match huginn_net_tcp::packet_parser::parse_packet(packet) {
@@ -398,7 +397,7 @@ fn bench_tcp_os_fingerprinting(c: &mut Criterion) {
     println!("  Total packets: {} (repeated {}x)", packets.len(), REPEAT_COUNT);
 
     // Count TCP analysis results
-    let mut connection_tracker = TtlCache::new(1000);
+    let mut connection_tracker = ConnectionTracker::new(1000);
     let mut syn_count: u32 = 0;
     let mut syn_ack_count: u32 = 0;
     let mut mtu_count: u32 = 0;
@@ -445,7 +444,7 @@ fn bench_tcp_os_fingerprinting(c: &mut Criterion) {
     group.bench_function("tcp_with_os_matching", |b| {
         b.iter(|| {
             let matcher = TcpSignatureMatcher::new(&db.tcp);
-            let mut tracker = TtlCache::new(1000);
+            let mut tracker = ConnectionTracker::new(1000);
             for packet in packets.iter() {
                 let _ = process_tcp_packet(packet, &mut tracker, Some(&matcher));
             }
@@ -455,7 +454,7 @@ fn bench_tcp_os_fingerprinting(c: &mut Criterion) {
     // Benchmark TCP processing without OS matching
     group.bench_function("tcp_without_os_matching", |b| {
         b.iter(|| {
-            let mut tracker = TtlCache::new(1000);
+            let mut tracker = ConnectionTracker::new(1000);
             for packet in packets.iter() {
                 let _ = process_tcp_packet(packet, &mut tracker, None);
             }
@@ -477,7 +476,7 @@ fn bench_tcp_os_fingerprinting(c: &mut Criterion) {
     let tcp_with_os_time = measure_average_time(
         || {
             let matcher = TcpSignatureMatcher::new(&db.tcp);
-            let mut tracker = TtlCache::new(1000);
+            let mut tracker = ConnectionTracker::new(1000);
             for packet in packets.iter() {
                 let _ = process_tcp_packet(packet, &mut tracker, Some(&matcher));
             }
@@ -487,7 +486,7 @@ fn bench_tcp_os_fingerprinting(c: &mut Criterion) {
 
     let tcp_without_os_time = measure_average_time(
         || {
-            let mut tracker = TtlCache::new(1000);
+            let mut tracker = ConnectionTracker::new(1000);
             for packet in packets.iter() {
                 let _ = process_tcp_packet(packet, &mut tracker, None);
             }
@@ -547,7 +546,7 @@ fn bench_tcp_mtu_detection(c: &mut Criterion) {
 
     // Count MTU detections
     let matcher = TcpSignatureMatcher::new(&db.tcp);
-    let mut connection_tracker = TtlCache::new(1000);
+    let mut connection_tracker = ConnectionTracker::new(1000);
     let mut mtu_detections: u32 = 0;
 
     for packet in &packets {
@@ -567,7 +566,7 @@ fn bench_tcp_mtu_detection(c: &mut Criterion) {
     group.bench_function("mtu_with_link_matching", |b| {
         b.iter(|| {
             let matcher = TcpSignatureMatcher::new(&db.tcp);
-            let mut tracker = TtlCache::new(1000);
+            let mut tracker = ConnectionTracker::new(1000);
             for packet in packets.iter() {
                 if let Some(result) = process_tcp_packet(packet, &mut tracker, Some(&matcher)) {
                     if let Some(mtu_output) = result.mtu {
@@ -583,7 +582,7 @@ fn bench_tcp_mtu_detection(c: &mut Criterion) {
     // Benchmark MTU detection without link matching
     group.bench_function("mtu_without_link_matching", |b| {
         b.iter(|| {
-            let mut tracker = TtlCache::new(1000);
+            let mut tracker = ConnectionTracker::new(1000);
             for packet in packets.iter() {
                 if let Some(result) = process_tcp_packet(packet, &mut tracker, None) {
                     if let Some(mtu_output) = result.mtu {
@@ -601,7 +600,7 @@ fn bench_tcp_mtu_detection(c: &mut Criterion) {
     let mtu_with_link_time = measure_average_time(
         || {
             let matcher = TcpSignatureMatcher::new(&db.tcp);
-            let mut tracker = TtlCache::new(1000);
+            let mut tracker = ConnectionTracker::new(1000);
             for packet in packets.iter() {
                 if let Some(result) = process_tcp_packet(packet, &mut tracker, Some(&matcher)) {
                     if let Some(mtu_output) = result.mtu {
@@ -616,7 +615,7 @@ fn bench_tcp_mtu_detection(c: &mut Criterion) {
 
     let mtu_without_link_time = measure_average_time(
         || {
-            let mut tracker = TtlCache::new(1000);
+            let mut tracker = ConnectionTracker::new(1000);
             for packet in packets.iter() {
                 if let Some(result) = process_tcp_packet(packet, &mut tracker, None) {
                     if let Some(mtu_output) = result.mtu {
@@ -659,7 +658,7 @@ fn bench_tcp_uptime_calculation(c: &mut Criterion) {
     println!("  Total packets: {} (repeated {}x)", packets.len(), REPEAT_COUNT);
 
     // Count uptime calculations
-    let mut connection_tracker = TtlCache::new(1000);
+    let mut connection_tracker = ConnectionTracker::new(1000);
     let mut uptime_calculations: u32 = 0;
 
     for packet in &packets {
@@ -678,7 +677,7 @@ fn bench_tcp_uptime_calculation(c: &mut Criterion) {
     // Benchmark uptime calculation with connection tracking
     group.bench_function("uptime_with_tracking", |b| {
         b.iter(|| {
-            let mut tracker = TtlCache::new(1000);
+            let mut tracker = ConnectionTracker::new(1000);
             for packet in packets.iter() {
                 if let Some(result) = process_tcp_packet(packet, &mut tracker, None) {
                     if let Some(uptime_output) = result.client_uptime {
@@ -701,7 +700,7 @@ fn bench_tcp_uptime_calculation(c: &mut Criterion) {
     // Benchmark TCP processing with different cache sizes
     group.bench_function("uptime_small_cache", |b| {
         b.iter(|| {
-            let mut tracker = TtlCache::new(100); // Smaller cache
+            let mut tracker = ConnectionTracker::new(100); // Smaller cache
             for packet in packets.iter() {
                 let _ = process_tcp_packet(packet, &mut tracker, None);
             }
@@ -710,7 +709,7 @@ fn bench_tcp_uptime_calculation(c: &mut Criterion) {
 
     group.bench_function("uptime_large_cache", |b| {
         b.iter(|| {
-            let mut tracker = TtlCache::new(10000); // Larger cache
+            let mut tracker = ConnectionTracker::new(10000); // Larger cache
             for packet in packets.iter() {
                 let _ = process_tcp_packet(packet, &mut tracker, None);
             }
@@ -722,7 +721,7 @@ fn bench_tcp_uptime_calculation(c: &mut Criterion) {
     // Measure and store uptime calculation times
     let uptime_with_tracking_time = measure_average_time(
         || {
-            let mut tracker = TtlCache::new(1000);
+            let mut tracker = ConnectionTracker::new(1000);
             for packet in packets.iter() {
                 if let Some(result) = process_tcp_packet(packet, &mut tracker, None) {
                     if let Some(uptime_output) = result.client_uptime {
@@ -745,7 +744,7 @@ fn bench_tcp_uptime_calculation(c: &mut Criterion) {
 
     let uptime_small_cache_time = measure_average_time(
         || {
-            let mut tracker = TtlCache::new(100);
+            let mut tracker = ConnectionTracker::new(100);
             for packet in packets.iter() {
                 let _ = process_tcp_packet(packet, &mut tracker, None);
             }
@@ -755,7 +754,7 @@ fn bench_tcp_uptime_calculation(c: &mut Criterion) {
 
     let uptime_large_cache_time = measure_average_time(
         || {
-            let mut tracker = TtlCache::new(10000);
+            let mut tracker = ConnectionTracker::new(10000);
             for packet in packets.iter() {
                 let _ = process_tcp_packet(packet, &mut tracker, None);
             }
@@ -820,7 +819,7 @@ fn bench_tcp_processing_overhead(c: &mut Criterion) {
     group.bench_function("full_tcp_analysis", |b| {
         b.iter(|| {
             let matcher = TcpSignatureMatcher::new(&db.tcp);
-            let mut tracker = TtlCache::new(1000);
+            let mut tracker = ConnectionTracker::new(1000);
             for packet in packets.iter() {
                 let _ = process_tcp_packet(packet, &mut tracker, Some(&matcher));
             }
@@ -831,7 +830,7 @@ fn bench_tcp_processing_overhead(c: &mut Criterion) {
     group.bench_function("full_analysis_with_collection", |b| {
         b.iter(|| {
             let matcher = TcpSignatureMatcher::new(&db.tcp);
-            let mut tracker = TtlCache::new(1000);
+            let mut tracker = ConnectionTracker::new(1000);
             let mut results = Vec::new();
 
             for packet in packets.iter() {
@@ -869,7 +868,7 @@ fn bench_tcp_processing_overhead(c: &mut Criterion) {
     let full_tcp_analysis_time = measure_average_time(
         || {
             let matcher = TcpSignatureMatcher::new(&db.tcp);
-            let mut tracker = TtlCache::new(1000);
+            let mut tracker = ConnectionTracker::new(1000);
             for packet in packets.iter() {
                 let _ = process_tcp_packet(packet, &mut tracker, Some(&matcher));
             }
@@ -880,7 +879,7 @@ fn bench_tcp_processing_overhead(c: &mut Criterion) {
     let full_analysis_with_collection_time = measure_average_time(
         || {
             let matcher = TcpSignatureMatcher::new(&db.tcp);
-            let mut tracker = TtlCache::new(1000);
+            let mut tracker = ConnectionTracker::new(1000);
             let mut results = Vec::new();
             for packet in packets.iter() {
                 if let Some(result) = process_tcp_packet(packet, &mut tracker, Some(&matcher)) {

--- a/examples/README.md
+++ b/examples/README.md
@@ -140,6 +140,6 @@ RUST_LOG=info RUST_BACKTRACE=1 ./target/release/examples/capture-http -l http-ca
 
 #### Differences between examples:
 - **`capture`**: Full analysis (TCP fingerprinting, HTTP analysis, TLS JA4, database matching)
-- **`capture-tls`**: TLS-only analysis (JA4 fingerprinting, supports sequential and parallel modes with round-robin dispatch)
+- **`capture-tls`**: TLS-only analysis (JA4 fingerprinting, supports sequential and parallel modes with hash-based worker assignment)
 - **`capture-tcp`**: TCP-only analysis (OS fingerprinting, MTU detection, uptime estimation, requires database, supports sequential and parallel modes with hash-based worker assignment)
 - **`capture-http`**: HTTP-only analysis (browser fingerprinting, web server detection, language detection, requires database, supports sequential and parallel modes with flow-based routing)

--- a/huginn-net-db/Cargo.toml
+++ b/huginn-net-db/Cargo.toml
@@ -26,6 +26,12 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+# The TCP integration test (`tests/tcp_pcap_golden.rs`) destructures every
+# field of `TcpAnalysisResult` (syn, syn-ack, mtu, uptime), so the test build
+# must activate all four `huginn-net-tcp` features. The non-test build keeps
+# `default-features = false` (see `[dependencies]` above) so feature
+# unification does not leak into downstream binaries.
+huginn-net-tcp = { workspace = true, features = ["syn", "syn-ack", "mtu", "uptime"] }
 lazy_static = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/huginn-net-db/Cargo.toml
+++ b/huginn-net-db/Cargo.toml
@@ -20,7 +20,7 @@ http = ["dep:huginn-net-http"]
 
 [dependencies]
 huginn-net-http = { workspace = true, optional = true }
-huginn-net-tcp = { workspace = true, optional = true }
+huginn-net-tcp = { workspace = true, optional = true, default-features = false }
 nom = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/huginn-net-tcp/Cargo.toml
+++ b/huginn-net-tcp/Cargo.toml
@@ -13,13 +13,20 @@ homepage.workspace = true
 keywords = ["tcp", "fingerprinting", "network", "security"]
 categories = ["network-programming"]
 
+[features]
+default = ["syn", "syn-ack", "mtu", "uptime"]
+syn = []
+syn-ack = []
+mtu = []
+uptime = ["dep:ttl_cache"]
+
 [dependencies]
 crossbeam-channel = { workspace = true }
 pcap-file = { workspace = true }
 pnet = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-ttl_cache = { workspace = true }
+ttl_cache = { workspace = true, optional = true }
 
 [dev-dependencies]
 clap = { workspace = true }

--- a/huginn-net-tcp/Cargo.toml
+++ b/huginn-net-tcp/Cargo.toml
@@ -41,10 +41,10 @@ tracing-subscriber = { workspace = true }
 [[example]]
 name = "capture-tcp"
 path = "../examples/capture-tcp.rs"
-required-features = ["mtu", "uptime"]
+required-features = ["syn", "syn-ack", "mtu", "uptime"]
 
 [[bench]]
 name = "bench_tcp"
 path = "../benches/bench_tcp.rs"
 harness = false
-required-features = ["mtu", "uptime"]
+required-features = ["syn", "syn-ack", "mtu", "uptime"]

--- a/huginn-net-tcp/Cargo.toml
+++ b/huginn-net-tcp/Cargo.toml
@@ -41,8 +41,10 @@ tracing-subscriber = { workspace = true }
 [[example]]
 name = "capture-tcp"
 path = "../examples/capture-tcp.rs"
+required-features = ["mtu", "uptime"]
 
 [[bench]]
 name = "bench_tcp"
 path = "../benches/bench_tcp.rs"
 harness = false
+required-features = ["mtu", "uptime"]

--- a/huginn-net-tcp/README.md
+++ b/huginn-net-tcp/README.md
@@ -61,9 +61,45 @@ huginn-net-db = { version = "1.7.5", default-features = false, features = ["tcp"
 
 ### Cargo Features
 
-This crate has no Cargo features of its own. Database support is opt-in
-at the dependency level by adding `huginn-net-db` and calling
-[`HuginnNetTcp::with_matcher`].
+All four analysis features below are enabled by default — existing
+`Cargo.toml` entries require no change. Disable any of them to strip the
+matching code paths, the corresponding fields on `TcpAnalysisResult`, and
+(for `uptime`) the `ttl_cache` dependency.
+
+| Feature   | Default | What it enables                                                              | Extra dependency |
+|-----------|---------|------------------------------------------------------------------------------|------------------|
+| `syn`     | Yes     | TCP SYN OS fingerprinting (client → server, request side)                    | —                |
+| `syn-ack` | Yes     | TCP SYN+ACK OS fingerprinting (server → client, response side)               | —                |
+| `mtu`     | Yes     | MTU extraction from the TCP MSS option                                       | —                |
+| `uptime`  | Yes     | Uptime estimation from TCP timestamps                                        | `ttl_cache`      |
+
+When a build disables every feature that would consume a packet's side
+(request or response), the TCP options parser short-circuits — SYN-only
+builds pay zero per-packet cost for SYN+ACK traffic, and SYN+ACK-only
+builds skip the request-side work entirely.
+
+Opt-out examples:
+
+```toml
+# Fingerprint only clients connecting to you, no MTU/uptime, no ttl_cache
+huginn-net-tcp = { version = "2.0", default-features = false, features = ["syn"] }
+
+# Recon: fingerprint only servers you connect to, with MTU detection
+huginn-net-tcp = { version = "2.0", default-features = false, features = ["syn-ack", "mtu"] }
+
+# Full OS fingerprinting, no MTU/uptime
+huginn-net-tcp = { version = "2.0", default-features = false, features = ["syn", "syn-ack"] }
+```
+
+> Fields on `TcpAnalysisResult` (`syn`, `syn_ack`, `mtu`, `client_uptime`,
+> `server_uptime`) are **gated by their respective features** — disabling a
+> feature removes the field from the struct entirely (rather than setting it
+> to `None`). Consumers that construct `TcpAnalysisResult` literals or
+> destructure exhaustively must `#[cfg]` their code to match the enabled
+> features.
+
+Database support is opt-in at the dependency level by adding
+`huginn-net-db` and calling [`HuginnNetTcp::with_matcher`].
 
 ### Basic Usage — with database (OS fingerprinting)
 

--- a/huginn-net-tcp/README.md
+++ b/huginn-net-tcp/README.md
@@ -71,7 +71,7 @@ matching code paths, the corresponding fields on `TcpAnalysisResult`, and
 | `syn`     | Yes     | TCP SYN OS fingerprinting (client → server, request side)                    | —                |
 | `syn-ack` | Yes     | TCP SYN+ACK OS fingerprinting (server → client, response side)               | —                |
 | `mtu`     | Yes     | MTU extraction from the TCP MSS option                                       | —                |
-| `uptime`  | Yes     | Uptime estimation from TCP timestamps                                        | `ttl_cache`      |
+| `uptime`  | Yes     | Uptime estimation from TCP timestamps for **both client and server** sides   | `ttl_cache`      |
 
 When a build disables every feature that would consume a packet's side
 (request or response), the TCP options parser short-circuits — SYN-only

--- a/huginn-net-tcp/src/analyzer.rs
+++ b/huginn-net-tcp/src/analyzer.rs
@@ -362,6 +362,7 @@ impl HuginnNetTcp {
                 return Ok(TcpAnalysisResult {
                     syn: None,
                     syn_ack: None,
+                    #[cfg(feature = "mtu")]
                     mtu: None,
                     #[cfg(feature = "uptime")]
                     client_uptime: None,
@@ -380,6 +381,7 @@ impl HuginnNetTcp {
             IpPacket::None => Ok(TcpAnalysisResult {
                 syn: None,
                 syn_ack: None,
+                #[cfg(feature = "mtu")]
                 mtu: None,
                 #[cfg(feature = "uptime")]
                 client_uptime: None,

--- a/huginn-net-tcp/src/analyzer.rs
+++ b/huginn-net-tcp/src/analyzer.rs
@@ -360,7 +360,9 @@ impl HuginnNetTcp {
             if !raw_filter::apply(packet, filter) {
                 debug!("Filtered out packet before parsing");
                 return Ok(TcpAnalysisResult {
+                    #[cfg(feature = "syn")]
                     syn: None,
+                    #[cfg(feature = "syn-ack")]
                     syn_ack: None,
                     #[cfg(feature = "mtu")]
                     mtu: None,
@@ -379,7 +381,9 @@ impl HuginnNetTcp {
             IpPacket::Ipv4(ipv4) => process_ipv4_packet(&ipv4, connection_tracker, matcher_ref),
             IpPacket::Ipv6(ipv6) => process_ipv6_packet(&ipv6, connection_tracker, matcher_ref),
             IpPacket::None => Ok(TcpAnalysisResult {
+                #[cfg(feature = "syn")]
                 syn: None,
+                #[cfg(feature = "syn-ack")]
                 syn_ack: None,
                 #[cfg(feature = "mtu")]
                 mtu: None,

--- a/huginn-net-tcp/src/analyzer.rs
+++ b/huginn-net-tcp/src/analyzer.rs
@@ -4,8 +4,9 @@ use crate::filter::FilterConfig;
 use crate::matcher_api::TcpMatcher;
 use crate::output::TcpAnalysisResult;
 use crate::parser::packet::{parse_packet, IpPacket};
-use crate::process::{process_ipv4_packet, process_ipv6_packet, PoolStats, WorkerPool};
-use crate::uptime::{ConnectionKey, TcpTimestamp};
+use crate::process::{
+    process_ipv4_packet, process_ipv6_packet, ConnectionTracker, PoolStats, WorkerPool,
+};
 use pcap_file::pcap::PcapReader;
 use pnet::datalink::{self, Channel, Config};
 use std::fs::File;
@@ -13,7 +14,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
 use tracing::{debug, error};
-use ttl_cache::TtlCache;
 
 #[derive(Debug, Clone, Copy)]
 struct ParallelConfig {
@@ -216,7 +216,7 @@ impl HuginnNetTcp {
     where
         F: FnMut() -> Option<Result<Vec<u8>, HuginnNetTcpError>>,
     {
-        let mut connection_tracker = TtlCache::new(self.max_connections);
+        let mut connection_tracker = ConnectionTracker::new(self.max_connections);
 
         while let Some(packet_result) = packet_fn() {
             if let Some(ref cancel) = cancel_signal {
@@ -354,7 +354,7 @@ impl HuginnNetTcp {
     fn process_packet(
         &self,
         packet: &[u8],
-        connection_tracker: &mut TtlCache<ConnectionKey, TcpTimestamp>,
+        connection_tracker: &mut ConnectionTracker,
     ) -> Result<TcpAnalysisResult, HuginnNetTcpError> {
         if let Some(ref filter) = self.filter_config {
             if !raw_filter::apply(packet, filter) {
@@ -363,7 +363,9 @@ impl HuginnNetTcp {
                     syn: None,
                     syn_ack: None,
                     mtu: None,
+                    #[cfg(feature = "uptime")]
                     client_uptime: None,
+                    #[cfg(feature = "uptime")]
                     server_uptime: None,
                 });
             }
@@ -379,7 +381,9 @@ impl HuginnNetTcp {
                 syn: None,
                 syn_ack: None,
                 mtu: None,
+                #[cfg(feature = "uptime")]
                 client_uptime: None,
+                #[cfg(feature = "uptime")]
                 server_uptime: None,
             }),
         }

--- a/huginn-net-tcp/src/lib.rs
+++ b/huginn-net-tcp/src/lib.rs
@@ -25,6 +25,7 @@ pub mod output;
 pub mod parser;
 pub mod process;
 pub mod tcp;
+#[cfg(feature = "uptime")]
 pub mod uptime;
 
 // Re-exports from new canonical locations
@@ -33,9 +34,10 @@ pub use error::*;
 pub use filter::*;
 pub use mtu::ObservableMtu;
 pub use output::*;
-pub use process::{process_ipv4_packet, process_ipv6_packet};
+pub use process::{process_ipv4_packet, process_ipv6_packet, ConnectionTracker};
 pub use process::{DispatchResult, PoolStats, WorkerPool, WorkerStats};
 pub use tcp::observable::{ObservableTcp, TcpObservation};
+#[cfg(feature = "uptime")]
 pub use uptime::{
     calculate_uptime_improved, Connection, ConnectionKey, FrequencyState, TcpTimestamp,
     UptimeTracker,
@@ -57,6 +59,7 @@ pub mod ip_options {
 pub mod observable {
     pub use crate::mtu::ObservableMtu;
     pub use crate::tcp::observable::{ObservableTcp, TcpObservation};
+    #[cfg(feature = "uptime")]
     pub use crate::uptime::ObservableUptime;
 }
 

--- a/huginn-net-tcp/src/lib.rs
+++ b/huginn-net-tcp/src/lib.rs
@@ -15,6 +15,30 @@
 //! In the default workspace setup, `huginn-net-db` provides
 //! `TcpSignatureMatcher`, which loads p0f-style signatures and implements
 //! [`matcher_api::TcpMatcher`].
+//!
+//! ## Cargo Features
+//!
+//! All four analysis features are enabled by default. Disable any of them to
+//! strip the matching code paths, the corresponding fields on
+//! [`TcpAnalysisResult`], and (for `uptime`) the `ttl_cache` dependency.
+//!
+//! | Feature   | Default | Description                                                                                |
+//! |-----------|---------|--------------------------------------------------------------------------------------------|
+//! | `syn`     | Yes     | TCP SYN OS fingerprinting (client → server, request side). Gates [`SynTCPOutput`].         |
+//! | `syn-ack` | Yes     | TCP SYN+ACK OS fingerprinting (server → client, response side). Gates [`SynAckTCPOutput`]. |
+//! | `mtu`     | Yes     | MTU extraction from the TCP MSS option. Gates [`mtu`] and [`MTUOutput`].                   |
+//! | `uptime`  | Yes     | Uptime estimation from TCP timestamps. Gates [`uptime`] and pulls in `ttl_cache`.          |
+//!
+//! When a build disables every feature that would consume a packet's side
+//! (request or response), `visit_tcp` short-circuits before parsing TCP
+//! options. SYN-only builds therefore pay zero per-packet cost for SYN+ACK
+//! traffic, and SYN+ACK-only builds skip the request-side work entirely.
+//!
+//! Example — fingerprint clients only, no MTU/uptime, no extra dependencies:
+//!
+//! ```toml
+//! huginn-net-tcp = { version = "2.0", default-features = false, features = ["syn"] }
+//! ```
 
 pub mod analyzer;
 pub mod error;

--- a/huginn-net-tcp/src/lib.rs
+++ b/huginn-net-tcp/src/lib.rs
@@ -20,6 +20,7 @@ pub mod analyzer;
 pub mod error;
 pub mod filter;
 pub mod matcher_api;
+#[cfg(feature = "mtu")]
 pub mod mtu;
 pub mod output;
 pub mod parser;
@@ -32,6 +33,7 @@ pub mod uptime;
 pub use analyzer::{HuginnNetTcp, SharedTcpMatcher};
 pub use error::*;
 pub use filter::*;
+#[cfg(feature = "mtu")]
 pub use mtu::ObservableMtu;
 pub use output::*;
 pub use process::{process_ipv4_packet, process_ipv6_packet, ConnectionTracker};
@@ -57,6 +59,7 @@ pub mod ip_options {
 }
 
 pub mod observable {
+    #[cfg(feature = "mtu")]
     pub use crate::mtu::ObservableMtu;
     pub use crate::tcp::observable::{ObservableTcp, TcpObservation};
     #[cfg(feature = "uptime")]

--- a/huginn-net-tcp/src/lib.rs
+++ b/huginn-net-tcp/src/lib.rs
@@ -22,12 +22,12 @@
 //! strip the matching code paths, the corresponding fields on
 //! [`TcpAnalysisResult`], and (for `uptime`) the `ttl_cache` dependency.
 //!
-//! | Feature   | Default | Description                                                                                |
-//! |-----------|---------|--------------------------------------------------------------------------------------------|
-//! | `syn`     | Yes     | TCP SYN OS fingerprinting (client → server, request side). Gates [`SynTCPOutput`].         |
-//! | `syn-ack` | Yes     | TCP SYN+ACK OS fingerprinting (server → client, response side). Gates [`SynAckTCPOutput`]. |
-//! | `mtu`     | Yes     | MTU extraction from the TCP MSS option. Gates [`mtu`] and [`MTUOutput`].                   |
-//! | `uptime`  | Yes     | Uptime estimation from TCP timestamps. Gates [`uptime`] and pulls in `ttl_cache`.          |
+//! | Feature   | Default | Description                                                                                                            |
+//! |-----------|---------|------------------------------------------------------------------------------------------------------------------------|
+//! | `syn`     | Yes     | TCP SYN OS fingerprinting (client → server, request side). Gates [`SynTCPOutput`].                                     |
+//! | `syn-ack` | Yes     | TCP SYN+ACK OS fingerprinting (server → client, response side). Gates [`SynAckTCPOutput`].                             |
+//! | `mtu`     | Yes     | MTU extraction from the TCP MSS option. Gates [`mtu`] and [`MTUOutput`].                                               |
+//! | `uptime`  | Yes     | Uptime estimation from TCP timestamps for **both client and server** sides. Gates [`uptime`] and pulls in `ttl_cache`. |
 //!
 //! When a build disables every feature that would consume a packet's side
 //! (request or response), `visit_tcp` short-circuits before parsing TCP

--- a/huginn-net-tcp/src/output.rs
+++ b/huginn-net-tcp/src/output.rs
@@ -6,7 +6,8 @@ use std::fmt::Formatter;
 /// Represents the output from TCP analysis.
 ///
 /// This struct contains various optional outputs that can be derived
-/// from analyzing TCP packets.
+/// from analyzing TCP packets. Some fields are only present when the
+/// corresponding Cargo feature is enabled.
 #[derive(Debug)]
 pub struct TcpAnalysisResult {
     /// Information derived from SYN packets.
@@ -19,9 +20,15 @@ pub struct TcpAnalysisResult {
     pub mtu: Option<MTUOutput>,
 
     /// Information about the client system uptime.
+    ///
+    /// Present only when the `uptime` feature is enabled.
+    #[cfg(feature = "uptime")]
     pub client_uptime: Option<UptimeOutput>,
 
     /// Information about the server system uptime.
+    ///
+    /// Present only when the `uptime` feature is enabled.
+    #[cfg(feature = "uptime")]
     pub server_uptime: Option<UptimeOutput>,
 }
 
@@ -229,12 +236,14 @@ impl fmt::Display for MTUOutput {
 }
 
 /// Represents the role of the host in the connection for uptime tracking.
+#[cfg(feature = "uptime")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UptimeRole {
     Client,
     Server,
 }
 
+#[cfg(feature = "uptime")]
 impl fmt::Display for UptimeRole {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
@@ -245,6 +254,7 @@ impl fmt::Display for UptimeRole {
 }
 
 /// Holds uptime information derived from TCP timestamp analysis.
+#[cfg(feature = "uptime")]
 #[derive(Debug)]
 pub struct UptimeOutput {
     pub source: IpPort,
@@ -257,6 +267,7 @@ pub struct UptimeOutput {
     pub freq: f64,
 }
 
+#[cfg(feature = "uptime")]
 impl fmt::Display for UptimeOutput {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let role_str = match self.role {

--- a/huginn-net-tcp/src/output.rs
+++ b/huginn-net-tcp/src/output.rs
@@ -1,4 +1,6 @@
+#[cfg(any(feature = "syn", feature = "syn-ack"))]
 use crate::observable::ObservableTcp;
+#[cfg(any(feature = "syn", feature = "syn-ack"))]
 use crate::tcp::Ttl;
 use std::fmt;
 use std::fmt::Formatter;
@@ -11,9 +13,15 @@ use std::fmt::Formatter;
 #[derive(Debug)]
 pub struct TcpAnalysisResult {
     /// Information derived from SYN packets.
+    ///
+    /// Present only when the `syn` feature is enabled.
+    #[cfg(feature = "syn")]
     pub syn: Option<SynTCPOutput>,
 
     /// Information derived from SYN-ACK packets.
+    ///
+    /// Present only when the `syn-ack` feature is enabled.
+    #[cfg(feature = "syn-ack")]
     pub syn_ack: Option<SynAckTCPOutput>,
 
     /// Information about the Maximum Transmission Unit (MTU).
@@ -102,6 +110,7 @@ pub struct OSQualityMatched {
 }
 
 /// Holds information derived from analyzing a TCP SYN packet (client initiation).
+#[cfg(feature = "syn")]
 #[derive(Debug)]
 pub struct SynTCPOutput {
     /// The source IP address and port of the client sending the SYN.
@@ -114,6 +123,7 @@ pub struct SynTCPOutput {
     pub sig: ObservableTcp,
 }
 
+#[cfg(feature = "syn")]
 impl fmt::Display for SynTCPOutput {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
@@ -151,6 +161,7 @@ impl fmt::Display for SynTCPOutput {
 }
 
 /// Holds information derived from analyzing a TCP SYN+ACK packet (server response).
+#[cfg(feature = "syn-ack")]
 #[derive(Debug)]
 pub struct SynAckTCPOutput {
     /// The source IP address and port of the server sending the SYN+ACK.
@@ -163,6 +174,7 @@ pub struct SynAckTCPOutput {
     pub sig: ObservableTcp,
 }
 
+#[cfg(feature = "syn-ack")]
 impl fmt::Display for SynAckTCPOutput {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(

--- a/huginn-net-tcp/src/output.rs
+++ b/huginn-net-tcp/src/output.rs
@@ -17,6 +17,9 @@ pub struct TcpAnalysisResult {
     pub syn_ack: Option<SynAckTCPOutput>,
 
     /// Information about the Maximum Transmission Unit (MTU).
+    ///
+    /// Present only when the `mtu` feature is enabled.
+    #[cfg(feature = "mtu")]
     pub mtu: Option<MTUOutput>,
 
     /// Information about the client system uptime.
@@ -196,6 +199,7 @@ impl fmt::Display for SynAckTCPOutput {
     }
 }
 
+#[cfg(feature = "mtu")]
 #[derive(Debug)]
 pub struct MTUQualityMatched {
     pub link: Option<String>,
@@ -203,6 +207,7 @@ pub struct MTUQualityMatched {
 }
 
 /// Holds information about the estimated Maximum Transmission Unit (MTU) of a link.
+#[cfg(feature = "mtu")]
 #[derive(Debug)]
 pub struct MTUOutput {
     /// The source IP address and port (usually the client).
@@ -215,6 +220,7 @@ pub struct MTUOutput {
     pub mtu: u16,
 }
 
+#[cfg(feature = "mtu")]
 impl fmt::Display for MTUOutput {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(

--- a/huginn-net-tcp/src/process/flow.rs
+++ b/huginn-net-tcp/src/process/flow.rs
@@ -5,8 +5,11 @@ use crate::mtu;
 use crate::mtu::ObservableMtu;
 use crate::process::ConnectionTracker;
 use crate::tcp;
+#[cfg(any(feature = "syn", feature = "syn-ack"))]
 use crate::tcp::observable::{ObservableTcp, TcpObservation};
-use crate::tcp::{IpOptions, IpVersion, PayloadSize, Quirk, TcpOption, Ttl, WindowSize};
+#[cfg(any(feature = "syn", feature = "syn-ack"))]
+use crate::tcp::{PayloadSize, WindowSize};
+use crate::tcp::{IpOptions, IpVersion, Quirk, TcpOption, Ttl};
 #[cfg(feature = "uptime")]
 use crate::uptime::{check_ts_tcp, Connection, ObservableUptime};
 use pnet::packet::ip::IpNextHeaderProtocols;
@@ -28,7 +31,9 @@ const IP4_MBZ: u8 = 0b0100;
 
 // Internal representation of a TCP package
 pub struct ObservableTCPPackage {
+    #[cfg(feature = "syn")]
     pub tcp_request: Option<ObservableTcp>,
+    #[cfg(feature = "syn-ack")]
     pub tcp_response: Option<ObservableTcp>,
     #[cfg(feature = "mtu")]
     pub mtu: Option<ObservableMtu>,
@@ -36,6 +41,24 @@ pub struct ObservableTCPPackage {
     pub client_uptime: Option<ObservableUptime>,
     #[cfg(feature = "uptime")]
     pub server_uptime: Option<ObservableUptime>,
+}
+
+impl ObservableTCPPackage {
+    #[inline]
+    pub fn empty() -> Self {
+        Self {
+            #[cfg(feature = "syn")]
+            tcp_request: None,
+            #[cfg(feature = "syn-ack")]
+            tcp_response: None,
+            #[cfg(feature = "mtu")]
+            mtu: None,
+            #[cfg(feature = "uptime")]
+            client_uptime: None,
+            #[cfg(feature = "uptime")]
+            server_uptime: None,
+        }
+    }
 }
 
 pub fn from_client(tcp_flags: u8) -> bool {
@@ -188,7 +211,17 @@ pub fn process_tcp_ipv6(
 }
 
 #[allow(clippy::too_many_arguments)]
-#[cfg_attr(not(feature = "uptime"), allow(unused_variables))]
+#[cfg_attr(
+    any(
+        not(feature = "uptime"),
+        not(any(feature = "syn", feature = "syn-ack")),
+    ),
+    allow(unused_variables)
+)]
+#[cfg_attr(
+    not(any(feature = "syn", feature = "syn-ack")),
+    allow(unused_assignments)
+)]
 fn visit_tcp(
     connection_tracker: &mut ConnectionTracker,
     tcp: &TcpPacket,
@@ -207,6 +240,25 @@ fn visit_tcp(
     let tcp_type: u8 = flags & (SYN | ACK | FIN | RST);
     if !is_valid(flags, tcp_type) {
         return Err(HuginnNetTcpError::InvalidTcpFlags(flags));
+    }
+
+    // Cross-feature early-exit: when the packet's side is not consumed by any
+    // enabled feature, return an empty package before parsing TCP options.
+    // In the default build (all four features on) this whole block is removed
+    // by `#[cfg]` and costs nothing.
+    #[cfg(not(all(
+        feature = "syn",
+        feature = "syn-ack",
+        feature = "mtu",
+        feature = "uptime"
+    )))]
+    {
+        let needs_request_side =
+            cfg!(feature = "syn") || cfg!(feature = "mtu") || cfg!(feature = "uptime");
+        let needs_response_side = cfg!(feature = "syn-ack") || cfg!(feature = "uptime");
+        if (from_client && !needs_request_side) || (!from_client && !needs_response_side) {
+            return Ok(ObservableTCPPackage::empty());
+        }
     }
 
     if (flags & (ECE | CWR)) != 0 {
@@ -352,32 +404,40 @@ fn visit_tcp(
         _ => None,
     };
 
-    let wsize: WindowSize = tcp::detect_win_multiplicator(
-        tcp.get_window(),
-        mss.unwrap_or(0),
-        ip_package_header_length as u16,
-        olayout.contains(&TcpOption::TS),
-        &version,
-    );
+    #[cfg(any(feature = "syn", feature = "syn-ack"))]
+    let tcp_signature: ObservableTcp = {
+        let wsize: WindowSize = tcp::detect_win_multiplicator(
+            tcp.get_window(),
+            mss.unwrap_or(0),
+            ip_package_header_length as u16,
+            olayout.contains(&TcpOption::TS),
+            &version,
+        );
 
-    let tcp_signature: ObservableTcp = ObservableTcp {
-        matching: TcpObservation {
-            version,
-            ittl,
-            olen,
-            mss,
-            wsize,
-            wscale,
-            olayout,
-            quirks,
-            pclass: if tcp.payload().is_empty() {
-                PayloadSize::Zero
-            } else {
-                PayloadSize::NonZero
+        ObservableTcp {
+            matching: TcpObservation {
+                version,
+                ittl,
+                olen,
+                mss,
+                wsize,
+                wscale,
+                olayout,
+                quirks,
+                pclass: if tcp.payload().is_empty() {
+                    PayloadSize::Zero
+                } else {
+                    PayloadSize::NonZero
+                },
             },
-        },
+        }
     };
 
+    #[cfg(any(feature = "syn", feature = "syn-ack"))]
+    #[cfg_attr(
+        not(all(feature = "syn", feature = "syn-ack")),
+        allow(unused_variables)
+    )]
     let (tcp_request, tcp_response) = if from_client {
         (Some(tcp_signature), None)
     } else {
@@ -385,7 +445,9 @@ fn visit_tcp(
     };
 
     Ok(ObservableTCPPackage {
+        #[cfg(feature = "syn")]
         tcp_request,
+        #[cfg(feature = "syn-ack")]
         tcp_response,
         #[cfg(feature = "mtu")]
         mtu: if from_client { mtu } else { None },

--- a/huginn-net-tcp/src/process/flow.rs
+++ b/huginn-net-tcp/src/process/flow.rs
@@ -7,9 +7,9 @@ use crate::process::ConnectionTracker;
 use crate::tcp;
 #[cfg(any(feature = "syn", feature = "syn-ack"))]
 use crate::tcp::observable::{ObservableTcp, TcpObservation};
+use crate::tcp::{IpOptions, IpVersion, Quirk, TcpOption, Ttl};
 #[cfg(any(feature = "syn", feature = "syn-ack"))]
 use crate::tcp::{PayloadSize, WindowSize};
-use crate::tcp::{IpOptions, IpVersion, Quirk, TcpOption, Ttl};
 #[cfg(feature = "uptime")]
 use crate::uptime::{check_ts_tcp, Connection, ObservableUptime};
 use pnet::packet::ip::IpNextHeaderProtocols;

--- a/huginn-net-tcp/src/process/flow.rs
+++ b/huginn-net-tcp/src/process/flow.rs
@@ -242,10 +242,6 @@ fn visit_tcp(
         return Err(HuginnNetTcpError::InvalidTcpFlags(flags));
     }
 
-    // Cross-feature early-exit: when the packet's side is not consumed by any
-    // enabled feature, return an empty package before parsing TCP options.
-    // In the default build (all four features on) this whole block is removed
-    // by `#[cfg]` and costs nothing.
     #[cfg(not(all(
         feature = "syn",
         feature = "syn-ack",

--- a/huginn-net-tcp/src/process/flow.rs
+++ b/huginn-net-tcp/src/process/flow.rs
@@ -1,5 +1,7 @@
 use crate::error::HuginnNetTcpError;
+#[cfg(feature = "mtu")]
 use crate::mtu;
+#[cfg(feature = "mtu")]
 use crate::mtu::ObservableMtu;
 use crate::process::ConnectionTracker;
 use crate::tcp;
@@ -28,6 +30,7 @@ const IP4_MBZ: u8 = 0b0100;
 pub struct ObservableTCPPackage {
     pub tcp_request: Option<ObservableTcp>,
     pub tcp_response: Option<ObservableTcp>,
+    #[cfg(feature = "mtu")]
     pub mtu: Option<ObservableMtu>,
     #[cfg(feature = "uptime")]
     pub client_uptime: Option<ObservableUptime>,
@@ -338,6 +341,7 @@ fn visit_tcp(
         }
     }
 
+    #[cfg(feature = "mtu")]
     let mtu: Option<ObservableMtu> = match (mss, &version) {
         (Some(mss_value), IpVersion::V4) => {
             mtu::extract_from_ipv4(tcp, ip_package_header_length, mss_value)
@@ -374,16 +378,17 @@ fn visit_tcp(
         },
     };
 
-    let (tcp_request, tcp_response, mtu_out) = if from_client {
-        (Some(tcp_signature), None, mtu)
+    let (tcp_request, tcp_response) = if from_client {
+        (Some(tcp_signature), None)
     } else {
-        (None, Some(tcp_signature), None)
+        (None, Some(tcp_signature))
     };
 
     Ok(ObservableTCPPackage {
         tcp_request,
         tcp_response,
-        mtu: mtu_out,
+        #[cfg(feature = "mtu")]
+        mtu: if from_client { mtu } else { None },
         #[cfg(feature = "uptime")]
         client_uptime,
         #[cfg(feature = "uptime")]

--- a/huginn-net-tcp/src/process/flow.rs
+++ b/huginn-net-tcp/src/process/flow.rs
@@ -1,10 +1,12 @@
 use crate::error::HuginnNetTcpError;
 use crate::mtu;
 use crate::mtu::ObservableMtu;
+use crate::process::ConnectionTracker;
 use crate::tcp;
 use crate::tcp::observable::{ObservableTcp, TcpObservation};
 use crate::tcp::{IpOptions, IpVersion, PayloadSize, Quirk, TcpOption, Ttl, WindowSize};
-use crate::uptime::{check_ts_tcp, Connection, ConnectionKey, ObservableUptime, TcpTimestamp};
+#[cfg(feature = "uptime")]
+use crate::uptime::{check_ts_tcp, Connection, ObservableUptime};
 use pnet::packet::ip::IpNextHeaderProtocols;
 use pnet::packet::{
     ipv4::{Ipv4Flags, Ipv4Packet},
@@ -14,7 +16,6 @@ use pnet::packet::{
 };
 use std::convert::TryInto;
 use std::net::IpAddr;
-use ttl_cache::TtlCache;
 
 /// Congestion encountered
 const IP_TOS_CE: u8 = 0x01;
@@ -28,7 +29,9 @@ pub struct ObservableTCPPackage {
     pub tcp_request: Option<ObservableTcp>,
     pub tcp_response: Option<ObservableTcp>,
     pub mtu: Option<ObservableMtu>,
+    #[cfg(feature = "uptime")]
     pub client_uptime: Option<ObservableUptime>,
+    #[cfg(feature = "uptime")]
     pub server_uptime: Option<ObservableUptime>,
 }
 
@@ -78,7 +81,7 @@ pub fn is_valid(tcp_flags: u8, tcp_type: u8) -> bool {
 #[inline]
 pub fn process_tcp_ipv4(
     packet: &Ipv4Packet,
-    connection_tracker: &mut TtlCache<ConnectionKey, TcpTimestamp>,
+    connection_tracker: &mut ConnectionTracker,
 ) -> Result<ObservableTCPPackage, HuginnNetTcpError> {
     if packet.get_next_level_protocol() != IpNextHeaderProtocols::Tcp {
         return Err(HuginnNetTcpError::UnsupportedProtocol("IPv4".to_string()));
@@ -141,7 +144,7 @@ pub fn process_tcp_ipv4(
 #[inline]
 pub fn process_tcp_ipv6(
     packet: &Ipv6Packet,
-    connection_tracker: &mut TtlCache<ConnectionKey, TcpTimestamp>,
+    connection_tracker: &mut ConnectionTracker,
 ) -> Result<ObservableTCPPackage, HuginnNetTcpError> {
     if packet.get_next_header() != IpNextHeaderProtocols::Tcp {
         return Err(HuginnNetTcpError::UnsupportedProtocol("IPv6".to_string()));
@@ -182,8 +185,9 @@ pub fn process_tcp_ipv6(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[cfg_attr(not(feature = "uptime"), allow(unused_variables))]
 fn visit_tcp(
-    connection_tracker: &mut TtlCache<ConnectionKey, TcpTimestamp>,
+    connection_tracker: &mut ConnectionTracker,
     tcp: &TcpPacket,
     version: IpVersion,
     ittl: Ttl,
@@ -230,7 +234,9 @@ fn visit_tcp(
     let mut mss = None;
     let mut wscale = None;
     let mut olayout: Vec<TcpOption> = Vec::with_capacity(8);
+    #[cfg(feature = "uptime")]
     let mut client_uptime: Option<ObservableUptime> = None;
+    #[cfg(feature = "uptime")]
     let mut server_uptime: Option<ObservableUptime> = None;
 
     while let Some(opt) = TcpOptionPacket::new(buf) {
@@ -298,6 +304,7 @@ fn visit_tcp(
                     }
                 }
 
+                #[cfg(feature = "uptime")]
                 if data.len() >= 8 {
                     let ts_val_bytes: [u8; 4] = data[..4].try_into().map_err(|_| {
                         HuginnNetTcpError::Parse(
@@ -315,8 +322,12 @@ fn visit_tcp(
                     let is_from_client =
                         is_packet_from_client(flags, tcp.get_source(), tcp.get_destination());
 
-                    let (cli_uptime, srv_uptime) =
-                        check_ts_tcp(connection_tracker, &connection, is_from_client, ts_val);
+                    let (cli_uptime, srv_uptime) = check_ts_tcp(
+                        &mut connection_tracker.inner,
+                        &connection,
+                        is_from_client,
+                        ts_val,
+                    );
                     client_uptime = cli_uptime;
                     server_uptime = srv_uptime;
                 }
@@ -373,7 +384,9 @@ fn visit_tcp(
         tcp_request,
         tcp_response,
         mtu: mtu_out,
+        #[cfg(feature = "uptime")]
         client_uptime,
+        #[cfg(feature = "uptime")]
         server_uptime,
     })
 }

--- a/huginn-net-tcp/src/process/mod.rs
+++ b/huginn-net-tcp/src/process/mod.rs
@@ -4,11 +4,17 @@ pub mod parallel;
 use self::flow as tcp_process;
 use crate::error::HuginnNetTcpError;
 use crate::matcher_api::TcpMatcher;
-use crate::output::{
-    IpPort, MatchQuality, OSQualityMatched, SynAckTCPOutput, SynTCPOutput, TcpAnalysisResult,
-};
+use crate::output::{IpPort, TcpAnalysisResult};
+#[cfg(any(feature = "syn", feature = "syn-ack", feature = "mtu"))]
+use crate::output::MatchQuality;
+#[cfg(any(feature = "syn", feature = "syn-ack"))]
+use crate::output::OSQualityMatched;
 #[cfg(feature = "mtu")]
 use crate::output::{MTUOutput, MTUQualityMatched};
+#[cfg(feature = "syn")]
+use crate::output::SynTCPOutput;
+#[cfg(feature = "syn-ack")]
+use crate::output::SynAckTCPOutput;
 #[cfg(feature = "uptime")]
 use crate::output::{UptimeOutput, UptimeRole};
 use pnet::packet::ipv4::Ipv4Packet;
@@ -61,6 +67,14 @@ pub fn process_ipv4_packet(
     create_observable_package_ipv4(ipv4, connection_tracker, matcher).map(|pkg| pkg.tcp_result)
 }
 
+#[cfg_attr(
+    not(any(feature = "syn", feature = "syn-ack")),
+    allow(unused_variables)
+)]
+#[cfg_attr(
+    not(any(feature = "syn", feature = "syn-ack", feature = "mtu", feature = "uptime")),
+    allow(unused_mut)
+)]
 fn create_observable_package_ipv4(
     ipv4: &Ipv4Packet,
     connection_tracker: &mut ConnectionTracker,
@@ -76,7 +90,9 @@ fn create_observable_package_ipv4(
     let tcp_package = tcp_process::process_tcp_ipv4(ipv4, connection_tracker)?;
 
     let mut tcp_result = TcpAnalysisResult {
+        #[cfg(feature = "syn")]
         syn: None,
+        #[cfg(feature = "syn-ack")]
         syn_ack: None,
         #[cfg(feature = "mtu")]
         mtu: None,
@@ -86,6 +102,7 @@ fn create_observable_package_ipv4(
         server_uptime: None,
     };
 
+    #[cfg(feature = "syn")]
     if let Some(tcp_request) = tcp_package.tcp_request {
         let os_quality =
             classify_tcp_match(matcher, |m| m.match_tcp_request(&tcp_request.matching));
@@ -99,6 +116,7 @@ fn create_observable_package_ipv4(
         tcp_result.syn = Some(syn_output);
     }
 
+    #[cfg(feature = "syn-ack")]
     if let Some(tcp_response) = tcp_package.tcp_response {
         let os_quality =
             classify_tcp_match(matcher, |m| m.match_tcp_response(&tcp_response.matching));
@@ -168,6 +186,14 @@ pub fn process_ipv6_packet(
     create_observable_package_ipv6(ipv6, connection_tracker, matcher).map(|pkg| pkg.tcp_result)
 }
 
+#[cfg_attr(
+    not(any(feature = "syn", feature = "syn-ack")),
+    allow(unused_variables)
+)]
+#[cfg_attr(
+    not(any(feature = "syn", feature = "syn-ack", feature = "mtu", feature = "uptime")),
+    allow(unused_mut)
+)]
 fn create_observable_package_ipv6(
     ipv6: &Ipv6Packet,
     connection_tracker: &mut ConnectionTracker,
@@ -183,7 +209,9 @@ fn create_observable_package_ipv6(
     let tcp_package = tcp_process::process_tcp_ipv6(ipv6, connection_tracker)?;
 
     let mut tcp_result = TcpAnalysisResult {
+        #[cfg(feature = "syn")]
         syn: None,
+        #[cfg(feature = "syn-ack")]
         syn_ack: None,
         #[cfg(feature = "mtu")]
         mtu: None,
@@ -193,6 +221,7 @@ fn create_observable_package_ipv6(
         server_uptime: None,
     };
 
+    #[cfg(feature = "syn")]
     if let Some(tcp_request) = tcp_package.tcp_request {
         let os_quality =
             classify_tcp_match(matcher, |m| m.match_tcp_request(&tcp_request.matching));
@@ -206,6 +235,7 @@ fn create_observable_package_ipv6(
         tcp_result.syn = Some(syn_output);
     }
 
+    #[cfg(feature = "syn-ack")]
     if let Some(tcp_response) = tcp_package.tcp_response {
         let os_quality =
             classify_tcp_match(matcher, |m| m.match_tcp_response(&tcp_response.matching));

--- a/huginn-net-tcp/src/process/mod.rs
+++ b/huginn-net-tcp/src/process/mod.rs
@@ -6,17 +6,43 @@ use crate::error::HuginnNetTcpError;
 use crate::matcher_api::TcpMatcher;
 use crate::output::{
     IpPort, MTUOutput, MTUQualityMatched, MatchQuality, OSQualityMatched, SynAckTCPOutput,
-    SynTCPOutput, TcpAnalysisResult, UptimeOutput, UptimeRole,
+    SynTCPOutput, TcpAnalysisResult,
 };
-use crate::uptime::{ConnectionKey, TcpTimestamp};
+#[cfg(feature = "uptime")]
+use crate::output::{UptimeOutput, UptimeRole};
 use pnet::packet::ipv4::Ipv4Packet;
 use pnet::packet::ipv6::Ipv6Packet;
 use pnet::packet::tcp::TcpPacket;
 use pnet::packet::Packet;
 use std::net::IpAddr;
-use ttl_cache::TtlCache;
 
 pub use parallel::{DispatchResult, PoolStats, WorkerPool, WorkerStats};
+
+/// Per-flow connection state used by uptime tracking.
+///
+/// When the `uptime` feature is enabled, this wraps a `TtlCache` of TCP
+/// timestamp samples keyed by connection direction. When the feature is
+/// disabled, it is a zero-sized stub and all operations on it are no-ops, so
+/// builds without uptime tracking drop the `ttl_cache` dependency entirely
+/// without changing public function signatures.
+pub struct ConnectionTracker {
+    #[cfg(feature = "uptime")]
+    pub(crate) inner:
+        ttl_cache::TtlCache<crate::uptime::ConnectionKey, crate::uptime::TcpTimestamp>,
+}
+
+impl ConnectionTracker {
+    /// Creates a new connection tracker.
+    ///
+    /// `max_connections` is the upper bound on tracked flows. When the
+    /// `uptime` feature is disabled the argument is ignored.
+    pub fn new(_max_connections: usize) -> Self {
+        Self {
+            #[cfg(feature = "uptime")]
+            inner: ttl_cache::TtlCache::new(_max_connections),
+        }
+    }
+}
 
 pub struct ObservablePackage {
     pub source: IpPort,
@@ -28,7 +54,7 @@ pub struct ObservablePackage {
 #[inline]
 pub fn process_ipv4_packet(
     ipv4: &Ipv4Packet,
-    connection_tracker: &mut TtlCache<ConnectionKey, TcpTimestamp>,
+    connection_tracker: &mut ConnectionTracker,
     matcher: Option<&dyn TcpMatcher>,
 ) -> Result<TcpAnalysisResult, HuginnNetTcpError> {
     create_observable_package_ipv4(ipv4, connection_tracker, matcher).map(|pkg| pkg.tcp_result)
@@ -36,7 +62,7 @@ pub fn process_ipv4_packet(
 
 fn create_observable_package_ipv4(
     ipv4: &Ipv4Packet,
-    connection_tracker: &mut TtlCache<ConnectionKey, TcpTimestamp>,
+    connection_tracker: &mut ConnectionTracker,
     matcher: Option<&dyn TcpMatcher>,
 ) -> Result<ObservablePackage, HuginnNetTcpError> {
     let tcp = TcpPacket::new(ipv4.payload())
@@ -52,7 +78,9 @@ fn create_observable_package_ipv4(
         syn: None,
         syn_ack: None,
         mtu: None,
+        #[cfg(feature = "uptime")]
         client_uptime: None,
+        #[cfg(feature = "uptime")]
         server_uptime: None,
     };
 
@@ -94,6 +122,7 @@ fn create_observable_package_ipv4(
         tcp_result.mtu = Some(mtu_output);
     }
 
+    #[cfg(feature = "uptime")]
     if let Some(uptime) = tcp_package.client_uptime {
         let uptime_output = UptimeOutput {
             source: IpPort::new(IpAddr::V4(ipv4.get_source()), tcp.get_source()),
@@ -108,6 +137,7 @@ fn create_observable_package_ipv4(
         tcp_result.client_uptime = Some(uptime_output);
     }
 
+    #[cfg(feature = "uptime")]
     if let Some(uptime) = tcp_package.server_uptime {
         let uptime_output = UptimeOutput {
             source: IpPort::new(IpAddr::V4(ipv4.get_source()), tcp.get_source()),
@@ -129,7 +159,7 @@ fn create_observable_package_ipv4(
 #[inline]
 pub fn process_ipv6_packet(
     ipv6: &Ipv6Packet,
-    connection_tracker: &mut TtlCache<ConnectionKey, TcpTimestamp>,
+    connection_tracker: &mut ConnectionTracker,
     matcher: Option<&dyn TcpMatcher>,
 ) -> Result<TcpAnalysisResult, HuginnNetTcpError> {
     create_observable_package_ipv6(ipv6, connection_tracker, matcher).map(|pkg| pkg.tcp_result)
@@ -137,7 +167,7 @@ pub fn process_ipv6_packet(
 
 fn create_observable_package_ipv6(
     ipv6: &Ipv6Packet,
-    connection_tracker: &mut TtlCache<ConnectionKey, TcpTimestamp>,
+    connection_tracker: &mut ConnectionTracker,
     matcher: Option<&dyn TcpMatcher>,
 ) -> Result<ObservablePackage, HuginnNetTcpError> {
     let tcp = TcpPacket::new(ipv6.payload())
@@ -153,7 +183,9 @@ fn create_observable_package_ipv6(
         syn: None,
         syn_ack: None,
         mtu: None,
+        #[cfg(feature = "uptime")]
         client_uptime: None,
+        #[cfg(feature = "uptime")]
         server_uptime: None,
     };
 
@@ -195,6 +227,7 @@ fn create_observable_package_ipv6(
         tcp_result.mtu = Some(mtu_output);
     }
 
+    #[cfg(feature = "uptime")]
     if let Some(uptime) = tcp_package.client_uptime {
         let uptime_output = UptimeOutput {
             source: IpPort::new(IpAddr::V6(ipv6.get_source()), tcp.get_source()),
@@ -209,6 +242,7 @@ fn create_observable_package_ipv6(
         tcp_result.client_uptime = Some(uptime_output);
     }
 
+    #[cfg(feature = "uptime")]
     if let Some(uptime) = tcp_package.server_uptime {
         let uptime_output = UptimeOutput {
             source: IpPort::new(IpAddr::V6(ipv6.get_source()), tcp.get_source()),

--- a/huginn-net-tcp/src/process/mod.rs
+++ b/huginn-net-tcp/src/process/mod.rs
@@ -4,17 +4,17 @@ pub mod parallel;
 use self::flow as tcp_process;
 use crate::error::HuginnNetTcpError;
 use crate::matcher_api::TcpMatcher;
-use crate::output::{IpPort, TcpAnalysisResult};
 #[cfg(any(feature = "syn", feature = "syn-ack", feature = "mtu"))]
 use crate::output::MatchQuality;
 #[cfg(any(feature = "syn", feature = "syn-ack"))]
 use crate::output::OSQualityMatched;
-#[cfg(feature = "mtu")]
-use crate::output::{MTUOutput, MTUQualityMatched};
-#[cfg(feature = "syn")]
-use crate::output::SynTCPOutput;
 #[cfg(feature = "syn-ack")]
 use crate::output::SynAckTCPOutput;
+#[cfg(feature = "syn")]
+use crate::output::SynTCPOutput;
+use crate::output::{IpPort, TcpAnalysisResult};
+#[cfg(feature = "mtu")]
+use crate::output::{MTUOutput, MTUQualityMatched};
 #[cfg(feature = "uptime")]
 use crate::output::{UptimeOutput, UptimeRole};
 use pnet::packet::ipv4::Ipv4Packet;
@@ -72,7 +72,12 @@ pub fn process_ipv4_packet(
     allow(unused_variables)
 )]
 #[cfg_attr(
-    not(any(feature = "syn", feature = "syn-ack", feature = "mtu", feature = "uptime")),
+    not(any(
+        feature = "syn",
+        feature = "syn-ack",
+        feature = "mtu",
+        feature = "uptime"
+    )),
     allow(unused_mut)
 )]
 fn create_observable_package_ipv4(
@@ -191,7 +196,12 @@ pub fn process_ipv6_packet(
     allow(unused_variables)
 )]
 #[cfg_attr(
-    not(any(feature = "syn", feature = "syn-ack", feature = "mtu", feature = "uptime")),
+    not(any(
+        feature = "syn",
+        feature = "syn-ack",
+        feature = "mtu",
+        feature = "uptime"
+    )),
     allow(unused_mut)
 )]
 fn create_observable_package_ipv6(
@@ -295,6 +305,7 @@ fn create_observable_package_ipv6(
     Ok(ObservablePackage { source, destination, tcp_result })
 }
 
+#[cfg(any(feature = "syn", feature = "syn-ack"))]
 fn classify_tcp_match<F>(matcher: Option<&dyn TcpMatcher>, call: F) -> OSQualityMatched
 where
     F: FnOnce(&dyn TcpMatcher) -> Option<crate::matcher_api::TcpMatch>,

--- a/huginn-net-tcp/src/process/mod.rs
+++ b/huginn-net-tcp/src/process/mod.rs
@@ -5,9 +5,10 @@ use self::flow as tcp_process;
 use crate::error::HuginnNetTcpError;
 use crate::matcher_api::TcpMatcher;
 use crate::output::{
-    IpPort, MTUOutput, MTUQualityMatched, MatchQuality, OSQualityMatched, SynAckTCPOutput,
-    SynTCPOutput, TcpAnalysisResult,
+    IpPort, MatchQuality, OSQualityMatched, SynAckTCPOutput, SynTCPOutput, TcpAnalysisResult,
 };
+#[cfg(feature = "mtu")]
+use crate::output::{MTUOutput, MTUQualityMatched};
 #[cfg(feature = "uptime")]
 use crate::output::{UptimeOutput, UptimeRole};
 use pnet::packet::ipv4::Ipv4Packet;
@@ -77,6 +78,7 @@ fn create_observable_package_ipv4(
     let mut tcp_result = TcpAnalysisResult {
         syn: None,
         syn_ack: None,
+        #[cfg(feature = "mtu")]
         mtu: None,
         #[cfg(feature = "uptime")]
         client_uptime: None,
@@ -110,6 +112,7 @@ fn create_observable_package_ipv4(
         tcp_result.syn_ack = Some(syn_ack_output);
     }
 
+    #[cfg(feature = "mtu")]
     if let Some(mtu) = tcp_package.mtu {
         let link_quality = classify_mtu_match(matcher, mtu.value);
 
@@ -182,6 +185,7 @@ fn create_observable_package_ipv6(
     let mut tcp_result = TcpAnalysisResult {
         syn: None,
         syn_ack: None,
+        #[cfg(feature = "mtu")]
         mtu: None,
         #[cfg(feature = "uptime")]
         client_uptime: None,
@@ -215,6 +219,7 @@ fn create_observable_package_ipv6(
         tcp_result.syn_ack = Some(syn_ack_output);
     }
 
+    #[cfg(feature = "mtu")]
     if let Some(mtu) = tcp_package.mtu {
         let link_quality = classify_mtu_match(matcher, mtu.value);
 
@@ -276,6 +281,7 @@ where
     }
 }
 
+#[cfg(feature = "mtu")]
 fn classify_mtu_match(matcher: Option<&dyn TcpMatcher>, mtu: u16) -> MTUQualityMatched {
     match matcher {
         Some(m) => match m.match_mtu(mtu) {

--- a/huginn-net-tcp/src/process/parallel.rs
+++ b/huginn-net-tcp/src/process/parallel.rs
@@ -275,7 +275,9 @@ impl WorkerPool {
             IpPacket::Ipv4(ipv4) => process_ipv4_packet(&ipv4, connection_tracker, matcher),
             IpPacket::Ipv6(ipv6) => process_ipv6_packet(&ipv6, connection_tracker, matcher),
             IpPacket::None => Ok(TcpAnalysisResult {
+                #[cfg(feature = "syn")]
                 syn: None,
+                #[cfg(feature = "syn-ack")]
                 syn_ack: None,
                 #[cfg(feature = "mtu")]
                 mtu: None,

--- a/huginn-net-tcp/src/process/parallel.rs
+++ b/huginn-net-tcp/src/process/parallel.rs
@@ -277,6 +277,7 @@ impl WorkerPool {
             IpPacket::None => Ok(TcpAnalysisResult {
                 syn: None,
                 syn_ack: None,
+                #[cfg(feature = "mtu")]
                 mtu: None,
                 #[cfg(feature = "uptime")]
                 client_uptime: None,

--- a/huginn-net-tcp/src/process/parallel.rs
+++ b/huginn-net-tcp/src/process/parallel.rs
@@ -1,4 +1,4 @@
-use super::{process_ipv4_packet, process_ipv6_packet};
+use super::{process_ipv4_packet, process_ipv6_packet, ConnectionTracker};
 use crate::error::HuginnNetTcpError;
 use crate::filter::raw as raw_filter;
 use crate::filter::FilterConfig;
@@ -11,7 +11,6 @@ use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use ttl_cache::TtlCache;
 
 type SharedMatcher = Arc<dyn TcpMatcher + Send + Sync>;
 
@@ -193,7 +192,7 @@ impl WorkerPool {
         let matcher_ref: Option<&dyn TcpMatcher> = matcher.as_deref().map(|m| m as &dyn TcpMatcher);
 
         // Each worker maintains its own connection tracker (state isolation)
-        let mut connection_tracker = TtlCache::new(config.max_connections);
+        let mut connection_tracker = ConnectionTracker::new(config.max_connections);
 
         let timeout = Duration::from_millis(config.timeout_ms);
 
@@ -260,10 +259,7 @@ impl WorkerPool {
     /// Returns `false` if the result channel is closed (signal to exit).
     fn process_packet(
         packet: &[u8],
-        connection_tracker: &mut TtlCache<
-            crate::uptime::ConnectionKey,
-            crate::uptime::TcpTimestamp,
-        >,
+        connection_tracker: &mut ConnectionTracker,
         matcher: Option<&dyn TcpMatcher>,
         result_sender: &std::sync::mpsc::Sender<TcpAnalysisResult>,
         filter: Option<&FilterConfig>,
@@ -282,7 +278,9 @@ impl WorkerPool {
                 syn: None,
                 syn_ack: None,
                 mtu: None,
+                #[cfg(feature = "uptime")]
                 client_uptime: None,
+                #[cfg(feature = "uptime")]
                 server_uptime: None,
             }),
         };

--- a/huginn-net-tcp/tests/pcap_golden.rs
+++ b/huginn-net-tcp/tests/pcap_golden.rs
@@ -107,7 +107,27 @@ fn has_meaningful_tcp_data(result: &TcpAnalysisResult) -> bool {
             false
         }
     };
-    result.syn.is_some() || result.syn_ack.is_some() || has_mtu || has_uptime
+    let has_syn = {
+        #[cfg(feature = "syn")]
+        {
+            result.syn.is_some()
+        }
+        #[cfg(not(feature = "syn"))]
+        {
+            false
+        }
+    };
+    let has_syn_ack = {
+        #[cfg(feature = "syn-ack")]
+        {
+            result.syn_ack.is_some()
+        }
+        #[cfg(not(feature = "syn-ack"))]
+        {
+            false
+        }
+    };
+    has_syn || has_syn_ack || has_mtu || has_uptime
 }
 
 fn assert_connection_matches_snapshot(
@@ -115,6 +135,7 @@ fn assert_connection_matches_snapshot(
     expected: &ConnectionSnapshot,
     connection_index: usize,
 ) {
+    #[cfg(feature = "syn")]
     if let (Some(actual_syn), Some(expected_syn)) = (&actual.syn, &expected.tcp_analysis.syn) {
         assert_eq!(
             actual_syn.source.ip.to_string(),
@@ -141,6 +162,7 @@ fn assert_connection_matches_snapshot(
         );
     }
 
+    #[cfg(feature = "syn-ack")]
     if let (Some(actual_syn_ack), Some(expected_syn_ack)) =
         (&actual.syn_ack, &expected.tcp_analysis.syn_ack)
     {

--- a/huginn-net-tcp/tests/pcap_golden.rs
+++ b/huginn-net-tcp/tests/pcap_golden.rs
@@ -87,11 +87,17 @@ fn analyze_pcap_file(pcap_path: &str) -> Result<Vec<TcpAnalysisResult>, HuginnNe
 
 /// Check if a TCP analysis result has meaningful data for golden tests.
 fn has_meaningful_tcp_data(result: &TcpAnalysisResult) -> bool {
-    result.syn.is_some()
-        || result.syn_ack.is_some()
-        || result.mtu.is_some()
-        || result.client_uptime.is_some()
-        || result.server_uptime.is_some()
+    let has_uptime = {
+        #[cfg(feature = "uptime")]
+        {
+            result.client_uptime.is_some() || result.server_uptime.is_some()
+        }
+        #[cfg(not(feature = "uptime"))]
+        {
+            false
+        }
+    };
+    result.syn.is_some() || result.syn_ack.is_some() || result.mtu.is_some() || has_uptime
 }
 
 fn assert_connection_matches_snapshot(
@@ -151,30 +157,33 @@ fn assert_connection_matches_snapshot(
         );
     }
 
-    if let (Some(actual_uptime), Some(expected_uptime)) =
-        (&actual.client_uptime, &expected.tcp_analysis.client_uptime)
+    #[cfg(feature = "uptime")]
     {
-        assert_eq!(
-            actual_uptime.freq, expected_uptime.raw_frequency,
-            "Connection {connection_index}: Client uptime raw frequency mismatch"
-        );
-        assert_eq!(
-            actual_uptime.days, expected_uptime.uptime_days,
-            "Connection {connection_index}: Client uptime days mismatch"
-        );
-    }
+        if let (Some(actual_uptime), Some(expected_uptime)) =
+            (&actual.client_uptime, &expected.tcp_analysis.client_uptime)
+        {
+            assert_eq!(
+                actual_uptime.freq, expected_uptime.raw_frequency,
+                "Connection {connection_index}: Client uptime raw frequency mismatch"
+            );
+            assert_eq!(
+                actual_uptime.days, expected_uptime.uptime_days,
+                "Connection {connection_index}: Client uptime days mismatch"
+            );
+        }
 
-    if let (Some(actual_uptime), Some(expected_uptime)) =
-        (&actual.server_uptime, &expected.tcp_analysis.server_uptime)
-    {
-        assert_eq!(
-            actual_uptime.freq, expected_uptime.raw_frequency,
-            "Connection {connection_index}: Server uptime raw frequency mismatch"
-        );
-        assert_eq!(
-            actual_uptime.days, expected_uptime.uptime_days,
-            "Connection {connection_index}: Server uptime days mismatch"
-        );
+        if let (Some(actual_uptime), Some(expected_uptime)) =
+            (&actual.server_uptime, &expected.tcp_analysis.server_uptime)
+        {
+            assert_eq!(
+                actual_uptime.freq, expected_uptime.raw_frequency,
+                "Connection {connection_index}: Server uptime raw frequency mismatch"
+            );
+            assert_eq!(
+                actual_uptime.days, expected_uptime.uptime_days,
+                "Connection {connection_index}: Server uptime days mismatch"
+            );
+        }
     }
 }
 

--- a/huginn-net-tcp/tests/pcap_golden.rs
+++ b/huginn-net-tcp/tests/pcap_golden.rs
@@ -97,7 +97,17 @@ fn has_meaningful_tcp_data(result: &TcpAnalysisResult) -> bool {
             false
         }
     };
-    result.syn.is_some() || result.syn_ack.is_some() || result.mtu.is_some() || has_uptime
+    let has_mtu = {
+        #[cfg(feature = "mtu")]
+        {
+            result.mtu.is_some()
+        }
+        #[cfg(not(feature = "mtu"))]
+        {
+            false
+        }
+    };
+    result.syn.is_some() || result.syn_ack.is_some() || has_mtu || has_uptime
 }
 
 fn assert_connection_matches_snapshot(
@@ -150,6 +160,7 @@ fn assert_connection_matches_snapshot(
         );
     }
 
+    #[cfg(feature = "mtu")]
     if let (Some(actual_mtu), Some(expected_mtu)) = (&actual.mtu, &expected.tcp_analysis.mtu) {
         assert_eq!(
             actual_mtu.mtu, expected_mtu.raw_mtu,

--- a/huginn-net-tcp/tests/uptime_backward_ts.rs
+++ b/huginn-net-tcp/tests/uptime_backward_ts.rs
@@ -1,5 +1,7 @@
 //! Tests for backward timestamp detection and handling
 
+#![cfg(feature = "uptime")]
+
 use huginn_net_tcp::uptime::{check_ts_tcp, Connection};
 use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;

--- a/huginn-net-tcp/tests/uptime_calculator.rs
+++ b/huginn-net-tcp/tests/uptime_calculator.rs
@@ -1,5 +1,7 @@
 //! Tests for uptime calculation validations
 
+#![cfg(feature = "uptime")]
+
 use huginn_net_tcp::uptime::{check_ts_tcp, Connection};
 use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;

--- a/huginn-net-tcp/tests/uptime_tracker_flow.rs
+++ b/huginn-net-tcp/tests/uptime_tracker_flow.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "uptime")]
+
 use huginn_net_tcp::{calculate_uptime_improved, FrequencyState, TcpTimestamp, UptimeTracker};
 
 #[test]

--- a/huginn-net-tls/src/lib.rs
+++ b/huginn-net-tls/src/lib.rs
@@ -1,3 +1,6 @@
+#![forbid(unsafe_code)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! TLS fingerprinting and JA4 analysis.
 //!
 //! ## Cargo Features
@@ -5,9 +8,6 @@
 //! | Feature | Default | Description |
 //! |---------|---------|-------------|
 //! | `stable-v1` | No | Adds [`Signature::generate_ja4_stable_v1`] / [`ObservableTlsClient::ja4_stable_v1`], ephemeral extensions excluded for stable fingerprints |
-
-#![forbid(unsafe_code)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod analyzer;
 pub mod error;

--- a/huginn-net/Cargo.toml
+++ b/huginn-net/Cargo.toml
@@ -19,14 +19,18 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["db"]
+default = ["db", "tcp-syn", "tcp-syn-ack", "tcp-mtu", "tcp-uptime"]
 db = ["dep:huginn-net-db", "huginn-net-db/tcp", "huginn-net-db/http"]
+tcp-mtu = ["huginn-net-tcp/mtu"]
+tcp-syn = ["huginn-net-tcp/syn"]
+tcp-syn-ack = ["huginn-net-tcp/syn-ack"]
+tcp-uptime = ["huginn-net-tcp/uptime"]
 tls-stable-v1 = ["huginn-net-tls/stable-v1"]
 
 [dependencies]
 huginn-net-db = { workspace = true, optional = true }
 huginn-net-http = { workspace = true }
-huginn-net-tcp = { workspace = true }
+huginn-net-tcp = { workspace = true, default-features = false }
 huginn-net-tls = { workspace = true }
 lazy_static = { workspace = true }
 pcap-file = { workspace = true }
@@ -44,4 +48,4 @@ tracing-subscriber = { workspace = true }
 [[example]]
 name = "capture"
 path = "../examples/capture.rs"
-required-features = ["db"]
+required-features = ["db", "tcp-syn", "tcp-syn-ack", "tcp-mtu", "tcp-uptime"]

--- a/huginn-net/README.md
+++ b/huginn-net/README.md
@@ -44,9 +44,18 @@ huginn-net-db = "1.7.5"
 | Feature | Default | Description |
 |---------|---------|-------------|
 | `db` | Yes | Pulls in `huginn-net-db` and enables p0f signature matching for TCP and HTTP. Disable for an observation-only build (raw signatures + JA4, no database). |
-| `tls-stable-v1` | No | Adds `JA4_s1` / `JA4_rs1` fingerprints — ephemeral extensions excluded for stable fingerprints |
+| `tcp-syn` | Yes | Pass-through for `huginn-net-tcp/syn`: TCP SYN fingerprinting (`FingerprintResult::tcp_syn`). |
+| `tcp-syn-ack` | Yes | Pass-through for `huginn-net-tcp/syn-ack`: TCP SYN+ACK fingerprinting (`FingerprintResult::tcp_syn_ack`). |
+| `tcp-mtu` | Yes | Pass-through for `huginn-net-tcp/mtu`: MTU detection (`FingerprintResult::tcp_mtu`). |
+| `tcp-uptime` | Yes | Pass-through for `huginn-net-tcp/uptime`: uptime estimation for both client and server (`FingerprintResult::tcp_client_uptime` / `tcp_server_uptime`). |
+| `tls-stable-v1` | No | Adds `JA4_s1` / `JA4_rs1` fingerprints — ephemeral extensions excluded for stable fingerprints. |
 
-Default build (with database matching):
+Each `tcp-*` feature gates the corresponding field on `FingerprintResult` at
+compile time. Disabling one shrinks the result struct and lets the parser
+skip its work (the TCP layer also early-exits when no enabled feature
+consumes a packet's side).
+
+Default build (everything except `tls-stable-v1`):
 
 ```toml
 [dependencies]
@@ -62,11 +71,21 @@ huginn-net = { version = "1.7.5", features = ["tls-stable-v1"] }
 huginn-net-db = "1.7.5"
 ```
 
+Opt out of TCP work that you don't need (example: SYN-only, no MTU / uptime / SYN+ACK):
+
+```toml
+[dependencies]
+huginn-net = { version = "1.7.5", default-features = false, features = ["db", "tcp-syn"] }
+huginn-net-db = "1.7.5"
+```
+
 Observation-only build (no database, no p0f matching — useful for TLS terminators, sidecars, or custom matchers):
 
 ```toml
 [dependencies]
-huginn-net = { version = "1.7.5", default-features = false }
+huginn-net = { version = "1.7.5", default-features = false, features = [
+    "tcp-syn", "tcp-syn-ack", "tcp-mtu", "tcp-uptime",
+] }
 ```
 
 With `db` disabled, use `HuginnNet::new_observable(max_connections, None)` instead of `HuginnNet::new(...)`.

--- a/huginn-net/src/analyzer/matchers.rs
+++ b/huginn-net/src/analyzer/matchers.rs
@@ -4,10 +4,14 @@ use huginn_net_http::observable::{ObservableHttpRequest, ObservableHttpResponse}
 use huginn_net_http::output::{
     BrowserQualityMatched, MatchQuality as HttpMatchQuality, WebServerQualityMatched,
 };
+#[cfg(any(feature = "tcp-syn", feature = "tcp-syn-ack"))]
 use huginn_net_tcp::observable::ObservableTcp;
-use huginn_net_tcp::output::{
-    MTUQualityMatched, MatchQuality as TcpMatchQuality, OSQualityMatched,
-};
+#[cfg(feature = "tcp-mtu")]
+use huginn_net_tcp::output::MTUQualityMatched;
+#[cfg(any(feature = "tcp-syn", feature = "tcp-syn-ack", feature = "tcp-mtu"))]
+use huginn_net_tcp::output::MatchQuality as TcpMatchQuality;
+#[cfg(any(feature = "tcp-syn", feature = "tcp-syn-ack"))]
+use huginn_net_tcp::output::OSQualityMatched;
 
 #[cfg(feature = "db")]
 use crate::quality_match;
@@ -15,7 +19,7 @@ use crate::quality_match;
 use crate::simple_quality_match;
 #[cfg(feature = "db")]
 use huginn_net_http::output::{Browser, WebServer};
-#[cfg(feature = "db")]
+#[cfg(all(feature = "db", any(feature = "tcp-syn", feature = "tcp-syn-ack")))]
 use huginn_net_tcp::output::OperativeSystem;
 
 use crate::AnalysisConfig;
@@ -45,6 +49,7 @@ pub(super) fn cache_sizes(config: &AnalysisConfig, max_connections: usize) -> (u
 }
 
 impl<'a> HuginnNet<'a> {
+    #[cfg(feature = "tcp-mtu")]
     pub(super) fn match_mtu(&self, mtu: &u16) -> MTUQualityMatched {
         #[cfg(feature = "db")]
         {
@@ -73,6 +78,7 @@ impl<'a> HuginnNet<'a> {
         }
     }
 
+    #[cfg(feature = "tcp-syn")]
     pub(super) fn match_tcp_request(&self, observable_tcp: &ObservableTcp) -> OSQualityMatched {
         #[cfg(feature = "db")]
         {
@@ -101,6 +107,7 @@ impl<'a> HuginnNet<'a> {
         }
     }
 
+    #[cfg(feature = "tcp-syn-ack")]
     pub(super) fn match_tcp_response(&self, observable_tcp: &ObservableTcp) -> OSQualityMatched {
         #[cfg(feature = "db")]
         {

--- a/huginn-net/src/analyzer/mod.rs
+++ b/huginn-net/src/analyzer/mod.rs
@@ -8,7 +8,7 @@ use huginn_net_http::http::HttpDiagnosis;
 use huginn_net_http::http_process::{FlowKey, HttpProcessors, TcpFlow};
 use huginn_net_http::output::{HttpRequestOutput, HttpResponseOutput};
 use huginn_net_tcp::output::{MTUOutput, SynAckTCPOutput, SynTCPOutput, UptimeOutput, UptimeRole};
-use huginn_net_tcp::uptime::{ConnectionKey, TcpTimestamp};
+use huginn_net_tcp::ConnectionTracker;
 use huginn_net_tls::output::TlsClientOutput;
 use pcap_file::pcap::PcapReader;
 use pnet::datalink::{self, Channel, Config};
@@ -97,7 +97,7 @@ pub struct HuginnNet<'a> {
     pub tcp_matcher: Option<huginn_net_db::TcpSignatureMatcher<'a>>,
     #[cfg(feature = "db")]
     pub http_matcher: Option<huginn_net_db::HttpSignatureMatcher<'a>>,
-    connection_tracker: TtlCache<ConnectionKey, TcpTimestamp>,
+    connection_tracker: ConnectionTracker,
     http_flows: TtlCache<FlowKey, TcpFlow>,
     http_processors: HttpProcessors,
     pub(crate) config: AnalysisConfig,
@@ -160,7 +160,7 @@ impl<'a> HuginnNet<'a> {
         Ok(Self {
             tcp_matcher,
             http_matcher,
-            connection_tracker: TtlCache::new(connection_tracker_size),
+            connection_tracker: ConnectionTracker::new(connection_tracker_size),
             http_flows: TtlCache::new(http_flows_size),
             http_processors: HttpProcessors::new(),
             config,
@@ -188,7 +188,7 @@ impl<'a> HuginnNet<'a> {
         let (connection_tracker_size, http_flows_size) = cache_sizes(&config, max_connections);
 
         Ok(Self {
-            connection_tracker: TtlCache::new(connection_tracker_size),
+            connection_tracker: ConnectionTracker::new(connection_tracker_size),
             http_flows: TtlCache::new(http_flows_size),
             http_processors: HttpProcessors::new(),
             config,

--- a/huginn-net/src/analyzer/mod.rs
+++ b/huginn-net/src/analyzer/mod.rs
@@ -7,7 +7,14 @@ use crate::process::ObservablePackage;
 use huginn_net_http::http::HttpDiagnosis;
 use huginn_net_http::http_process::{FlowKey, HttpProcessors, TcpFlow};
 use huginn_net_http::output::{HttpRequestOutput, HttpResponseOutput};
-use huginn_net_tcp::output::{MTUOutput, SynAckTCPOutput, SynTCPOutput, UptimeOutput, UptimeRole};
+#[cfg(feature = "tcp-mtu")]
+use huginn_net_tcp::output::MTUOutput;
+#[cfg(feature = "tcp-syn-ack")]
+use huginn_net_tcp::output::SynAckTCPOutput;
+#[cfg(feature = "tcp-syn")]
+use huginn_net_tcp::output::SynTCPOutput;
+#[cfg(feature = "tcp-uptime")]
+use huginn_net_tcp::output::{UptimeOutput, UptimeRole};
 use huginn_net_tcp::ConnectionTracker;
 use huginn_net_tls::output::TlsClientOutput;
 use pcap_file::pcap::PcapReader;
@@ -358,20 +365,30 @@ impl<'a> HuginnNet<'a> {
             &self.config,
         ) {
             Ok(observable_package) => {
-                let (
-                    syn,
-                    syn_ack,
-                    mtu,
-                    client_uptime,
-                    server_uptime,
-                    http_request,
-                    http_response,
-                    tls_client,
-                ) = {
-                    let mtu: Option<MTUOutput> = observable_package.mtu.map(|observable_mtu| {
-                        let link_quality = self.match_mtu(&observable_mtu.value);
+                #[cfg(feature = "tcp-mtu")]
+                let mtu: Option<MTUOutput> = observable_package.mtu.map(|observable_mtu| {
+                    let link_quality = self.match_mtu(&observable_mtu.value);
 
-                        MTUOutput {
+                    MTUOutput {
+                        source: huginn_net_tcp::output::IpPort::new(
+                            observable_package.source.ip,
+                            observable_package.source.port,
+                        ),
+                        destination: huginn_net_tcp::output::IpPort::new(
+                            observable_package.destination.ip,
+                            observable_package.destination.port,
+                        ),
+                        link: link_quality,
+                        mtu: observable_mtu.value,
+                    }
+                });
+
+                #[cfg(feature = "tcp-syn")]
+                let syn: Option<SynTCPOutput> =
+                    observable_package.tcp_request.map(|observable_tcp| {
+                        let os_quality = self.match_tcp_request(&observable_tcp);
+
+                        SynTCPOutput {
                             source: huginn_net_tcp::output::IpPort::new(
                                 observable_package.source.ip,
                                 observable_package.source.port,
@@ -380,49 +397,17 @@ impl<'a> HuginnNet<'a> {
                                 observable_package.destination.ip,
                                 observable_package.destination.port,
                             ),
-                            link: link_quality,
-                            mtu: observable_mtu.value,
+                            os_matched: os_quality,
+                            sig: observable_tcp,
                         }
                     });
 
-                    let syn: Option<SynTCPOutput> =
-                        observable_package.tcp_request.map(|observable_tcp| {
-                            let os_quality = self.match_tcp_request(&observable_tcp);
+                #[cfg(feature = "tcp-syn-ack")]
+                let syn_ack: Option<SynAckTCPOutput> =
+                    observable_package.tcp_response.map(|observable_tcp| {
+                        let os_quality = self.match_tcp_response(&observable_tcp);
 
-                            SynTCPOutput {
-                                source: huginn_net_tcp::output::IpPort::new(
-                                    observable_package.source.ip,
-                                    observable_package.source.port,
-                                ),
-                                destination: huginn_net_tcp::output::IpPort::new(
-                                    observable_package.destination.ip,
-                                    observable_package.destination.port,
-                                ),
-                                os_matched: os_quality,
-                                sig: observable_tcp,
-                            }
-                        });
-
-                    let syn_ack: Option<SynAckTCPOutput> =
-                        observable_package.tcp_response.map(|observable_tcp| {
-                            let os_quality = self.match_tcp_response(&observable_tcp);
-
-                            SynAckTCPOutput {
-                                source: huginn_net_tcp::output::IpPort::new(
-                                    observable_package.source.ip,
-                                    observable_package.source.port,
-                                ),
-                                destination: huginn_net_tcp::output::IpPort::new(
-                                    observable_package.destination.ip,
-                                    observable_package.destination.port,
-                                ),
-                                os_matched: os_quality,
-                                sig: observable_tcp,
-                            }
-                        });
-
-                    let client_uptime: Option<UptimeOutput> =
-                        observable_package.client_uptime.map(|update| UptimeOutput {
+                        SynAckTCPOutput {
                             source: huginn_net_tcp::output::IpPort::new(
                                 observable_package.source.ip,
                                 observable_package.source.port,
@@ -431,33 +416,51 @@ impl<'a> HuginnNet<'a> {
                                 observable_package.destination.ip,
                                 observable_package.destination.port,
                             ),
-                            role: UptimeRole::Client,
-                            days: update.days,
-                            hours: update.hours,
-                            min: update.min,
-                            up_mod_days: update.up_mod_days,
-                            freq: update.freq,
-                        });
+                            os_matched: os_quality,
+                            sig: observable_tcp,
+                        }
+                    });
 
-                    let server_uptime: Option<UptimeOutput> =
-                        observable_package.server_uptime.map(|update| UptimeOutput {
-                            source: huginn_net_tcp::output::IpPort::new(
-                                observable_package.source.ip,
-                                observable_package.source.port,
-                            ),
-                            destination: huginn_net_tcp::output::IpPort::new(
-                                observable_package.destination.ip,
-                                observable_package.destination.port,
-                            ),
-                            role: UptimeRole::Server,
-                            days: update.days,
-                            hours: update.hours,
-                            min: update.min,
-                            up_mod_days: update.up_mod_days,
-                            freq: update.freq,
-                        });
+                #[cfg(feature = "tcp-uptime")]
+                let client_uptime: Option<UptimeOutput> =
+                    observable_package.client_uptime.map(|update| UptimeOutput {
+                        source: huginn_net_tcp::output::IpPort::new(
+                            observable_package.source.ip,
+                            observable_package.source.port,
+                        ),
+                        destination: huginn_net_tcp::output::IpPort::new(
+                            observable_package.destination.ip,
+                            observable_package.destination.port,
+                        ),
+                        role: UptimeRole::Client,
+                        days: update.days,
+                        hours: update.hours,
+                        min: update.min,
+                        up_mod_days: update.up_mod_days,
+                        freq: update.freq,
+                    });
 
-                    let http_request: Option<HttpRequestOutput> = observable_package
+                #[cfg(feature = "tcp-uptime")]
+                let server_uptime: Option<UptimeOutput> =
+                    observable_package.server_uptime.map(|update| UptimeOutput {
+                        source: huginn_net_tcp::output::IpPort::new(
+                            observable_package.source.ip,
+                            observable_package.source.port,
+                        ),
+                        destination: huginn_net_tcp::output::IpPort::new(
+                            observable_package.destination.ip,
+                            observable_package.destination.port,
+                        ),
+                        role: UptimeRole::Server,
+                        days: update.days,
+                        hours: update.hours,
+                        min: update.min,
+                        up_mod_days: update.up_mod_days,
+                        freq: update.freq,
+                    });
+
+                let http_request: Option<HttpRequestOutput> =
+                    observable_package
                         .http_request
                         .map(|observable_http_request| {
                             let HttpRequestMatchResult { browser_quality, http_diagnosis } =
@@ -479,59 +482,52 @@ impl<'a> HuginnNet<'a> {
                             }
                         });
 
-                    let http_response: Option<HttpResponseOutput> = observable_package
-                        .http_response
-                        .map(|observable_http_response| {
-                            let web_server_quality =
-                                self.match_http_response(&observable_http_response);
+                let http_response: Option<HttpResponseOutput> = observable_package
+                    .http_response
+                    .map(|observable_http_response| {
+                        let web_server_quality =
+                            self.match_http_response(&observable_http_response);
 
-                            HttpResponseOutput {
-                                source: huginn_net_http::output::IpPort::new(
-                                    observable_package.source.ip,
-                                    observable_package.source.port,
-                                ),
-                                destination: huginn_net_http::output::IpPort::new(
-                                    observable_package.destination.ip,
-                                    observable_package.destination.port,
-                                ),
-                                web_server_matched: web_server_quality,
-                                diagnosis: HttpDiagnosis::None,
-                                sig: observable_http_response,
-                            }
+                        HttpResponseOutput {
+                            source: huginn_net_http::output::IpPort::new(
+                                observable_package.source.ip,
+                                observable_package.source.port,
+                            ),
+                            destination: huginn_net_http::output::IpPort::new(
+                                observable_package.destination.ip,
+                                observable_package.destination.port,
+                            ),
+                            web_server_matched: web_server_quality,
+                            diagnosis: HttpDiagnosis::None,
+                            sig: observable_http_response,
+                        }
+                    });
+
+                let tls_client: Option<TlsClientOutput> =
+                    observable_package
+                        .tls_client
+                        .map(|observable_tls| TlsClientOutput {
+                            source: huginn_net_tls::output::IpPort::new(
+                                observable_package.source.ip,
+                                observable_package.source.port,
+                            ),
+                            destination: huginn_net_tls::output::IpPort::new(
+                                observable_package.destination.ip,
+                                observable_package.destination.port,
+                            ),
+                            sig: observable_tls,
                         });
 
-                    let tls_client: Option<TlsClientOutput> =
-                        observable_package
-                            .tls_client
-                            .map(|observable_tls| TlsClientOutput {
-                                source: huginn_net_tls::output::IpPort::new(
-                                    observable_package.source.ip,
-                                    observable_package.source.port,
-                                ),
-                                destination: huginn_net_tls::output::IpPort::new(
-                                    observable_package.destination.ip,
-                                    observable_package.destination.port,
-                                ),
-                                sig: observable_tls,
-                            });
-
-                    (
-                        syn,
-                        syn_ack,
-                        mtu,
-                        client_uptime,
-                        server_uptime,
-                        http_request,
-                        http_response,
-                        tls_client,
-                    )
-                };
-
                 FingerprintResult {
+                    #[cfg(feature = "tcp-syn")]
                     tcp_syn: syn,
+                    #[cfg(feature = "tcp-syn-ack")]
                     tcp_syn_ack: syn_ack,
+                    #[cfg(feature = "tcp-mtu")]
                     tcp_mtu: mtu,
+                    #[cfg(feature = "tcp-uptime")]
                     tcp_client_uptime: client_uptime,
+                    #[cfg(feature = "tcp-uptime")]
                     tcp_server_uptime: server_uptime,
                     http_request,
                     http_response,
@@ -541,10 +537,15 @@ impl<'a> HuginnNet<'a> {
             Err(error) => {
                 debug!("Fail to process signature: {}", error);
                 FingerprintResult {
+                    #[cfg(feature = "tcp-syn")]
                     tcp_syn: None,
+                    #[cfg(feature = "tcp-syn-ack")]
                     tcp_syn_ack: None,
+                    #[cfg(feature = "tcp-mtu")]
                     tcp_mtu: None,
+                    #[cfg(feature = "tcp-uptime")]
                     tcp_client_uptime: None,
+                    #[cfg(feature = "tcp-uptime")]
                     tcp_server_uptime: None,
                     http_request: None,
                     http_response: None,

--- a/huginn-net/src/lib.rs
+++ b/huginn-net/src/lib.rs
@@ -1,3 +1,6 @@
+#![forbid(unsafe_code)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! Multi-protocol passive fingerprinting library: TCP/HTTP (p0f-style) + TLS (JA4) analysis.
 //!
 //! ## Cargo Features
@@ -6,9 +9,6 @@
 //! |---------|---------|-------------|
 //! | `db` | Yes | Pulls in [`huginn_net_db`] and enables p0f signature matching for TCP and HTTP. Disable for an observation-only build (e.g. JA4-only or downstream consumers that bring their own matcher implementation). |
 //! | `tls-stable-v1` | No | Adds `JA4_s1` / `JA4_rs1` fingerprints via [`huginn_net_tls`], ephemeral extensions excluded for stable fingerprints |
-
-#![forbid(unsafe_code)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 
 // ---------------------------------------------------------------------------
 // Domain modules (canonical locations)

--- a/huginn-net/src/lib.rs
+++ b/huginn-net/src/lib.rs
@@ -8,7 +8,18 @@
 //! | Feature | Default | Description |
 //! |---------|---------|-------------|
 //! | `db` | Yes | Pulls in [`huginn_net_db`] and enables p0f signature matching for TCP and HTTP. Disable for an observation-only build (e.g. JA4-only or downstream consumers that bring their own matcher implementation). |
-//! | `tls-stable-v1` | No | Adds `JA4_s1` / `JA4_rs1` fingerprints via [`huginn_net_tls`], ephemeral extensions excluded for stable fingerprints |
+//! | `tcp-syn` | Yes | Pass-through for `huginn-net-tcp/syn`: TCP SYN fingerprinting (`FingerprintResult::tcp_syn`). |
+//! | `tcp-syn-ack` | Yes | Pass-through for `huginn-net-tcp/syn-ack`: TCP SYN+ACK fingerprinting (`FingerprintResult::tcp_syn_ack`). |
+//! | `tcp-mtu` | Yes | Pass-through for `huginn-net-tcp/mtu`: MTU detection (`FingerprintResult::tcp_mtu`). |
+//! | `tcp-uptime` | Yes | Pass-through for `huginn-net-tcp/uptime`: uptime estimation for both client and server (`FingerprintResult::tcp_client_uptime` / `tcp_server_uptime`). |
+//! | `tls-stable-v1` | No | Adds `JA4_s1` / `JA4_rs1` fingerprints via [`huginn_net_tls`], ephemeral extensions excluded for stable fingerprints. |
+//!
+//! Each `tcp-*` feature gates the corresponding field on [`FingerprintResult`]
+//! and the matching re-exports. Disabling a feature removes its field at
+//! compile time and shrinks the result struct. The underlying parser also
+//! early-exits when none of the consumers for a packet's side are enabled,
+//! so disabling features is a zero-cost optimization, not just a build
+//! configuration.
 
 // ---------------------------------------------------------------------------
 // Domain modules (canonical locations)
@@ -30,10 +41,19 @@ pub use output::FingerprintResult;
 #[cfg(feature = "db")]
 pub use huginn_net_db::{db_matching_trait, Database, Label};
 
+#[cfg(any(feature = "tcp-syn", feature = "tcp-syn-ack"))]
+pub use huginn_net_tcp::output::OSQualityMatched;
+#[cfg(feature = "tcp-syn-ack")]
+pub use huginn_net_tcp::output::SynAckTCPOutput;
+#[cfg(feature = "tcp-syn")]
+pub use huginn_net_tcp::output::SynTCPOutput;
+#[cfg(feature = "tcp-mtu")]
+pub use huginn_net_tcp::output::{MTUOutput, MTUQualityMatched};
 pub use huginn_net_tcp::output::{
-    MTUOutput, MTUQualityMatched, MatchQuality as TcpMatchQuality, OSQualityMatched,
-    OperativeSystem, OsKind as TcpOsKind, SynAckTCPOutput, SynTCPOutput, UptimeOutput, UptimeRole,
+    MatchQuality as TcpMatchQuality, OperativeSystem, OsKind as TcpOsKind,
 };
+#[cfg(feature = "tcp-uptime")]
+pub use huginn_net_tcp::output::{UptimeOutput, UptimeRole};
 pub use huginn_net_tcp::tcp;
 pub use huginn_net_tcp::tcp::Ttl;
 
@@ -47,6 +67,7 @@ pub use huginn_net_http::output::{
 pub use huginn_net_tls::output::TlsClientOutput;
 pub use huginn_net_tls::ObservableTlsClient;
 
+#[cfg(any(feature = "tcp-syn", feature = "tcp-syn-ack"))]
 pub use huginn_net_tcp::observable::ObservableTcp;
 
 pub use huginn_net_tcp;

--- a/huginn-net/src/output.rs
+++ b/huginn-net/src/output.rs
@@ -1,5 +1,12 @@
 use huginn_net_http::output::{HttpRequestOutput, HttpResponseOutput};
-use huginn_net_tcp::output::{MTUOutput, SynAckTCPOutput, SynTCPOutput, UptimeOutput};
+#[cfg(feature = "tcp-mtu")]
+use huginn_net_tcp::output::MTUOutput;
+#[cfg(feature = "tcp-syn-ack")]
+use huginn_net_tcp::output::SynAckTCPOutput;
+#[cfg(feature = "tcp-syn")]
+use huginn_net_tcp::output::SynTCPOutput;
+#[cfg(feature = "tcp-uptime")]
+use huginn_net_tcp::output::UptimeOutput;
 use huginn_net_tls::output::TlsClientOutput;
 
 /// Represents the output from the Huginn Net analyzer.
@@ -8,18 +15,33 @@ use huginn_net_tls::output::TlsClientOutput;
 /// from analyzing TCP, HTTP, and TLS packets.
 pub struct FingerprintResult {
     /// Information derived from TCP SYN packets.
+    ///
+    /// Present only when the `tcp-syn` feature is enabled.
+    #[cfg(feature = "tcp-syn")]
     pub tcp_syn: Option<SynTCPOutput>,
 
     /// Information derived from TCP SYN-ACK packets.
+    ///
+    /// Present only when the `tcp-syn-ack` feature is enabled.
+    #[cfg(feature = "tcp-syn-ack")]
     pub tcp_syn_ack: Option<SynAckTCPOutput>,
 
     /// Information about the TCP Maximum Transmission Unit (MTU).
+    ///
+    /// Present only when the `tcp-mtu` feature is enabled.
+    #[cfg(feature = "tcp-mtu")]
     pub tcp_mtu: Option<MTUOutput>,
 
     /// Information about the TCP client system uptime.
+    ///
+    /// Present only when the `tcp-uptime` feature is enabled.
+    #[cfg(feature = "tcp-uptime")]
     pub tcp_client_uptime: Option<UptimeOutput>,
 
     /// Information about the TCP server system uptime.
+    ///
+    /// Present only when the `tcp-uptime` feature is enabled.
+    #[cfg(feature = "tcp-uptime")]
     pub tcp_server_uptime: Option<UptimeOutput>,
 
     /// Information derived from HTTP request headers.

--- a/huginn-net/src/process/mod.rs
+++ b/huginn-net/src/process/mod.rs
@@ -5,7 +5,12 @@ use huginn_net_http::error::HuginnNetHttpError;
 use huginn_net_http::http_process::{FlowKey, HttpProcessors, ObservableHttpPackage, TcpFlow};
 use huginn_net_http::observable::{ObservableHttpRequest, ObservableHttpResponse};
 use huginn_net_tcp::error::HuginnNetTcpError;
-use huginn_net_tcp::observable::{ObservableMtu, ObservableTcp, ObservableUptime};
+#[cfg(feature = "tcp-mtu")]
+use huginn_net_tcp::observable::ObservableMtu;
+#[cfg(any(feature = "tcp-syn", feature = "tcp-syn-ack"))]
+use huginn_net_tcp::observable::ObservableTcp;
+#[cfg(feature = "tcp-uptime")]
+use huginn_net_tcp::observable::ObservableUptime;
 use huginn_net_tcp::tcp_process::ObservableTCPPackage;
 use huginn_net_tcp::ConnectionTracker;
 use huginn_net_tls::error::HuginnNetTlsError;
@@ -24,10 +29,15 @@ pub struct IpPort {
 pub struct ObservablePackage {
     pub source: IpPort,
     pub destination: IpPort,
+    #[cfg(feature = "tcp-syn")]
     pub tcp_request: Option<ObservableTcp>,
+    #[cfg(feature = "tcp-syn-ack")]
     pub tcp_response: Option<ObservableTcp>,
+    #[cfg(feature = "tcp-mtu")]
     pub mtu: Option<ObservableMtu>,
+    #[cfg(feature = "tcp-uptime")]
     pub client_uptime: Option<ObservableUptime>,
+    #[cfg(feature = "tcp-uptime")]
     pub server_uptime: Option<ObservableUptime>,
     pub http_request: Option<ObservableHttpRequest>,
     pub http_response: Option<ObservableHttpResponse>,
@@ -267,13 +277,7 @@ fn execute_analysis<P: IpPacketProcessor>(
     let tcp_response: ObservableTCPPackage = if config.tcp_enabled {
         P::process_tcp_with_data(packet_data, connection_tracker)?
     } else {
-        ObservableTCPPackage {
-            tcp_request: None,
-            tcp_response: None,
-            mtu: None,
-            client_uptime: None,
-            server_uptime: None,
-        }
+        ObservableTCPPackage::empty()
     };
 
     let tls_response = if config.tls_enabled {
@@ -344,13 +348,27 @@ fn handle_http_tcp_tlc(
     destination: IpPort,
 ) -> Result<ObservablePackage, HuginnNetError> {
     match (http_response, tcp_response, tls_response) {
+        #[cfg_attr(
+            not(any(
+                feature = "tcp-syn",
+                feature = "tcp-syn-ack",
+                feature = "tcp-mtu",
+                feature = "tcp-uptime"
+            )),
+            allow(unused_variables)
+        )]
         (Ok(http_package), Ok(tcp_package), Ok(tls_package)) => Ok(ObservablePackage {
             source,
             destination,
+            #[cfg(feature = "tcp-syn")]
             tcp_request: tcp_package.tcp_request,
+            #[cfg(feature = "tcp-syn-ack")]
             tcp_response: tcp_package.tcp_response,
+            #[cfg(feature = "tcp-mtu")]
             mtu: tcp_package.mtu,
+            #[cfg(feature = "tcp-uptime")]
             client_uptime: tcp_package.client_uptime,
+            #[cfg(feature = "tcp-uptime")]
             server_uptime: tcp_package.server_uptime,
             http_request: http_package.http_request,
             http_response: http_package.http_response,

--- a/huginn-net/src/process/mod.rs
+++ b/huginn-net/src/process/mod.rs
@@ -7,7 +7,7 @@ use huginn_net_http::observable::{ObservableHttpRequest, ObservableHttpResponse}
 use huginn_net_tcp::error::HuginnNetTcpError;
 use huginn_net_tcp::observable::{ObservableMtu, ObservableTcp, ObservableUptime};
 use huginn_net_tcp::tcp_process::ObservableTCPPackage;
-use huginn_net_tcp::uptime::{ConnectionKey, TcpTimestamp};
+use huginn_net_tcp::ConnectionTracker;
 use huginn_net_tls::error::HuginnNetTlsError;
 use huginn_net_tls::{ObservableTlsClient, ObservableTlsPackage};
 use pnet::packet::ip::IpNextHeaderProtocols;
@@ -37,7 +37,7 @@ pub struct ObservablePackage {
 impl ObservablePackage {
     pub fn extract(
         packet: &[u8],
-        connection_tracker: &mut TtlCache<ConnectionKey, TcpTimestamp>,
+        connection_tracker: &mut ConnectionTracker,
         http_flows: &mut TtlCache<FlowKey, TcpFlow>,
         http_processors: &HttpProcessors,
         config: &AnalysisConfig,
@@ -75,7 +75,7 @@ trait IpPacketProcessor: Packet {
     ) -> Result<ObservableHttpPackage, HuginnNetError>;
     fn process_tcp_with_data(
         data: &[u8],
-        connection_tracker: &mut TtlCache<ConnectionKey, TcpTimestamp>,
+        connection_tracker: &mut ConnectionTracker,
     ) -> Result<ObservableTCPPackage, HuginnNetError>;
     fn process_tls_with_data(data: &[u8]) -> Result<ObservableTlsPackage, HuginnNetError>;
 }
@@ -121,7 +121,7 @@ impl IpPacketProcessor for Ipv4Packet<'_> {
 
     fn process_tcp_with_data(
         data: &[u8],
-        connection_tracker: &mut TtlCache<ConnectionKey, TcpTimestamp>,
+        connection_tracker: &mut ConnectionTracker,
     ) -> Result<ObservableTCPPackage, HuginnNetError> {
         if let Some(packet) = Ipv4Packet::new(data) {
             huginn_net_tcp::tcp_process::process_tcp_ipv4(&packet, connection_tracker).map_err(
@@ -203,7 +203,7 @@ impl IpPacketProcessor for Ipv6Packet<'_> {
 
     fn process_tcp_with_data(
         data: &[u8],
-        connection_tracker: &mut TtlCache<ConnectionKey, TcpTimestamp>,
+        connection_tracker: &mut ConnectionTracker,
     ) -> Result<ObservableTCPPackage, HuginnNetError> {
         if let Some(packet) = Ipv6Packet::new(data) {
             huginn_net_tcp::tcp_process::process_tcp_ipv6(&packet, connection_tracker).map_err(
@@ -251,7 +251,7 @@ impl IpPacketProcessor for Ipv6Packet<'_> {
 
 fn execute_analysis<P: IpPacketProcessor>(
     packet_data: &[u8],
-    connection_tracker: &mut TtlCache<ConnectionKey, TcpTimestamp>,
+    connection_tracker: &mut ConnectionTracker,
     http_flows: &mut TtlCache<FlowKey, TcpFlow>,
     http_processors: &HttpProcessors,
     config: &AnalysisConfig,
@@ -286,7 +286,7 @@ fn execute_analysis<P: IpPacketProcessor>(
 }
 
 fn process_ip<P: IpPacketProcessor>(
-    connection_tracker: &mut TtlCache<ConnectionKey, TcpTimestamp>,
+    connection_tracker: &mut ConnectionTracker,
     http_flows: &mut TtlCache<FlowKey, TcpFlow>,
     http_processors: &HttpProcessors,
     packet: P,
@@ -317,7 +317,7 @@ fn process_ip<P: IpPacketProcessor>(
 }
 
 pub fn process_ipv4(
-    connection_tracker: &mut TtlCache<ConnectionKey, TcpTimestamp>,
+    connection_tracker: &mut ConnectionTracker,
     http_flows: &mut TtlCache<FlowKey, TcpFlow>,
     http_processors: &HttpProcessors,
     packet: Ipv4Packet,
@@ -327,7 +327,7 @@ pub fn process_ipv4(
 }
 
 pub fn process_ipv6(
-    connection_tracker: &mut TtlCache<ConnectionKey, TcpTimestamp>,
+    connection_tracker: &mut ConnectionTracker,
     http_flows: &mut TtlCache<FlowKey, TcpFlow>,
     http_processors: &HttpProcessors,
     packet: Ipv6Packet,

--- a/huginn-net/tests/smoke.rs
+++ b/huginn-net/tests/smoke.rs
@@ -6,7 +6,7 @@
 //! that the umbrella crate correctly wires and combines both protocols in a
 //! single `FingerprintResult`.
 
-#![cfg(feature = "db")]
+#![cfg(all(feature = "db", feature = "tcp-syn", feature = "tcp-mtu"))]
 
 use huginn_net::{Database, HuginnNet, TcpMatchQuality};
 use huginn_net_http::output::MatchQuality as HttpMatchQuality;


### PR DESCRIPTION
Add Rust `[features]` to `huginn-net-tcp` so consumers can enable/disable:

- **`syn`**: TCP SYN OS fingerprinting (default: enabled)
- **`syn+ack`**: TCP SYN+ACK OS fingerprinting (default: enabled)
- **`mtu`**:  MTU extraction from MSS option (default: enabled)
- **`uptime`**: uptime estimation from TCP timestamps; gates `ttl_cache` dependency (default: enabled)

The uptime signal is fast becoming obsolete. Furthermore, most integrations merely seek to collect MTU or TCP SYN packets, disregarding the remaining signals. With this proposal, we will introduce a significant improvement in analysis and processing performance by focusing on what truly matters.