### PR TITLE
Align TCP field matching with p0f (gates, quirks, TTL)

### DIFF
--- a/huginn-net-db/src/tcp/distances.rs
+++ b/huginn-net-db/src/tcp/distances.rs
@@ -16,69 +16,62 @@ pub fn distance_ip_version(observed: &IpVersion, signature: &IpVersion) -> Optio
     }
 }
 
+/// Largest hop count still considered plausible between the fingerprinted
+/// host and the sensor. Beyond it the observed TTL no longer supports the
+/// signature's initial TTL, and the match degrades to fuzzy. Mirrors
+/// `MAX_DIST` in `data/p0f/config.h`.
+pub const MAX_TTL_DISTANCE: u8 = 40;
+
+/// TTL as seen on the wire, whichever form the observation was classified
+/// into by `huginn_net_tcp::tcp::calculate_ttl`.
+fn observed_ttl(observed: &Ttl) -> u8 {
+    match observed {
+        Ttl::Value(ttl) | Ttl::Distance(ttl, _) | Ttl::Guess(ttl) | Ttl::Bad(ttl) => *ttl,
+    }
+}
+
+/// Initial TTL a database signature claims for the OS. Matches p0f's
+/// `.fp` parsing: `nnn+d` sums both
+/// halves, while `nnn` and `nnn-` are used verbatim.
+fn signature_initial_ttl(signature: &Ttl) -> u8 {
+    match signature {
+        Ttl::Value(ttl) | Ttl::Guess(ttl) | Ttl::Bad(ttl) => *ttl,
+        Ttl::Distance(ttl, distance) => ttl.saturating_add(*distance),
+    }
+}
+
 /// Distance score between an observed `Ttl` and a database `Ttl`.
 ///
-/// Returns `None` when the two TTL kinds are incompatible (e.g. observed
-/// `Bad` vs database `Value`).
+/// TTL is not compared for equality: routers decrement it, so the observed
+/// value is expected to sit *below* the signature's initial TTL, by at most
+/// [`MAX_TTL_DISTANCE`] hops. Within that window the field matches exactly;
+/// outside it the signature still matches, but only as fuzzy — p0f never
+/// rejects on TTL alone (`data/p0f/fp_tcp.c::tcp_find_match`).
+///
+/// The one exception is a signature with a randomised TTL (`nnn-`, parsed as
+/// [`Ttl::Bad`]): the value carries no hop information, so only the upper
+/// bound is enforced, and exceeding it is a hard reject.
+///
+/// The fuzzy case is currently reported as the worst non-rejecting score;
+/// once the match tiers land it becomes `Fuzzy(TtlOutOfRange)` carrying the
+/// hop distance, which also breaks ties between equally exact candidates.
 pub fn distance_ttl(observed: &Ttl, signature: &Ttl) -> Option<u32> {
-    match (observed, signature) {
-        (Ttl::Value(a), Ttl::Value(b)) => {
-            if a == b {
-                Some(TcpMatchQuality::High.as_score())
-            } else {
-                Some(TcpMatchQuality::Low.as_score())
-            }
-        }
-        (Ttl::Distance(a1, a2), Ttl::Distance(b1, b2)) => {
-            if a1 == b1 && a2 == b2 {
-                Some(TcpMatchQuality::High.as_score())
-            } else {
-                Some(TcpMatchQuality::Low.as_score())
-            }
-        }
-        (Ttl::Distance(a1, a2), Ttl::Value(b1)) => {
-            if a1.saturating_add(*a2) == *b1 {
-                Some(TcpMatchQuality::High.as_score())
-            } else {
-                Some(TcpMatchQuality::Low.as_score())
-            }
-        }
-        (Ttl::Guess(a), Ttl::Guess(b)) => {
-            if a == b {
-                Some(TcpMatchQuality::High.as_score())
-            } else {
-                Some(TcpMatchQuality::Low.as_score())
-            }
-        }
-        (Ttl::Bad(a), Ttl::Bad(b)) => {
-            if a == b {
-                Some(TcpMatchQuality::High.as_score())
-            } else {
-                Some(TcpMatchQuality::Low.as_score())
-            }
-        }
-        (Ttl::Guess(a), Ttl::Value(b)) => {
-            if a == b {
-                Some(TcpMatchQuality::High.as_score())
-            } else {
-                Some(TcpMatchQuality::Low.as_score())
-            }
-        }
-        (Ttl::Value(a), Ttl::Distance(b1, b2)) => {
-            if *a == b1.saturating_add(*b2) {
-                Some(TcpMatchQuality::High.as_score())
-            } else {
-                Some(TcpMatchQuality::Low.as_score())
-            }
-        }
-        (Ttl::Value(a), Ttl::Guess(b)) => {
-            if a == b {
-                Some(TcpMatchQuality::High.as_score())
-            } else {
-                Some(TcpMatchQuality::Low.as_score())
-            }
-        }
-        _ => None,
+    let observed = observed_ttl(observed);
+    let initial = signature_initial_ttl(signature);
+
+    if matches!(signature, Ttl::Bad(_)) {
+        return if observed > initial {
+            None
+        } else {
+            Some(TcpMatchQuality::High.as_score())
+        };
+    }
+
+    if observed > initial || initial.saturating_sub(observed) > MAX_TTL_DISTANCE {
+        debug!("ttl out of range: observed {observed}, signature initial {initial}");
+        Some(TcpMatchQuality::Low.as_score())
+    } else {
+        Some(TcpMatchQuality::High.as_score())
     }
 }
 
@@ -86,6 +79,10 @@ pub fn distance_ttl(observed: &Ttl, signature: &Ttl) -> Option<u32> {
 ///
 /// Takes the observed MSS as context to resolve `WindowSize::Mss(_)` patterns
 /// against a raw window value. Returns `None` for incompatible pairings.
+///
+/// A mismatch is always a hard reject (`None`), never a soft penalty: p0f's
+/// window-size check never tolerates a mismatch here, regardless of type. Only
+/// `WindowSize::Any` in the signature is a true wildcard.
 pub fn distance_window_size(
     observed: &WindowSize,
     signature: &WindowSize,
@@ -96,14 +93,14 @@ pub fn distance_window_size(
             if a == b {
                 Some(TcpMatchQuality::High.as_score())
             } else {
-                Some(TcpMatchQuality::Low.as_score())
+                None
             }
         }
         (WindowSize::Mtu(a), WindowSize::Mtu(b)) => {
             if a == b {
                 Some(TcpMatchQuality::High.as_score())
             } else {
-                Some(TcpMatchQuality::Low.as_score())
+                None
             }
         }
         (WindowSize::Value(a), WindowSize::Mss(b)) => {
@@ -116,27 +113,27 @@ pub fn distance_window_size(
                         );
                         Some(TcpMatchQuality::High.as_score())
                     } else {
-                        Some(TcpMatchQuality::Low.as_score())
+                        None
                     }
                 } else {
-                    Some(TcpMatchQuality::Low.as_score())
+                    None
                 }
             } else {
-                Some(TcpMatchQuality::Low.as_score())
+                None
             }
         }
         (WindowSize::Mod(a), WindowSize::Mod(b)) => {
             if a == b {
                 Some(TcpMatchQuality::High.as_score())
             } else {
-                Some(TcpMatchQuality::Low.as_score())
+                None
             }
         }
         (WindowSize::Value(a), WindowSize::Value(b)) => {
             if a == b {
                 Some(TcpMatchQuality::High.as_score())
             } else {
-                Some(TcpMatchQuality::Low.as_score())
+                None
             }
         }
         (_, WindowSize::Any) => Some(TcpMatchQuality::High.as_score()),

--- a/huginn-net-db/src/tcp/distances.rs
+++ b/huginn-net-db/src/tcp/distances.rs
@@ -40,21 +40,9 @@ fn signature_initial_ttl(signature: &Ttl) -> u8 {
     }
 }
 
-/// Distance score between an observed `Ttl` and a database `Ttl`.
-///
-/// TTL is not compared for equality: routers decrement it, so the observed
-/// value is expected to sit *below* the signature's initial TTL, by at most
-/// [`MAX_TTL_DISTANCE`] hops. Within that window the field matches exactly;
-/// outside it the signature still matches, but only as fuzzy — p0f never
-/// rejects on TTL alone (`data/p0f/fp_tcp.c::tcp_find_match`).
-///
-/// The one exception is a signature with a randomised TTL (`nnn-`, parsed as
-/// [`Ttl::Bad`]): the value carries no hop information, so only the upper
-/// bound is enforced, and exceeding it is a hard reject.
-///
-/// The fuzzy case is currently reported as the worst non-rejecting score;
-/// once the match tiers land it becomes `Fuzzy(TtlOutOfRange)` carrying the
-/// hop distance, which also breaks ties between equally exact candidates.
+/// Hop-distance vs the signature's initial TTL, not equality.
+/// Within [`MAX_TTL_DISTANCE`]: High. Outside: Low (not a reject).
+/// [`Ttl::Bad`] (`nnn-`): reject if observed > initial.
 pub fn distance_ttl(observed: &Ttl, signature: &Ttl) -> Option<u32> {
     let observed = observed_ttl(observed);
     let initial = signature_initial_ttl(signature);

--- a/huginn-net-db/src/tcp/matching.rs
+++ b/huginn-net-db/src/tcp/matching.rs
@@ -21,26 +21,31 @@ use crate::database::TcpIndexKey;
 use crate::db_matching_trait::{DatabaseSignature, MatchQuality, ObservedFingerprint};
 use crate::tcp::{
     self, distance_ip_version, distance_payload_size, distance_ttl, distance_window_size,
-    IpVersion, PayloadSize,
+    IpVersion, PayloadSize, Quirk,
 };
 use huginn_net_tcp::observable::TcpObservation;
 
+/// `olen` is never wildcarded in p0f's format: a mismatch is a hard reject, not a soft penalty.
 pub(crate) fn distance_olen(observed: &TcpObservation, signature: &tcp::Signature) -> Option<u32> {
     if observed.olen == signature.olen {
         Some(tcp::TcpMatchQuality::High.as_score())
     } else {
-        Some(tcp::TcpMatchQuality::Low.as_score())
+        None
     }
 }
 
+/// A signature-specified `mss` is a hard gate in p0f: only `mss == *`
+/// (wildcard, `None` here) tolerates any observed value.
 pub(crate) fn distance_mss(observed: &TcpObservation, signature: &tcp::Signature) -> Option<u32> {
     if signature.mss.is_none() || observed.mss == signature.mss {
         Some(tcp::TcpMatchQuality::High.as_score())
     } else {
-        Some(tcp::TcpMatchQuality::Low.as_score())
+        None
     }
 }
 
+/// A signature-specified `wscale` is a hard gate in p0f: only `wscale == *`
+/// (wildcard, `None` here) tolerates any observed value.
 pub(crate) fn distance_wscale(
     observed: &TcpObservation,
     signature: &tcp::Signature,
@@ -48,7 +53,7 @@ pub(crate) fn distance_wscale(
     if signature.wscale.is_none() || observed.wscale == signature.wscale {
         Some(tcp::TcpMatchQuality::High.as_score())
     } else {
-        Some(tcp::TcpMatchQuality::Medium.as_score())
+        None
     }
 }
 
@@ -63,14 +68,77 @@ pub(crate) fn distance_olayout(
     }
 }
 
+/// Quirks a database signature may declare without the observation showing
+/// them (`df` and `id+` in p0f terms).
+const FUZZY_DELETABLE_QUIRKS: [Quirk; 2] = [Quirk::Df, Quirk::NonZeroID];
+
+/// Quirks an observation may show without the database signature declaring
+/// them (`id-` and `ecn` in p0f terms).
+const FUZZY_ADDABLE_QUIRKS: [Quirk; 2] = [Quirk::ZeroID, Quirk::Ecn];
+
+/// Whether a database quirk must be ignored because the signature is
+/// version-agnostic (`ver == *`) and the quirk only exists for the other IP
+/// version. Mirrors the `ref_quirks &= …` masking in
+/// `data/p0f/fp_tcp.c::tcp_find_match`.
+fn quirk_masked_by_ip_version(
+    quirk: &Quirk,
+    signature_version: IpVersion,
+    observed_version: IpVersion,
+) -> bool {
+    if signature_version != IpVersion::Any {
+        return false;
+    }
+    match observed_version {
+        IpVersion::V6 => matches!(quirk, Quirk::Df | Quirk::NonZeroID | Quirk::ZeroID),
+        _ => matches!(quirk, Quirk::FlowID),
+    }
+}
+
+/// Quirks are compared as sets, not as ordered lists, and a narrow set of
+/// differences is tolerated as a fuzzy match: `df`/`id+` may be absent from
+/// the traffic, and `id-`/`ecn` may appear in it. Any other difference
+/// rejects the signature outright.
+///
+/// The fuzzy case is currently reported as the worst non-rejecting score;
+/// once the match tiers land it becomes `Fuzzy(QuirksWhitelisted)` instead,
+/// which sorts below every exact match regardless of the other fields.
 pub(crate) fn distance_quirks(
     observed: &TcpObservation,
     signature: &tcp::Signature,
 ) -> Option<u32> {
-    if observed.quirks == signature.quirks {
-        Some(tcp::TcpMatchQuality::High.as_score())
+    let declared_by_signature = |quirk: &Quirk| {
+        signature.quirks.contains(quirk)
+            && !quirk_masked_by_ip_version(quirk, signature.version, observed.version)
+    };
+
+    let mut fuzzy = false;
+
+    for quirk in &signature.quirks {
+        if quirk_masked_by_ip_version(quirk, signature.version, observed.version)
+            || observed.quirks.contains(quirk)
+        {
+            continue;
+        }
+        if !FUZZY_DELETABLE_QUIRKS.contains(quirk) {
+            return None;
+        }
+        fuzzy = true;
+    }
+
+    for quirk in &observed.quirks {
+        if declared_by_signature(quirk) {
+            continue;
+        }
+        if !FUZZY_ADDABLE_QUIRKS.contains(quirk) {
+            return None;
+        }
+        fuzzy = true;
+    }
+
+    if fuzzy {
+        Some(tcp::TcpMatchQuality::Low.as_score())
     } else {
-        None
+        Some(tcp::TcpMatchQuality::High.as_score())
     }
 }
 

--- a/huginn-net-db/src/tcp/mod.rs
+++ b/huginn-net-db/src/tcp/mod.rs
@@ -11,5 +11,6 @@ mod signature;
 
 pub use distances::{
     distance_ip_version, distance_payload_size, distance_ttl, distance_window_size,
+    MAX_TTL_DISTANCE,
 };
 pub use signature::{Signature, TcpMatchQuality};

--- a/huginn-net-db/tests/snapshots/macos_tcp_flags.pcap.json
+++ b/huginn-net-db/tests/snapshots/macos_tcp_flags.pcap.json
@@ -14,10 +14,10 @@
       },
       "tcp_analysis": {
         "syn": {
-          "os_name": null,
-          "os_family": null,
-          "os_variant": null,
-          "quality": "NotMatched",
+          "os_name": "Mac OS X",
+          "os_family": "unix",
+          "os_variant": "10.x",
+          "quality": "Matched(0.9)",
           "raw_signature": "4:64+0:0:1460:65535,6:mss,nop,ws,nop,nop,ts,sok,eol+1:df,ecn:0"
         },
         "syn_ack": null,

--- a/huginn-net-db/tests/tcp_distances.rs
+++ b/huginn-net-db/tests/tcp_distances.rs
@@ -1,58 +1,113 @@
 #![cfg(feature = "tcp")]
-use huginn_net_db::tcp::{distance_ttl, TcpMatchQuality, Ttl};
+use huginn_net_db::tcp::{
+    distance_ttl, distance_window_size, TcpMatchQuality, Ttl, WindowSize, MAX_TTL_DISTANCE,
+};
 
-#[test]
-fn test_distance_ttl_matching_cases() {
-    assert_eq!(
-        distance_ttl(&Ttl::Value(64), &Ttl::Value(64)),
-        Some(TcpMatchQuality::High.as_score())
-    );
-    assert_eq!(
-        distance_ttl(&Ttl::Distance(57, 7), &Ttl::Distance(57, 7)),
-        Some(TcpMatchQuality::High.as_score())
-    );
-    assert_eq!(
-        distance_ttl(&Ttl::Distance(57, 7), &Ttl::Value(64)),
-        Some(TcpMatchQuality::High.as_score())
-    );
-    assert_eq!(
-        distance_ttl(&Ttl::Guess(64), &Ttl::Value(64)),
-        Some(TcpMatchQuality::High.as_score())
-    );
+fn exact() -> Option<u32> {
+    Some(TcpMatchQuality::High.as_score())
+}
+
+/// Score of a TTL that no longer supports the signature's initial TTL: still
+/// a match, but only a fuzzy one.
+fn fuzzy() -> Option<u32> {
+    Some(TcpMatchQuality::Low.as_score())
 }
 
 #[test]
-fn test_distance_ttl_non_matching_cases() {
-    assert_eq!(
-        distance_ttl(&Ttl::Value(64), &Ttl::Value(128)),
-        Some(TcpMatchQuality::Low.as_score())
-    );
-    assert_eq!(
-        distance_ttl(&Ttl::Distance(57, 7), &Ttl::Value(128)),
-        Some(TcpMatchQuality::Low.as_score())
-    );
-    assert_eq!(distance_ttl(&Ttl::Bad(0), &Ttl::Bad(1)), Some(TcpMatchQuality::Low.as_score()));
+fn test_distance_ttl_matches_when_observed_equals_initial() {
+    assert_eq!(distance_ttl(&Ttl::Value(64), &Ttl::Value(64)), exact());
+    assert_eq!(distance_ttl(&Ttl::Value(64), &Ttl::Guess(64)), exact());
+    // `nnn+d` in the database means "initial TTL is nnn + d".
+    assert_eq!(distance_ttl(&Ttl::Value(64), &Ttl::Distance(57, 7)), exact());
 }
 
 #[test]
-fn test_distance_ttl_additional_cases() {
-    assert_eq!(
-        distance_ttl(&Ttl::Value(64), &Ttl::Distance(57, 7)),
-        Some(TcpMatchQuality::High.as_score())
-    );
-    assert_eq!(
-        distance_ttl(&Ttl::Value(64), &Ttl::Guess(64)),
-        Some(TcpMatchQuality::High.as_score())
-    );
-    assert_eq!(
-        distance_ttl(&Ttl::Value(64), &Ttl::Distance(60, 7)),
-        Some(TcpMatchQuality::Low.as_score())
-    );
+fn test_distance_ttl_matches_within_hop_distance() {
+    // Observed TTL below the signature's initial TTL is the normal case: the
+    // difference is the hop count, and any plausible count matches exactly.
+    assert_eq!(distance_ttl(&Ttl::Distance(57, 7), &Ttl::Value(64)), exact());
+    assert_eq!(distance_ttl(&Ttl::Value(50), &Ttl::Value(64)), exact());
+    assert_eq!(distance_ttl(&Ttl::Guess(100), &Ttl::Value(128)), exact());
+    // The old implementation compared the enum contents, so a signature
+    // written as `60+7` (initial TTL 67) failed against an observed 64.
+    assert_eq!(distance_ttl(&Ttl::Value(64), &Ttl::Distance(60, 7)), exact());
 }
 
 #[test]
-fn test_distance_ttl_incompatible_types() {
-    assert_eq!(distance_ttl(&Ttl::Bad(0), &Ttl::Value(64)), None);
+fn test_distance_ttl_hop_distance_boundary() {
+    let initial = 64;
+    let at_limit = initial - MAX_TTL_DISTANCE;
+    assert_eq!(distance_ttl(&Ttl::Value(at_limit), &Ttl::Value(initial)), exact());
+    assert_eq!(distance_ttl(&Ttl::Value(at_limit - 1), &Ttl::Value(initial)), fuzzy());
+}
+
+#[test]
+fn test_distance_ttl_is_fuzzy_beyond_hop_distance() {
+    assert_eq!(distance_ttl(&Ttl::Value(64), &Ttl::Value(128)), fuzzy());
+    assert_eq!(distance_ttl(&Ttl::Distance(57, 7), &Ttl::Value(128)), fuzzy());
+    // TTL 0 (parsed as `Bad` on the observed side) against a normal signature.
+    assert_eq!(distance_ttl(&Ttl::Bad(0), &Ttl::Value(64)), fuzzy());
+}
+
+#[test]
+fn test_distance_ttl_is_fuzzy_when_observed_exceeds_initial() {
+    // A TTL can only decrease in transit, so this cannot be a clean match.
+    assert_eq!(distance_ttl(&Ttl::Value(128), &Ttl::Value(64)), fuzzy());
+}
+
+#[test]
+fn test_distance_ttl_randomised_signature_only_enforces_upper_bound() {
+    // `nnn-` in the database: the value carries no hop information, so any
+    // observation at or below it matches, and anything above is rejected.
+    assert_eq!(distance_ttl(&Ttl::Value(64), &Ttl::Bad(64)), exact());
+    assert_eq!(distance_ttl(&Ttl::Value(1), &Ttl::Bad(64)), exact());
     assert_eq!(distance_ttl(&Ttl::Distance(64, 7), &Ttl::Bad(0)), None);
-    assert_eq!(distance_ttl(&Ttl::Guess(64), &Ttl::Distance(64, 7)), None);
+    assert_eq!(distance_ttl(&Ttl::Value(65), &Ttl::Bad(64)), None);
+}
+
+/// p0f never tolerates a window-size mismatch: every branch below must reject (`None`) rather than fall back to a soft `Low` penalty.
+#[test]
+fn test_distance_window_size_matching_cases() {
+    assert_eq!(
+        distance_window_size(&WindowSize::Mss(4), &WindowSize::Mss(4), None),
+        Some(TcpMatchQuality::High.as_score())
+    );
+    assert_eq!(
+        distance_window_size(&WindowSize::Mtu(2), &WindowSize::Mtu(2), None),
+        Some(TcpMatchQuality::High.as_score())
+    );
+    assert_eq!(
+        distance_window_size(&WindowSize::Mod(8192), &WindowSize::Mod(8192), None),
+        Some(TcpMatchQuality::High.as_score())
+    );
+    assert_eq!(
+        distance_window_size(&WindowSize::Value(65535), &WindowSize::Value(65535), None),
+        Some(TcpMatchQuality::High.as_score())
+    );
+    assert_eq!(
+        distance_window_size(&WindowSize::Value(5840), &WindowSize::Mss(4), Some(1460)),
+        Some(TcpMatchQuality::High.as_score())
+    );
+    assert_eq!(
+        distance_window_size(&WindowSize::Value(12345), &WindowSize::Any, None),
+        Some(TcpMatchQuality::High.as_score())
+    );
+}
+
+#[test]
+fn test_distance_window_size_rejects_on_mismatch() {
+    assert_eq!(distance_window_size(&WindowSize::Mss(4), &WindowSize::Mss(5), None), None);
+    assert_eq!(distance_window_size(&WindowSize::Mtu(2), &WindowSize::Mtu(3), None), None);
+    assert_eq!(distance_window_size(&WindowSize::Mod(8192), &WindowSize::Mod(4096), None), None);
+    assert_eq!(
+        distance_window_size(&WindowSize::Value(65535), &WindowSize::Value(1), None),
+        None
+    );
+    // Wrong ratio for the observed MSS.
+    assert_eq!(
+        distance_window_size(&WindowSize::Value(5840), &WindowSize::Mss(3), Some(1460)),
+        None
+    );
+    // No observed MSS available to resolve the ratio against.
+    assert_eq!(distance_window_size(&WindowSize::Value(5840), &WindowSize::Mss(4), None), None);
 }

--- a/huginn-net-db/tests/tcp_matching.rs
+++ b/huginn-net-db/tests/tcp_matching.rs
@@ -1,11 +1,4 @@
 #![cfg(feature = "tcp")]
-//! Hard-gate behaviour of `Signature::calculate_distance`.
-//!
-//! p0f rejects a candidate signature outright when `olen`, `mss`, `wscale` or
-//! the window size disagree; none of
-//! them may degrade into a soft penalty. These tests pin that contract on the
-//! public matching API rather than on the `pub(crate)` per-field helpers.
-
 use huginn_net_db::db_matching_trait::DatabaseSignature;
 use huginn_net_db::tcp::{
     IpVersion, PayloadSize, Quirk, Signature, TcpMatchQuality, Ttl, WindowSize,

--- a/huginn-net-db/tests/tcp_matching.rs
+++ b/huginn-net-db/tests/tcp_matching.rs
@@ -1,0 +1,216 @@
+#![cfg(feature = "tcp")]
+//! Hard-gate behaviour of `Signature::calculate_distance`.
+//!
+//! p0f rejects a candidate signature outright when `olen`, `mss`, `wscale` or
+//! the window size disagree; none of
+//! them may degrade into a soft penalty. These tests pin that contract on the
+//! public matching API rather than on the `pub(crate)` per-field helpers.
+
+use huginn_net_db::db_matching_trait::DatabaseSignature;
+use huginn_net_db::tcp::{
+    IpVersion, PayloadSize, Quirk, Signature, TcpMatchQuality, Ttl, WindowSize,
+};
+use huginn_net_tcp::observable::TcpObservation;
+
+fn base_observation() -> TcpObservation {
+    TcpObservation {
+        version: IpVersion::V4,
+        ittl: Ttl::Value(64),
+        olen: 0,
+        mss: Some(1460),
+        wsize: WindowSize::Value(65535),
+        wscale: Some(6),
+        olayout: Vec::new(),
+        quirks: Vec::new(),
+        pclass: PayloadSize::Zero,
+    }
+}
+
+fn base_signature() -> Signature {
+    Signature {
+        version: IpVersion::V4,
+        ittl: Ttl::Value(64),
+        olen: 0,
+        mss: Some(1460),
+        wsize: WindowSize::Value(65535),
+        wscale: Some(6),
+        olayout: Vec::new(),
+        quirks: Vec::new(),
+        pclass: PayloadSize::Zero,
+    }
+}
+
+#[test]
+fn identical_signature_has_zero_distance() {
+    assert_eq!(base_signature().calculate_distance(&base_observation()), Some(0));
+}
+
+#[test]
+fn olen_mismatch_rejects_signature() {
+    let mut signature = base_signature();
+    signature.olen = 4;
+    assert_eq!(
+        signature.calculate_distance(&base_observation()),
+        None,
+        "olen is never wildcarded in p0f, so a mismatch must reject"
+    );
+}
+
+#[test]
+fn wildcard_mss_matches_any_observed_value() {
+    let mut signature = base_signature();
+    signature.mss = None;
+    assert_eq!(signature.calculate_distance(&base_observation()), Some(0));
+}
+
+#[test]
+fn mss_mismatch_rejects_signature() {
+    let mut signature = base_signature();
+    signature.mss = Some(1400);
+    assert_eq!(
+        signature.calculate_distance(&base_observation()),
+        None,
+        "a concrete mss is a hard gate in p0f"
+    );
+}
+
+#[test]
+fn wildcard_wscale_matches_any_observed_value() {
+    let mut signature = base_signature();
+    signature.wscale = None;
+    assert_eq!(signature.calculate_distance(&base_observation()), Some(0));
+}
+
+#[test]
+fn wscale_mismatch_rejects_signature() {
+    let mut signature = base_signature();
+    signature.wscale = Some(7);
+    assert_eq!(
+        signature.calculate_distance(&base_observation()),
+        None,
+        "a concrete wscale is a hard gate in p0f"
+    );
+}
+
+#[test]
+fn window_size_mismatch_rejects_signature() {
+    let mut signature = base_signature();
+    signature.wsize = WindowSize::Value(8192);
+    assert_eq!(
+        signature.calculate_distance(&base_observation()),
+        None,
+        "p0f never tolerates a window size mismatch"
+    );
+}
+
+#[test]
+fn wildcard_window_size_matches_any_observed_value() {
+    let mut signature = base_signature();
+    signature.wsize = WindowSize::Any;
+    assert_eq!(signature.calculate_distance(&base_observation()), Some(0));
+}
+
+// ---------------------------------------------------------------------------
+// Quirks: set comparison, fuzziness whitelist and IP-version masking.
+// ---------------------------------------------------------------------------
+
+/// Distance of a quirks-only fuzzy match: every other field is identical, so
+/// the whole distance comes from the tolerated quirk difference.
+fn fuzzy_quirks_distance() -> Option<u32> {
+    Some(TcpMatchQuality::Low.as_score())
+}
+
+#[test]
+fn quirks_are_compared_as_sets_not_ordered_lists() {
+    let mut signature = base_signature();
+    signature.quirks = vec![Quirk::Df, Quirk::NonZeroID];
+    let mut observed = base_observation();
+    observed.quirks = vec![Quirk::NonZeroID, Quirk::Df];
+    assert_eq!(signature.calculate_distance(&observed), Some(0));
+}
+
+#[test]
+fn missing_df_or_non_zero_id_is_a_fuzzy_match() {
+    for quirk in [Quirk::Df, Quirk::NonZeroID] {
+        let mut signature = base_signature();
+        signature.quirks = vec![quirk.clone()];
+        assert_eq!(
+            signature.calculate_distance(&base_observation()),
+            fuzzy_quirks_distance(),
+            "p0f tolerates {quirk:?} disappearing from the traffic"
+        );
+    }
+}
+
+#[test]
+fn extra_zero_id_or_ecn_is_a_fuzzy_match() {
+    for quirk in [Quirk::ZeroID, Quirk::Ecn] {
+        let mut observed = base_observation();
+        observed.quirks = vec![quirk.clone()];
+        assert_eq!(
+            base_signature().calculate_distance(&observed),
+            fuzzy_quirks_distance(),
+            "p0f tolerates {quirk:?} appearing in the traffic"
+        );
+    }
+}
+
+#[test]
+fn other_missing_quirk_rejects_signature() {
+    let mut signature = base_signature();
+    signature.quirks = vec![Quirk::MustBeZero];
+    assert_eq!(
+        signature.calculate_distance(&base_observation()),
+        None,
+        "only df and id+ may disappear"
+    );
+}
+
+#[test]
+fn other_extra_quirk_rejects_signature() {
+    let mut observed = base_observation();
+    observed.quirks = vec![Quirk::SeqNumZero];
+    assert_eq!(
+        base_signature().calculate_distance(&observed),
+        None,
+        "only id- and ecn may appear"
+    );
+}
+
+#[test]
+fn version_agnostic_signature_ignores_ipv6_only_quirks_on_ipv4() {
+    let mut signature = base_signature();
+    signature.version = IpVersion::Any;
+    signature.quirks = vec![Quirk::FlowID];
+    assert_eq!(
+        signature.calculate_distance(&base_observation()),
+        Some(0),
+        "flow cannot appear in IPv4 traffic, so it must be masked out, not counted as fuzzy"
+    );
+}
+
+#[test]
+fn version_agnostic_signature_ignores_ipv4_only_quirks_on_ipv6() {
+    let mut signature = base_signature();
+    signature.version = IpVersion::Any;
+    signature.quirks = vec![Quirk::Df, Quirk::NonZeroID, Quirk::ZeroID];
+    let mut observed = base_observation();
+    observed.version = IpVersion::V6;
+    assert_eq!(
+        signature.calculate_distance(&observed),
+        Some(0),
+        "df/id+/id- cannot appear in IPv6 traffic, so they must be masked out"
+    );
+}
+
+#[test]
+fn version_specific_signature_does_not_mask_quirks() {
+    let mut signature = base_signature();
+    signature.version = IpVersion::V4;
+    signature.quirks = vec![Quirk::FlowID];
+    assert_eq!(
+        signature.calculate_distance(&base_observation()),
+        None,
+        "masking only applies to version-agnostic signatures"
+    );
+}

--- a/huginn-net/tests/smoke.rs
+++ b/huginn-net/tests/smoke.rs
@@ -44,9 +44,18 @@ fn e2e_tcp_syn_and_mtu_are_identified() {
         .and_then(|r| r.tcp_syn.as_ref())
         .unwrap_or_else(|| panic!("expected at least one SYN in macos_tcp_flags.pcap"));
 
+    // The capture's quirks are `df,ecn` while p0f.fp writes `df,id+` for this
+    // signature: `id+` missing and `ecn` extra are both inside p0f's fuzzy
+    // whitelist, so this is a match, not a reject.
+    let os = first_syn
+        .os_matched
+        .os
+        .as_ref()
+        .unwrap_or_else(|| panic!("expected an OS match for the first SYN"));
+    assert_eq!(os.name, "Mac OS X", "first SYN OS name");
     assert!(
-        matches!(first_syn.os_matched.quality, TcpMatchQuality::NotMatched),
-        "matcher must run and return NotMatched, got {:?}",
+        matches!(first_syn.os_matched.quality, TcpMatchQuality::Matched(_)),
+        "matcher must run and return a fuzzy match, got {:?}",
         first_syn.os_matched.quality
     );
 


### PR DESCRIPTION
Align TCP field matching with p0f (gates, quirks, TTL)

## Summary
- Treat `olen` / `mss` / `wscale` / `wsize` mismatches as hard rejects (no soft scoring).
- Quirks: whitelist fuzzy diffs (`df`/`id+` missing, `id-`/`ecn` extra) + IP-version quirk mask.
- TTL: hop-distance vs `MAX_DIST` (35), not structural `Ttl` enum equality.
- Golden TCP harness / default `.fp` cleanup as needed for the above.
