### PR TITLE
HTTP horder / habsent + HttpParams

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,46 @@
 
 ---
 
+## v2.0.0 → v2.1.0
+
+### What changed
+
+The matcher now follows p0f's algorithm instead of summing soft penalties, so
+which signatures match changes: TCP gains coverage (p0f's fuzzy tolerances for
+quirks and TTL are honoured), HTTP loses it (no error budget — a header that
+does not fit is a rejection), and HTTP quality scores go up.
+
+---
+
+### `HttpDiagnosis` → `HttpParams`
+
+`HttpRequestOutput`/`HttpResponseOutput` carry `params: HttpParams` instead of
+`diagnosis: HttpDiagnosis`, because p0f reports these as combinable flags
+(`dishonest generic`) rather than one verdict.
+
+```rust
+// v2.0
+match output.diagnosis { HttpDiagnosis::Dishonest => …, … }
+
+// v2.1
+if output.params.dishonest { … }
+println!("{}", output.params); // "dishonest generic", or "none"
+```
+
+`dishonest` now means what p0f means: the `User-Agent`/`Server` string does not
+contain the software the matched signature declares.
+
+---
+
+### Removed
+
+| v2.0 | v2.1 |
+|------|------|
+| `http_common::get_diagnostic` | `http_common::build_params` |
+| `huginn_net_db::http::distance_expsw` | `huginn_net_db::http::expsw_matches` (no longer part of the distance) |
+
+---
+
 ## v1.x → v2.0.0
 
 ### What changed

--- a/benches/bench_http.rs
+++ b/benches/bench_http.rs
@@ -587,7 +587,7 @@ fn bench_http_server_detection(c: &mut Criterion) {
                     if let Some(response) = result.http_response {
                         // Access server information to ensure full processing
                         let _ = &response.web_server_matched;
-                        let _ = &response.diagnosis;
+                        let _ = &response.params;
                     }
                 }
             }
@@ -603,7 +603,7 @@ fn bench_http_server_detection(c: &mut Criterion) {
                 if let Some(result) = process_http_packet(packet, &mut flows, &processors, None) {
                     if let Some(response) = result.http_response {
                         // Access basic response information
-                        let _ = &response.diagnosis;
+                        let _ = &response.params;
                     }
                 }
             }
@@ -624,7 +624,7 @@ fn bench_http_server_detection(c: &mut Criterion) {
                 {
                     if let Some(response) = result.http_response {
                         let _ = &response.web_server_matched;
-                        let _ = &response.diagnosis;
+                        let _ = &response.params;
                     }
                 }
             }
@@ -639,7 +639,7 @@ fn bench_http_server_detection(c: &mut Criterion) {
             for packet in packets.iter() {
                 if let Some(result) = process_http_packet(packet, &mut flows, &processors, None) {
                     if let Some(response) = result.http_response {
-                        let _ = &response.diagnosis;
+                        let _ = &response.params;
                     }
                 }
             }

--- a/huginn-net-db/src/http/distances.rs
+++ b/huginn-net-db/src/http/distances.rs
@@ -24,27 +24,8 @@ pub fn distance_http_version(observed: Version, signature: Version) -> Option<u3
     }
 }
 
-/// Distance score between the headers a database signature expects
-/// (`horder`) and the headers seen in the traffic.
-///
-/// Header matching has no error budget in p0f: every header the signature
-/// lists must be found in the observed list, in the same relative order, and
-/// any mismatch rejects the whole signature. Concretely:
-///
-/// - Observed headers the signature does not mention are skipped for free,
-///   however many of them appear and wherever they appear.
-/// - When the signature specifies a value, the observed value must *contain*
-///   it as a substring (so `Accept=[,*/*]` matches a longer real `Accept`),
-///   and an observed header carrying no value never satisfies one that
-///   expects a value.
-/// - A required header that is not found rejects the signature.
-/// - An optional header (`?` in the `.fp`) may be missing, but only if it is
-///   absent from the traffic altogether: appearing in a different position
-///   than the signature dictates is still a mismatch.
-///
-/// Only the signature's `optional` flag is consulted. Observations carry one
-/// too, but it describes how p0f would *print* the header, not how to match
-/// it.
+/// Signature `horder` vs traffic headers: required names in order, extras free.
+/// Signature values are substrings. `?` may be missing, not out of order.
 pub fn distance_header(observed: &[Header], signature: &[Header]) -> Option<u32> {
     let mut position = 0usize;
 
@@ -87,14 +68,7 @@ pub fn distance_header(observed: &[Header], signature: &[Header]) -> Option<u32>
     Some(HttpMatchQuality::High.as_score())
 }
 
-/// Distance score for a signature's `habsent` list: the headers that must
-/// *not* show up in matching traffic.
-///
-/// Note that `observed` is the list of headers actually seen (the
-/// observation's `horder`), not the observation's own `habsent`. p0f checks
-/// its forbidden headers against the traffic's real headers; an observation's
-/// `habsent` is only the set of common headers it happened to be missing,
-/// which exists to print a candidate signature, not to match one.
+/// Reject if any signature `habsent` name appears in the traffic headers.
 pub fn distance_habsent(observed: &[Header], signature_absent: &[Header]) -> Option<u32> {
     for forbidden in signature_absent {
         if observed.iter().any(|h| h.name == forbidden.name) {
@@ -106,20 +80,8 @@ pub fn distance_habsent(observed: &[Header], signature_absent: &[Header]) -> Opt
     Some(HttpMatchQuality::High.as_score())
 }
 
-/// Whether the software string seen in the traffic backs up the one the
-/// matched signature declares (`expsw`).
-///
-/// This is deliberately *not* a distance. In p0f the check runs only once a
-/// signature has already been chosen, and its outcome never rejects the
-/// signature nor makes it rank lower: it just flags the host as dishonest,
-/// because a host whose headers say Chrome while its `User-Agent` says
-/// something else is still a Chrome-shaped host.
-///
-/// The observed `User-Agent`/`Server` value must *contain* the signature's
-/// expected substring; note the database usually writes it with a leading
-/// space (`" Chrom"`), which is significant and keeps the match anchored at a
-/// token boundary. Either side having nothing to say means there is nothing
-/// to contradict, so it counts as honest.
+/// True if `observed` contains the signature `expsw` substring.
+/// Empty on either side counts as a match.
 pub fn expsw_matches(observed: &str, signature: &str) -> bool {
     if signature.is_empty() || observed.is_empty() || observed == UNKNOWN_SOFTWARE {
         return true;

--- a/huginn-net-db/src/http/distances.rs
+++ b/huginn-net-db/src/http/distances.rs
@@ -9,6 +9,8 @@
 
 use super::signature::HttpMatchQuality;
 use super::{Header, Version};
+use huginn_net_http::http::UNKNOWN_SOFTWARE;
+use tracing::debug;
 
 /// Distance score between an observed [`Version`] and a database [`Version`].
 ///
@@ -22,77 +24,106 @@ pub fn distance_http_version(observed: Version, signature: Version) -> Option<u3
     }
 }
 
-/// Distance score between two header slices using p0f's order-respecting,
-/// optional-header-aware comparison.
+/// Distance score between the headers a database signature expects
+/// (`horder`) and the headers seen in the traffic.
 ///
-/// Implements a two-pointer walk over `observed` and `signature` headers:
-/// - Exact matches advance both pointers with no error.
-/// - Same name, different value: error unless the signature header is
-///   marked optional.
-/// - Mismatched names: skip the signature side if optional, otherwise count
-///   an error.
-/// - Trailing observed headers count as errors; trailing signature headers
-///   count as errors unless optional.
+/// Header matching has no error budget in p0f: every header the signature
+/// lists must be found in the observed list, in the same relative order, and
+/// any mismatch rejects the whole signature. Concretely:
 ///
-/// Returns `None` once 12 or more errors accumulate (unmatchable).
+/// - Observed headers the signature does not mention are skipped for free,
+///   however many of them appear and wherever they appear.
+/// - When the signature specifies a value, the observed value must *contain*
+///   it as a substring (so `Accept=[,*/*]` matches a longer real `Accept`),
+///   and an observed header carrying no value never satisfies one that
+///   expects a value.
+/// - A required header that is not found rejects the signature.
+/// - An optional header (`?` in the `.fp`) may be missing, but only if it is
+///   absent from the traffic altogether: appearing in a different position
+///   than the signature dictates is still a mismatch.
+///
+/// Only the signature's `optional` flag is consulted. Observations carry one
+/// too, but it describes how p0f would *print* the header, not how to match
+/// it.
 pub fn distance_header(observed: &[Header], signature: &[Header]) -> Option<u32> {
-    let mut obs_idx = 0usize;
-    let mut sig_idx = 0usize;
-    let mut errors: u32 = 0;
+    let mut position = 0usize;
 
-    while obs_idx < observed.len() && sig_idx < signature.len() {
-        let obs_header = &observed[obs_idx];
-        let sig_header = &signature[sig_idx];
+    for expected in signature {
+        let found = observed
+            .get(position..)
+            .and_then(|rest| rest.iter().position(|h| h.name == expected.name));
 
-        if obs_header.name == sig_header.name && obs_header.value == sig_header.value {
-            obs_idx = obs_idx.saturating_add(1);
-            sig_idx = sig_idx.saturating_add(1);
-        } else if obs_header.name == sig_header.name {
-            if !sig_header.optional {
-                errors = errors.saturating_add(1);
+        match found {
+            Some(offset) => {
+                let header = observed.get(position.saturating_add(offset))?;
+                if let Some(expected_value) = expected.value.as_deref() {
+                    if !header
+                        .value
+                        .as_deref()
+                        .is_some_and(|v| v.contains(expected_value))
+                    {
+                        debug!(
+                            "header {} value mismatch: expected substring {expected_value}",
+                            expected.name
+                        );
+                        return None;
+                    }
+                }
+                position = position.saturating_add(offset).saturating_add(1);
             }
-            obs_idx = obs_idx.saturating_add(1);
-            sig_idx = sig_idx.saturating_add(1);
-        } else if sig_header.optional {
-            sig_idx = sig_idx.saturating_add(1);
-        } else {
-            errors = errors.saturating_add(1);
-            sig_idx = sig_idx.saturating_add(1);
+            None => {
+                if !expected.optional {
+                    debug!("required header {} missing", expected.name);
+                    return None;
+                }
+                if observed.iter().any(|h| h.name == expected.name) {
+                    debug!("optional header {} present but out of order", expected.name);
+                    return None;
+                }
+            }
         }
     }
 
-    while obs_idx < observed.len() {
-        errors = errors.saturating_add(1);
-        obs_idx = obs_idx.saturating_add(1);
-    }
-
-    while sig_idx < signature.len() {
-        if !signature[sig_idx].optional {
-            errors = errors.saturating_add(1);
-        }
-        sig_idx = sig_idx.saturating_add(1);
-    }
-
-    match errors {
-        0..=2 => Some(HttpMatchQuality::High.as_score()),
-        3..=5 => Some(HttpMatchQuality::Medium.as_score()),
-        6..=8 => Some(HttpMatchQuality::Low.as_score()),
-        9..=11 => Some(HttpMatchQuality::Bad.as_score()),
-        _ => None,
-    }
+    Some(HttpMatchQuality::High.as_score())
 }
 
-/// Distance score between an observed `expsw` string and a database
-/// signature's `expsw`.
+/// Distance score for a signature's `habsent` list: the headers that must
+/// *not* show up in matching traffic.
 ///
-/// The observed value is considered a match when the signature's `expsw`
-/// contains it as a substring. Mismatches still produce a score
-/// ([`HttpMatchQuality::Bad`]) rather than `None`, matching the original
-/// behaviour expected by the database matcher.
-pub fn distance_expsw(observed: &str, signature: &str) -> Option<u32> {
-    if signature.contains(observed) {
-        Some(HttpMatchQuality::High.as_score())
-    } else {
-        Some(HttpMatchQuality::Bad.as_score())
+/// Note that `observed` is the list of headers actually seen (the
+/// observation's `horder`), not the observation's own `habsent`. p0f checks
+/// its forbidden headers against the traffic's real headers; an observation's
+/// `habsent` is only the set of common headers it happened to be missing,
+/// which exists to print a candidate signature, not to match one.
+pub fn distance_habsent(observed: &[Header], signature_absent: &[Header]) -> Option<u32> {
+    for forbidden in signature_absent {
+        if observed.iter().any(|h| h.name == forbidden.name) {
+            debug!("forbidden header {} present in traffic", forbidden.name);
+            return None;
+        }
     }
+
+    Some(HttpMatchQuality::High.as_score())
+}
+
+/// Whether the software string seen in the traffic backs up the one the
+/// matched signature declares (`expsw`).
+///
+/// This is deliberately *not* a distance. In p0f the check runs only once a
+/// signature has already been chosen, and its outcome never rejects the
+/// signature nor makes it rank lower: it just flags the host as dishonest,
+/// because a host whose headers say Chrome while its `User-Agent` says
+/// something else is still a Chrome-shaped host.
+///
+/// The observed `User-Agent`/`Server` value must *contain* the signature's
+/// expected substring; note the database usually writes it with a leading
+/// space (`" Chrom"`), which is significant and keeps the match anchored at a
+/// token boundary. Either side having nothing to say means there is nothing
+/// to contradict, so it counts as honest.
+pub fn expsw_matches(observed: &str, signature: &str) -> bool {
+    if signature.is_empty() || observed.is_empty() || observed == UNKNOWN_SOFTWARE {
+        return true;
+    }
+
+    observed.contains(signature)
 }

--- a/huginn-net-db/src/http/matching.rs
+++ b/huginn-net-db/src/http/matching.rs
@@ -20,7 +20,9 @@
 
 use crate::database::HttpIndexKey;
 use crate::db_matching_trait::{DatabaseSignature, MatchQuality, ObservedFingerprint};
-use crate::http::{self, distance_expsw, distance_header, distance_http_version, Header, Version};
+use crate::http::{
+    self, distance_habsent, distance_header, distance_http_version, expsw_matches, Header, Version,
+};
 use huginn_net_http::observable::{HttpRequestObservation, HttpResponseObservation};
 
 impl ObservedFingerprint for HttpRequestObservation {
@@ -57,8 +59,8 @@ pub trait HttpDistance {
         distance_http_version(self.get_version(), other.version)
     }
 
-    /// Compare two header vectors respecting order and allowing optional
-    /// header skips. Delegates to [`crate::http::distance_header`].
+    /// Check that every header the signature expects appears in the observed
+    /// list, in order. Delegates to [`crate::http::distance_header`].
     fn distance_header(observed: &[Header], signature: &[Header]) -> Option<u32> {
         distance_header(observed, signature)
     }
@@ -67,12 +69,17 @@ pub trait HttpDistance {
         distance_header(self.get_horder(), &other.horder)
     }
 
+    /// The signature's forbidden headers are checked against the headers
+    /// actually seen, so this reads `horder`, not the observation's own
+    /// `habsent`. See [`crate::http::distance_habsent`].
     fn distance_habsent(&self, other: &http::Signature) -> Option<u32> {
-        distance_header(self.get_habsent(), &other.habsent)
+        distance_habsent(self.get_horder(), &other.habsent)
     }
 
-    fn distance_expsw(&self, other: &http::Signature) -> Option<u32> {
-        distance_expsw(self.get_expsw(), &other.expsw)
+    /// Whether the traffic's software string backs up what the signature
+    /// declares. Not part of the distance; see [`crate::http::expsw_matches`].
+    fn expsw_matches(&self, other: &http::Signature) -> bool {
+        expsw_matches(self.get_expsw(), &other.expsw)
     }
 }
 
@@ -124,10 +131,12 @@ trait HttpSignatureHelper {
 
 impl HttpSignatureHelper for http::Signature {
     fn calculate_http_distance<T: HttpDistance>(&self, observed: &T) -> Option<u32> {
+        // `expsw` is deliberately absent: p0f checks it only after a signature
+        // has been chosen, and a mismatch flags the host as dishonest instead
+        // of making the signature fit any worse.
         let distance = distance_http_version(observed.get_version(), self.version)?
             .saturating_add(distance_header(observed.get_horder(), &self.horder)?)
-            .saturating_add(distance_header(observed.get_habsent(), &self.habsent)?)
-            .saturating_add(distance_expsw(observed.get_expsw(), &self.expsw)?);
+            .saturating_add(distance_habsent(observed.get_horder(), &self.habsent)?);
         Some(distance)
     }
     fn generate_http_index_keys(&self) -> Vec<HttpIndexKey> {

--- a/huginn-net-db/src/http/matching.rs
+++ b/huginn-net-db/src/http/matching.rs
@@ -131,9 +131,6 @@ trait HttpSignatureHelper {
 
 impl HttpSignatureHelper for http::Signature {
     fn calculate_http_distance<T: HttpDistance>(&self, observed: &T) -> Option<u32> {
-        // `expsw` is deliberately absent: p0f checks it only after a signature
-        // has been chosen, and a mismatch flags the host as dishonest instead
-        // of making the signature fit any worse.
         let distance = distance_http_version(observed.get_version(), self.version)?
             .saturating_add(distance_header(observed.get_horder(), &self.horder)?)
             .saturating_add(distance_habsent(observed.get_horder(), &self.habsent)?);

--- a/huginn-net-db/src/http/mod.rs
+++ b/huginn-net-db/src/http/mod.rs
@@ -3,11 +3,11 @@
 pub use huginn_net_http::http::{
     request_common_headers, request_optional_headers, request_skip_value_headers,
     response_common_headers, response_optional_headers, response_skip_value_headers, Header,
-    HttpDiagnosis, Version,
+    HttpParams, Version, UNKNOWN_SOFTWARE,
 };
 
 mod distances;
 mod signature;
 
-pub use distances::{distance_expsw, distance_header, distance_http_version};
+pub use distances::{distance_habsent, distance_header, distance_http_version, expsw_matches};
 pub use signature::{HttpMatchQuality, Signature};

--- a/huginn-net-db/src/matcher/http_signature_matcher.rs
+++ b/huginn-net-db/src/matcher/http_signature_matcher.rs
@@ -1,5 +1,6 @@
 use crate::database::{HttpDatabase, Label, Type};
 use crate::db_matching_trait::FingerprintDb;
+use crate::http::expsw_matches;
 use huginn_net_http::matcher_api::{HttpMatcher, HttpRequestMatch, HttpResponseMatch, UaOsMatch};
 use huginn_net_http::observable::{HttpRequestObservation, HttpResponseObservation};
 use huginn_net_http::output::{Browser, OsKind, WebServer};
@@ -78,16 +79,24 @@ fn match_http_request_impl(
     db: &HttpDatabase,
     obs: &HttpRequestObservation,
 ) -> Option<HttpRequestMatch> {
-    let (label, _sig, quality) = db.http_request.find_best_match(obs)?;
-    Some(HttpRequestMatch { browser: Browser::from(label), quality })
+    let (label, sig, quality) = db.http_request.find_best_match(obs)?;
+    Some(HttpRequestMatch {
+        browser: Browser::from(label),
+        quality,
+        dishonest: !expsw_matches(&obs.expsw, &sig.expsw),
+    })
 }
 
 fn match_http_response_impl(
     db: &HttpDatabase,
     obs: &HttpResponseObservation,
 ) -> Option<HttpResponseMatch> {
-    let (label, _sig, quality) = db.http_response.find_best_match(obs)?;
-    Some(HttpResponseMatch { web_server: WebServer::from(label), quality })
+    let (label, sig, quality) = db.http_response.find_best_match(obs)?;
+    Some(HttpResponseMatch {
+        web_server: WebServer::from(label),
+        quality,
+        dishonest: !expsw_matches(&obs.expsw, &sig.expsw),
+    })
 }
 
 fn match_user_agent_impl(db: &HttpDatabase, ua: &str) -> Option<UaOsMatch> {

--- a/huginn-net-db/tests/http_distance_habsent.rs
+++ b/huginn-net-db/tests/http_distance_habsent.rs
@@ -1,7 +1,4 @@
 #![cfg(feature = "http")]
-//! `habsent` is the list of headers a signature forbids. p0f checks it
-//! against the headers actually seen in the traffic, so these tests pass an
-//! observed `horder` as the first argument.
 
 use huginn_net_db::http::{distance_habsent, Header, HttpMatchQuality};
 

--- a/huginn-net-db/tests/http_distance_habsent.rs
+++ b/huginn-net-db/tests/http_distance_habsent.rs
@@ -1,0 +1,60 @@
+#![cfg(feature = "http")]
+//! `habsent` is the list of headers a signature forbids. p0f checks it
+//! against the headers actually seen in the traffic, so these tests pass an
+//! observed `horder` as the first argument.
+
+use huginn_net_db::http::{distance_habsent, Header, HttpMatchQuality};
+
+fn matches() -> Option<u32> {
+    Some(HttpMatchQuality::High.as_score())
+}
+
+#[test]
+fn empty_absent_list_always_matches() {
+    let observed = vec![Header::new("Host"), Header::new("Accept-Charset")];
+
+    assert_eq!(distance_habsent(&observed, &[]), matches());
+}
+
+#[test]
+fn forbidden_header_absent_from_traffic_matches() {
+    let observed = vec![Header::new("Host"), Header::new("User-Agent")];
+    let forbidden = vec![Header::new("Accept-Charset"), Header::new("Keep-Alive")];
+
+    assert_eq!(distance_habsent(&observed, &forbidden), matches());
+}
+
+#[test]
+fn forbidden_header_present_in_traffic_rejects() {
+    let observed = vec![
+        Header::new("Host"),
+        Header::new("Accept-Charset").with_value("utf-8"),
+        Header::new("User-Agent"),
+    ];
+    let forbidden = vec![Header::new("Accept-Charset")];
+
+    assert_eq!(distance_habsent(&observed, &forbidden), None);
+}
+
+#[test]
+fn only_the_header_name_is_considered() {
+    // The `.fp` grammar has no values in the habsent list, but a value on
+    // either side must not change the outcome.
+    let observed = vec![Header::new("Keep-Alive").with_value("timeout=5")];
+    let forbidden = vec![Header::new("Keep-Alive").with_value("something else")];
+
+    assert_eq!(distance_habsent(&observed, &forbidden), None);
+}
+
+#[test]
+fn position_in_the_traffic_is_irrelevant() {
+    let observed = vec![
+        Header::new("Host"),
+        Header::new("User-Agent"),
+        Header::new("Accept"),
+        Header::new("Keep-Alive"),
+    ];
+    let forbidden = vec![Header::new("Keep-Alive")];
+
+    assert_eq!(distance_habsent(&observed, &forbidden), None);
+}

--- a/huginn-net-db/tests/http_distance_header.rs
+++ b/huginn-net-db/tests/http_distance_header.rs
@@ -207,8 +207,6 @@ fn test_distance_header_expected_value_matches_as_substring() {
 
 #[test]
 fn test_distance_header_expects_value_but_observed_has_none_rejects() {
-    // Observations drop the value of headers p0f prints without one, so a
-    // signature demanding a value can never be satisfied by them.
     let observed = vec![Header::new("Host"), Header::new("User-Agent")];
 
     let signature = vec![Header::new("Host"), Header::new("User-Agent").with_value("Mozilla/5.0")];
@@ -309,8 +307,6 @@ fn test_distance_header_value_mismatch_rejects() {
 
 #[test]
 fn test_distance_header_value_mismatch_rejects_even_when_optional() {
-    // `optional` only covers absence: a header that is present must still
-    // match the expected value.
     let observed = vec![Header::new("Host"), Header::new("Referer").with_value("http://other")];
 
     let signature = vec![

--- a/huginn-net-db/tests/http_distance_header.rs
+++ b/huginn-net-db/tests/http_distance_header.rs
@@ -43,7 +43,7 @@ fn test_distance_header_with_one_optional_header_mismatch() {
     assert_eq!(
         result,
         Some(HttpMatchQuality::High.as_score()),
-        "Expected Medium quality for 1 error in lists of 10"
+        "only the signature's optional flag is consulted, so the observation's differing flag is irrelevant"
     );
 }
 
@@ -94,8 +94,7 @@ fn test_distance_header_multiple_optional_skips() {
 }
 
 #[test]
-fn test_distance_header_required_in_middle_causes_error() {
-    // Required header in middle should cause error and misalignment
+fn test_distance_header_missing_required_header_in_middle_rejects() {
     let observed = vec![Header::new("Host"), Header::new("Connection").with_value("keep-alive")];
 
     let signature = vec![
@@ -105,11 +104,7 @@ fn test_distance_header_required_in_middle_causes_error() {
     ];
 
     let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
-    assert_eq!(
-        result,
-        Some(HttpMatchQuality::High.as_score()), // 1 error falls in High range (0-2 errors)
-        "Required header missing should cause 1 error"
-    );
+    assert_eq!(result, None, "a required header missing rejects the signature outright");
 }
 
 #[test]
@@ -162,7 +157,7 @@ fn test_distance_header_missing_optional_header() {
 }
 
 #[test]
-fn test_distance_header_missing_required_header() {
+fn test_distance_header_missing_required_header_at_end_rejects() {
     let observed = vec![Header::new("Host")];
 
     let signature = vec![
@@ -171,19 +166,16 @@ fn test_distance_header_missing_required_header() {
     ];
 
     let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
-    assert_eq!(
-        result,
-        Some(HttpMatchQuality::High.as_score()), // 1 error out of many
-        "Missing required headers should cause errors"
-    );
+    assert_eq!(result, None, "a required header missing rejects the signature outright");
 }
 
 #[test]
-fn test_distance_header_extra_headers_in_observed() {
+fn test_distance_header_extra_headers_in_observed_are_free() {
     let observed = vec![
         Header::new("Host"),
+        Header::new("X-Custom-Header").with_value("custom"), // Not in the signature
         Header::new("User-Agent").with_value("Mozilla/5.0"),
-        Header::new("X-Custom-Header").with_value("custom"), // Extra header
+        Header::new("X-Another").with_value("trailing"),
     ];
 
     let signature = vec![Header::new("Host"), Header::new("User-Agent").with_value("Mozilla/5.0")];
@@ -191,9 +183,69 @@ fn test_distance_header_extra_headers_in_observed() {
     let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
     assert_eq!(
         result,
-        Some(HttpMatchQuality::High.as_score()), // 1 error for extra header
-        "Extra headers in observed should cause errors"
+        Some(HttpMatchQuality::High.as_score()),
+        "headers the signature does not mention never penalise, wherever they appear"
     );
+}
+
+#[test]
+fn test_distance_header_expected_value_matches_as_substring() {
+    let observed = vec![
+        Header::new("Host"),
+        Header::new("Accept").with_value("image/avif,image/webp,image/*,*/*;q=0.8"),
+    ];
+
+    let signature = vec![Header::new("Host"), Header::new("Accept").with_value("*/*")];
+
+    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
+    assert_eq!(
+        result,
+        Some(HttpMatchQuality::High.as_score()),
+        "the expected value only has to be contained in the observed one"
+    );
+}
+
+#[test]
+fn test_distance_header_expects_value_but_observed_has_none_rejects() {
+    // Observations drop the value of headers p0f prints without one, so a
+    // signature demanding a value can never be satisfied by them.
+    let observed = vec![Header::new("Host"), Header::new("User-Agent")];
+
+    let signature = vec![Header::new("Host"), Header::new("User-Agent").with_value("Mozilla/5.0")];
+
+    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
+    assert_eq!(result, None, "a valueless observed header cannot satisfy an expected value");
+}
+
+#[test]
+fn test_distance_header_optional_header_out_of_order_rejects() {
+    // The signature wants Referer between Host and User-Agent. It does appear
+    // in the traffic, just in the wrong place: p0f treats that as a mismatch
+    // rather than as a missing optional header.
+    let observed = vec![
+        Header::new("Host"),
+        Header::new("User-Agent").with_value("Mozilla/5.0"),
+        Header::new("Referer").with_value("http://example.com"),
+    ];
+
+    let signature = vec![
+        Header::new("Host"),
+        Header::new("Referer").optional(),
+        Header::new("User-Agent").with_value("Mozilla/5.0"),
+    ];
+
+    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
+    assert_eq!(result, None, "an optional header present out of order rejects the signature");
+}
+
+#[test]
+fn test_distance_header_required_header_out_of_order_rejects() {
+    let observed = vec![Header::new("Connection").with_value("keep-alive"), Header::new("Host")];
+
+    let signature = vec![Header::new("Host"), Header::new("Connection").with_value("keep-alive")];
+
+    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
+    assert_eq!(result, None, "header order is part of the signature");
 }
 
 #[test]
@@ -213,23 +265,6 @@ fn test_distance_header_optional_header_at_end() {
         result,
         Some(HttpMatchQuality::High.as_score()),
         "Missing optional headers at end should not cause errors"
-    );
-}
-
-#[test]
-fn test_distance_header_required_header_at_end() {
-    let observed = vec![Header::new("Host")];
-
-    let signature = vec![
-        Header::new("Host"),
-        Header::new("User-Agent").with_value("Mozilla/5.0"), // Required, missing
-    ];
-
-    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
-    assert_eq!(
-        result,
-        Some(HttpMatchQuality::High.as_score()),
-        "Missing required headers should cause 1 error"
     );
 }
 
@@ -260,20 +295,33 @@ fn test_distance_header_observed_vs_signature_with_optional() {
 }
 
 #[test]
-fn test_distance_header_value_mismatch_not_optional() {
+fn test_distance_header_value_mismatch_rejects() {
     let observed = vec![Header::new("Host"), Header::new("Connection").with_value("keep-alive")];
 
     let signature = vec![
         Header::new("Host"),
-        Header::new("Connection").with_value("close"), // Different value, not optional
+        Header::new("Connection").with_value("close"), // Different value
     ];
 
     let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
-    assert_eq!(
-        result,
-        Some(HttpMatchQuality::High.as_score()),
-        "Should have 1 error out of 2 headers"
-    );
+    assert_eq!(result, None, "a value that is not a substring of the observed one rejects");
+}
+
+#[test]
+fn test_distance_header_value_mismatch_rejects_even_when_optional() {
+    // `optional` only covers absence: a header that is present must still
+    // match the expected value.
+    let observed = vec![Header::new("Host"), Header::new("Referer").with_value("http://other")];
+
+    let signature = vec![
+        Header::new("Host"),
+        Header::new("Referer")
+            .optional()
+            .with_value("http://example.com"),
+    ];
+
+    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
+    assert_eq!(result, None, "optional headers that are present must still match their value");
 }
 
 #[test]

--- a/huginn-net-db/tests/http_expsw.rs
+++ b/huginn-net-db/tests/http_expsw.rs
@@ -1,0 +1,132 @@
+#![cfg(feature = "http")]
+//! `expsw` is p0f's "expected software" field: what the matched signature
+//! claims the software is. It is checked *after* a signature wins, and its
+//! only effect is to flag the host as dishonest — never to reject or demote
+//! the signature.
+
+use huginn_net_db::db_matching_trait::DatabaseSignature;
+use huginn_net_db::http::UNKNOWN_SOFTWARE;
+use huginn_net_db::{http, HttpDatabase, HttpSignatureMatcher, SharedHttpSignatureMatcher};
+use huginn_net_http::matcher_api::HttpMatcher;
+use huginn_net_http::observable::HttpRequestObservation;
+use std::sync::Arc;
+
+/// A full `User-Agent` as seen on the wire.
+const CHROME_UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+                         (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36";
+
+/// How the database writes the claim: a short substring, kept anchored at a
+/// token boundary by a leading space.
+const CHROME_EXPSW: &str = " Chrom";
+
+#[test]
+fn observed_software_must_contain_the_signature_claim() {
+    assert!(
+        http::expsw_matches(CHROME_UA, CHROME_EXPSW),
+        "the traffic's User-Agent is the haystack and the signature's claim the needle"
+    );
+    assert!(
+        !http::expsw_matches(CHROME_EXPSW, CHROME_UA),
+        "comparing the other way round can never hold for real traffic"
+    );
+}
+
+#[test]
+fn the_leading_space_keeps_the_claim_on_a_token_boundary() {
+    assert!(!http::expsw_matches("Mozilla/5.0 UnChromed/1.0", CHROME_EXPSW));
+}
+
+#[test]
+fn nothing_to_compare_counts_as_honest() {
+    assert!(
+        http::expsw_matches(CHROME_UA, ""),
+        "a signature that claims nothing cannot be contradicted"
+    );
+    assert!(
+        http::expsw_matches("", CHROME_EXPSW),
+        "traffic that says nothing makes no claim to check"
+    );
+    assert!(
+        http::expsw_matches(UNKNOWN_SOFTWARE, CHROME_EXPSW),
+        "the absent-header placeholder is not a literal claim"
+    );
+}
+
+#[test]
+fn a_contradicting_software_string_is_dishonest() {
+    assert!(!http::expsw_matches("Mozilla/5.0 Firefox/128.0", CHROME_EXPSW));
+}
+
+/// The point of taking `expsw` out of the distance: two observations that
+/// differ *only* in their software string must be equally good matches.
+#[test]
+fn software_string_does_not_change_the_distance() {
+    let db = HttpDatabase::load_default()
+        .unwrap_or_else(|e| panic!("failed to create default database: {e}"));
+
+    let observation = |expsw: &str| HttpRequestObservation {
+        version: http::Version::V10,
+        horder: vec![
+            http::Header::new("Host"),
+            http::Header::new("User-Agent"),
+            http::Header::new("Accept").with_value(",*/*;q="),
+            http::Header::new("Accept-Language").optional(),
+            http::Header::new("Accept-Encoding").with_value("gzip,deflate"),
+            http::Header::new("Accept-Charset").with_value("utf-8;q=0.7,*;q=0.7"),
+            http::Header::new("Keep-Alive").with_value("300"),
+            http::Header::new("Connection").with_value("keep-alive"),
+        ],
+        habsent: vec![],
+        expsw: expsw.to_string(),
+    };
+
+    let matcher = HttpSignatureMatcher::new(&db);
+    let (_label, signature, honest_quality) = matcher
+        .matching_by_http_request(&observation("Firefox/"))
+        .unwrap_or_else(|| panic!("no match found for the Firefox 2.x signature"));
+
+    let honest = signature.calculate_distance(&observation("Firefox/"));
+    let lying = signature.calculate_distance(&observation("definitely-not-firefox"));
+    assert_eq!(honest, lying, "expsw must not contribute to the distance");
+
+    let (_label, _signature, lying_quality) = matcher
+        .matching_by_http_request(&observation("definitely-not-firefox"))
+        .unwrap_or_else(|| panic!("a dishonest software string must not reject the signature"));
+    assert_eq!(honest_quality, lying_quality);
+}
+
+/// The flag rides along with the match, because it takes the winning
+/// signature to know what was claimed.
+#[test]
+fn the_match_reports_whether_the_host_is_dishonest() {
+    let db = HttpDatabase::load_default()
+        .unwrap_or_else(|e| panic!("failed to create default database: {e}"));
+    let matcher = SharedHttpSignatureMatcher::new(Arc::new(db));
+
+    let observation = |expsw: &str| HttpRequestObservation {
+        version: http::Version::V10,
+        horder: vec![
+            http::Header::new("Host"),
+            http::Header::new("User-Agent"),
+            http::Header::new("Accept").with_value(",*/*;q="),
+            http::Header::new("Accept-Language").optional(),
+            http::Header::new("Accept-Encoding").with_value("gzip,deflate"),
+            http::Header::new("Accept-Charset").with_value("utf-8;q=0.7,*;q=0.7"),
+            http::Header::new("Keep-Alive").with_value("300"),
+            http::Header::new("Connection").with_value("keep-alive"),
+        ],
+        habsent: vec![],
+        expsw: expsw.to_string(),
+    };
+
+    let honest = matcher
+        .match_http_request(&observation("Mozilla/5.0 Firefox/2.0.0.1"))
+        .unwrap_or_else(|| panic!("expected a match for the honest request"));
+    assert!(!honest.dishonest);
+
+    let lying = matcher
+        .match_http_request(&observation("Mozilla/5.0 Chrome/137.0.0.0"))
+        .unwrap_or_else(|| panic!("expected the same match for the lying request"));
+    assert_eq!(lying.browser.name, honest.browser.name, "same headers, same browser");
+    assert!(lying.dishonest, "headers say Firefox 2.x but the User-Agent says Chrome");
+}

--- a/huginn-net-db/tests/http_expsw.rs
+++ b/huginn-net-db/tests/http_expsw.rs
@@ -1,8 +1,4 @@
 #![cfg(feature = "http")]
-//! `expsw` is p0f's "expected software" field: what the matched signature
-//! claims the software is. It is checked *after* a signature wins, and its
-//! only effect is to flag the host as dishonest — never to reject or demote
-//! the signature.
 
 use huginn_net_db::db_matching_trait::DatabaseSignature;
 use huginn_net_db::http::UNKNOWN_SOFTWARE;
@@ -11,12 +7,9 @@ use huginn_net_http::matcher_api::HttpMatcher;
 use huginn_net_http::observable::HttpRequestObservation;
 use std::sync::Arc;
 
-/// A full `User-Agent` as seen on the wire.
 const CHROME_UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
                          (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36";
 
-/// How the database writes the claim: a short substring, kept anchored at a
-/// token boundary by a leading space.
 const CHROME_EXPSW: &str = " Chrom";
 
 #[test]
@@ -57,8 +50,6 @@ fn a_contradicting_software_string_is_dishonest() {
     assert!(!http::expsw_matches("Mozilla/5.0 Firefox/128.0", CHROME_EXPSW));
 }
 
-/// The point of taking `expsw` out of the distance: two observations that
-/// differ *only* in their software string must be equally good matches.
 #[test]
 fn software_string_does_not_change_the_distance() {
     let db = HttpDatabase::load_default()
@@ -95,8 +86,6 @@ fn software_string_does_not_change_the_distance() {
     assert_eq!(honest_quality, lying_quality);
 }
 
-/// The flag rides along with the match, because it takes the winning
-/// signature to know what was claimed.
 #[test]
 fn the_match_reports_whether_the_host_is_dishonest() {
     let db = HttpDatabase::load_default()

--- a/huginn-net-db/tests/http_matcher.rs
+++ b/huginn-net-db/tests/http_matcher.rs
@@ -84,8 +84,19 @@ fn matching_apache_by_http_response() {
     }
 }
 
+/// p0f.fp's Chrome signatures date from ~2012 and require
+/// `Accept-Encoding=[gzip,deflate,sdch]` plus an `Accept-Charset`; a current
+/// Chrome sends neither (`sdch` was dropped around 2016). Header matching is
+/// all-or-nothing in p0f, and the `[http:request]` section has no generic
+/// catch-all, so a modern Chrome request is simply not covered by the
+/// bundled database.
+///
+/// Before header matching became faithful to p0f, an error budget let this
+/// request match the old Chrome signature with 4 mismatched headers, which
+/// happened to yield a plausible label ("11 or newer") from a signature the
+/// traffic did not actually match.
 #[test]
-fn matching_android_chrome_by_http_request() {
+fn modern_chrome_request_is_not_covered_by_bundled_signatures() {
     let db = match HttpDatabase::load_default() {
         Ok(db) => db,
         Err(e) => panic!("Failed to create default database: {e}"),
@@ -110,16 +121,12 @@ fn matching_android_chrome_by_http_request() {
 
     let matcher = HttpSignatureMatcher::new(&db);
 
-    match matcher.matching_by_http_request(&android_chrome_signature) {
-        Some((label, _matched_db_sig, quality)) => {
-            assert_eq!(label.name, "Chrome");
-            assert_eq!(label.class, None);
-            assert_eq!(label.flavor, Some("11 or newer".to_string()));
-            assert_eq!(label.ty, Type::Specified);
-            assert_eq!(quality, 0.7);
-        }
-        None => panic!("No HTTP match found for Android Chrome signature"),
-    }
+    assert!(
+        matcher
+            .matching_by_http_request(&android_chrome_signature)
+            .is_none(),
+        "no bundled signature describes this request, so it must not be labelled"
+    );
 }
 
 #[test]

--- a/huginn-net-db/tests/http_matcher.rs
+++ b/huginn-net-db/tests/http_matcher.rs
@@ -84,6 +84,46 @@ fn matching_apache_by_http_response() {
     }
 }
 
+#[test]
+fn matching_chrome11_by_http_request() {
+    let db = match HttpDatabase::load_default() {
+        Ok(db) => db,
+        Err(e) => panic!("Failed to create default database: {e}"),
+    };
+
+    // Layout from p0f.fp `Chrome:11 or newer` (2012): sdch + Accept-Charset.
+    let chrome_signature = HttpRequestObservation {
+        version: http::Version::V11,
+        horder: vec![
+            http::Header::new("Host"),
+            http::Header::new("Connection").with_value("keep-alive"),
+            http::Header::new("User-Agent"),
+            http::Header::new("Accept").with_value("*/*"),
+            http::Header::new("Accept-Encoding").with_value("gzip,deflate,sdch"),
+            http::Header::new("Accept-Language"),
+            http::Header::new("Accept-Charset").with_value("utf-8;q=0.7,*;q=0.3"),
+        ],
+        habsent: vec![],
+        expsw: "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.7 \
+                (KHTML, like Gecko) Chrome/16.0.912.75 Safari/535.7"
+            .to_string(),
+    };
+
+    let matcher = HttpSignatureMatcher::new(&db);
+
+    if let Some((label, _matched_db_sig, quality)) =
+        matcher.matching_by_http_request(&chrome_signature)
+    {
+        assert_eq!(label.name, "Chrome");
+        assert_eq!(label.class, None);
+        assert_eq!(label.flavor, Some("11 or newer".to_string()));
+        assert_eq!(label.ty, Type::Specified);
+        assert_eq!(quality, 1.0);
+    } else {
+        panic!("No match found for Chrome 11 HTTP signature");
+    }
+}
+
 /// p0f.fp's Chrome signatures date from ~2012 and require
 /// `Accept-Encoding=[gzip,deflate,sdch]` plus an `Accept-Charset`; a current
 /// Chrome sends neither (`sdch` was dropped around 2016). Header matching is

--- a/huginn-net-db/tests/http_pcap_golden.rs
+++ b/huginn-net-db/tests/http_pcap_golden.rs
@@ -34,6 +34,7 @@ struct EndpointSnapshot {
 struct HttpRequestSnapshot {
     browser: Option<String>,
     quality: Option<String>,
+    params: Option<String>,
     lang: Option<String>,
     user_agent: Option<String>,
     method: Option<String>,
@@ -44,6 +45,7 @@ struct HttpRequestSnapshot {
 struct HttpResponseSnapshot {
     web_server: Option<String>,
     quality: Option<String>,
+    params: Option<String>,
     status_code: Option<u16>,
     headers_count: usize,
 }
@@ -141,6 +143,14 @@ fn assert_connection(actual: &HttpAnalysisResult, expected: &ConnectionSnapshot,
             );
         }
 
+        if let Some(expected_params) = &exp_req.params {
+            assert_eq!(
+                &req.params.to_string(),
+                expected_params,
+                "connection {idx}: request params"
+            );
+        }
+
         if let Some(expected_lang) = &exp_req.lang {
             assert_eq!(
                 req.lang
@@ -224,6 +234,14 @@ fn assert_connection(actual: &HttpAnalysisResult, expected: &ConnectionSnapshot,
                 &resp.web_server_matched.quality,
                 expected_quality,
                 &format!("connection {idx} response"),
+            );
+        }
+
+        if let Some(expected_params) = &exp_resp.params {
+            assert_eq!(
+                &resp.params.to_string(),
+                expected_params,
+                "connection {idx}: response params"
             );
         }
 

--- a/huginn-net-db/tests/snapshots/http-simple-get.json
+++ b/huginn-net-db/tests/snapshots/http-simple-get.json
@@ -15,7 +15,8 @@
       "http_request": {
         "browser": "curl",
         "lang": null,
-        "quality": "Matched(0.8)",
+        "quality": "Matched(1.0)",
+        "params": "none",
         "user_agent": "curl/7.24.0 (x86_64-apple-darwin12.0) libcurl/7.24.0 OpenSSL/0.9.8y zlib/1.2.5",
         "method": "GET",
         "uri": "/"
@@ -34,7 +35,8 @@
       "http_request": null,
       "http_response": {
         "web_server": "Apache",
-        "quality": "Matched(0.8)",
+        "quality": "Matched(1.0)",
+        "params": "none",
         "status_code": 403,
         "headers_count": 6
       }

--- a/huginn-net-http/src/http/common.rs
+++ b/huginn-net-http/src/http/common.rs
@@ -1,4 +1,4 @@
-use super::{HttpDiagnosis, Version};
+use super::{HttpParams, Version};
 use std::collections::HashMap;
 use std::time::Instant;
 
@@ -130,41 +130,26 @@ pub trait HttpProcessor {
     fn name(&self) -> &'static str;
 }
 
-/// HTTP diagnostic function - determines the relationship between User-Agent and an
-/// externally-observed OS signal.
-///
-/// This function compares the OS family reported by the User-Agent string against an
-/// OS name observed from the network (typically obtained from TCP fingerprinting by the
-/// caller, but this crate is intentionally agnostic about the source). A mismatch
-/// between the two is a hint of potential spoofing.
+/// Build the [`HttpParams`] notes for a matched (or unmatched) observation.
 ///
 /// # Arguments
-/// * `user_agent` - Optional User-Agent string from HTTP headers
-/// * `ua_os_family` - OS family resolved from the User-Agent (UA→OS mapping in the database)
-/// * `network_os_name` - OS name observed from another source (e.g. TCP fingerprinting).
-///   `huginn-net-http` does not know how this was produced; it just compares strings.
+/// * `software` - the observation's `expsw`, i.e. the `User-Agent` or `Server`
+///   value, or [`UNKNOWN_SOFTWARE`] when the header was absent
+/// * `matched` - `None` when no signature matched; otherwise whether the
+///   matched signature was a generic catch-all and whether its declared
+///   software contradicts the traffic
 ///
-/// # Returns
-/// * `HttpDiagnosis::Anonymous` - No User-Agent provided
-/// * `HttpDiagnosis::Generic` - User-Agent OS matches the externally observed OS
-/// * `HttpDiagnosis::Dishonest` - User-Agent OS differs from the externally observed OS (potential spoofing)
-/// * `HttpDiagnosis::None` - Insufficient data for comparison
-pub fn get_diagnostic(
-    user_agent: Option<String>,
-    ua_os_family: Option<&str>,
-    network_os_name: Option<&str>,
-) -> HttpDiagnosis {
-    match user_agent {
-        None => HttpDiagnosis::Anonymous,
-        Some(_ua) => match (ua_os_family, network_os_name) {
-            (Some(ua_name), Some(net_name)) => {
-                if ua_name.eq_ignore_ascii_case(net_name) {
-                    HttpDiagnosis::Generic
-                } else {
-                    HttpDiagnosis::Dishonest
-                }
-            }
-            _ => HttpDiagnosis::None,
-        },
+/// [`UNKNOWN_SOFTWARE`]: crate::http::UNKNOWN_SOFTWARE
+pub fn build_params(software: &str, matched: Option<MatchedSignatureNotes>) -> HttpParams {
+    HttpParams {
+        dishonest: matched.as_ref().is_some_and(|m| m.dishonest),
+        anonymous: software.is_empty() || software == super::UNKNOWN_SOFTWARE,
+        generic: matched.as_ref().is_some_and(|m| m.generic),
     }
+}
+
+/// What the winning signature contributes to [`HttpParams`].
+pub struct MatchedSignatureNotes {
+    pub dishonest: bool,
+    pub generic: bool,
 }

--- a/huginn-net-http/src/http/mod.rs
+++ b/huginn-net-http/src/http/mod.rs
@@ -3,8 +3,8 @@ pub mod languages;
 pub mod observable;
 
 pub use common::{
-    get_diagnostic, HeaderSource, HttpCookie, HttpHeader, HttpParser, HttpProcessor,
-    ParsingMetadata,
+    build_params, HeaderSource, HttpCookie, HttpHeader, HttpParser, HttpProcessor,
+    MatchedSignatureNotes, ParsingMetadata,
 };
 pub use languages::get_highest_quality_language;
 pub use observable::*;
@@ -110,24 +110,52 @@ impl core::fmt::Display for Header {
     }
 }
 
-/// HTTP diagnostic flags derived from comparing User-Agent claims with the
-/// matched OS signature.
-#[derive(Clone, Debug, PartialEq)]
-pub enum HttpDiagnosis {
-    Dishonest,
-    Anonymous,
-    Generic,
-    None,
+/// Notes about a matched HTTP signature, mirroring p0f's `params` field.
+///
+/// These are independent observations, not a single verdict: a host can be
+/// dishonest *and* have matched a generic signature, and p0f reports both.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct HttpParams {
+    /// The `User-Agent`/`Server` string does not back up the software the
+    /// matched signature declares, so the host is claiming to be something
+    /// its header layout says it is not.
+    pub dishonest: bool,
+    /// The traffic carried no `User-Agent` (request) or `Server` (response)
+    /// at all, so there was no claim to check.
+    pub anonymous: bool,
+    /// The signature that matched is a catch-all, so the label names a family
+    /// rather than a precise product.
+    pub generic: bool,
 }
 
-impl core::fmt::Display for HttpDiagnosis {
+impl HttpParams {
+    /// Whether nothing worth reporting was found.
+    pub fn is_empty(&self) -> bool {
+        !self.dishonest && !self.anonymous && !self.generic
+    }
+}
+
+impl core::fmt::Display for HttpParams {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str(match self {
-            HttpDiagnosis::Dishonest => "dishonest",
-            HttpDiagnosis::Anonymous => "anonymous",
-            HttpDiagnosis::Generic => "generic",
-            HttpDiagnosis::None => "none",
-        })
+        if self.is_empty() {
+            return f.write_str("none");
+        }
+
+        let mut first = true;
+        for (flag, name) in [
+            (self.dishonest, "dishonest"),
+            (self.anonymous, "anonymous"),
+            (self.generic, "generic"),
+        ] {
+            if flag {
+                if !first {
+                    f.write_str(" ")?;
+                }
+                f.write_str(name)?;
+                first = false;
+            }
+        }
+        Ok(())
     }
 }
 

--- a/huginn-net-http/src/http/observable.rs
+++ b/huginn-net-http/src/http/observable.rs
@@ -3,6 +3,13 @@ use super::{Header, Version};
 use core::fmt;
 use std::fmt::Formatter;
 
+/// Placeholder an observation carries in `expsw` when the traffic had no
+/// `User-Agent` (request) or `Server` (response) header at all.
+///
+/// p0f leaves the field empty in that case; code comparing software strings
+/// must treat this value as "nothing to compare", not as a literal claim.
+pub const UNKNOWN_SOFTWARE: &str = "???";
+
 /// Observed HTTP request characteristics extracted from network traffic.
 ///
 /// `huginn-net-http` defines this type so the crate stays independent of any

--- a/huginn-net-http/src/matcher_api.rs
+++ b/huginn-net-http/src/matcher_api.rs
@@ -10,22 +10,20 @@ use crate::observable::{HttpRequestObservation, HttpResponseObservation};
 use crate::output::{Browser, WebServer};
 
 /// Result of matching an [`HttpRequestObservation`] against a database.
+/// `dishonest` is set when the User-Agent does not back the matched signature.
 #[derive(Debug, Clone)]
 pub struct HttpRequestMatch {
     pub browser: Browser,
     pub quality: f32,
-    /// The `User-Agent` in the traffic does not back up the software the
-    /// matched signature declares. Decided together with the match, since it
-    /// takes the winning signature to know what was claimed.
     pub dishonest: bool,
 }
 
 /// Result of matching an [`HttpResponseObservation`] against a database.
+/// `dishonest` is set when the Server header does not back the matched signature.
 #[derive(Debug, Clone)]
 pub struct HttpResponseMatch {
     pub web_server: WebServer,
     pub quality: f32,
-    /// Same as [`HttpRequestMatch::dishonest`], for the `Server` header.
     pub dishonest: bool,
 }
 

--- a/huginn-net-http/src/matcher_api.rs
+++ b/huginn-net-http/src/matcher_api.rs
@@ -14,6 +14,10 @@ use crate::output::{Browser, WebServer};
 pub struct HttpRequestMatch {
     pub browser: Browser,
     pub quality: f32,
+    /// The `User-Agent` in the traffic does not back up the software the
+    /// matched signature declares. Decided together with the match, since it
+    /// takes the winning signature to know what was claimed.
+    pub dishonest: bool,
 }
 
 /// Result of matching an [`HttpResponseObservation`] against a database.
@@ -21,6 +25,8 @@ pub struct HttpRequestMatch {
 pub struct HttpResponseMatch {
     pub web_server: WebServer,
     pub quality: f32,
+    /// Same as [`HttpRequestMatch::dishonest`], for the `Server` header.
+    pub dishonest: bool,
 }
 
 /// Result of mapping a User-Agent string against the database's UA→OS table.

--- a/huginn-net-http/src/output/request.rs
+++ b/huginn-net-http/src/output/request.rs
@@ -1,5 +1,5 @@
 use super::common::{Browser, IpPort, MatchQuality};
-use crate::http::HttpDiagnosis;
+use crate::http::HttpParams;
 use crate::observable::ObservableHttpRequest;
 use std::fmt;
 use std::fmt::Formatter;
@@ -21,9 +21,11 @@ pub struct HttpRequestOutput {
     pub destination: IpPort,
     /// The preferred language indicated in the `Accept-Language` header, if present.
     pub lang: Option<String>,
-    /// Diagnostic information about potential HTTP specification violations or common practices.
+    /// Notes about the matched signature: whether the host is lying about its
+    /// software, whether it identified itself at all, and whether the match
+    /// was a generic catch-all.
     #[cfg_attr(feature = "json", serde(serialize_with = "super::serialize_display"))]
-    pub diagnosis: HttpDiagnosis,
+    pub params: HttpParams,
     /// The browser with the highest quality that matches the HTTP request.
     pub browser_matched: BrowserQualityMatched,
     /// The raw signature representing the HTTP headers and their order.
@@ -55,7 +57,7 @@ impl fmt::Display for HttpRequestOutput {
                     )
                 }),
             self.lang.as_deref().unwrap_or("???"),
-            self.diagnosis,
+            self.params,
             self.sig,
         )
     }

--- a/huginn-net-http/src/output/response.rs
+++ b/huginn-net-http/src/output/response.rs
@@ -1,5 +1,5 @@
 use super::common::{IpPort, MatchQuality, WebServer};
-use crate::http::HttpDiagnosis;
+use crate::http::HttpParams;
 use crate::observable::ObservableHttpResponse;
 use std::fmt;
 use std::fmt::Formatter;
@@ -19,9 +19,11 @@ pub struct HttpResponseOutput {
     pub source: IpPort,
     /// The destination IP address and port of the client receiving the response.
     pub destination: IpPort,
-    /// Diagnostic information about potential HTTP specification violations or common practices.
+    /// Notes about the matched signature: whether the server is lying about
+    /// its software, whether it identified itself at all, and whether the
+    /// match was a generic catch-all.
     #[cfg_attr(feature = "json", serde(serialize_with = "super::serialize_display"))]
-    pub diagnosis: HttpDiagnosis,
+    pub params: HttpParams,
     /// The label identifying the likely server application (e.g., Apache, Nginx) and the quality.
     pub web_server_matched: WebServerQualityMatched,
     /// The raw signature representing the HTTP headers and their order.
@@ -55,7 +57,7 @@ impl fmt::Display for HttpResponseOutput {
                         )
                     }
                 }),
-            self.diagnosis,
+            self.params,
             self.sig,
         )
     }

--- a/huginn-net-http/src/process/mod.rs
+++ b/huginn-net-http/src/process/mod.rs
@@ -6,16 +6,16 @@ pub use parallel::{DispatchResult, PoolStats, SharedHttpMatcher, WorkerPool, Wor
 
 use self::flow as http_process;
 use crate::error::HuginnNetHttpError;
-#[cfg(feature = "p0f-response")]
-use crate::http::HttpDiagnosis;
-use crate::matcher_api::HttpMatcher;
 #[cfg(any(feature = "p0f-request", feature = "p0f-response"))]
-use crate::output::MatchQuality;
+use crate::http::{build_params, MatchedSignatureNotes};
+use crate::matcher_api::HttpMatcher;
 #[cfg(feature = "p0f-request")]
 use crate::output::{BrowserQualityMatched, HttpRequestOutput};
 use crate::output::{HttpAnalysisResult, IpPort};
 #[cfg(feature = "p0f-response")]
 use crate::output::{HttpResponseOutput, WebServerQualityMatched};
+#[cfg(any(feature = "p0f-request", feature = "p0f-response"))]
+use crate::output::{MatchQuality, OsKind};
 use pnet::packet::ipv4::Ipv4Packet;
 use pnet::packet::ipv6::Ipv6Packet;
 use pnet::packet::tcp::TcpPacket;
@@ -112,53 +112,36 @@ fn build_http_result(
 
     #[cfg(feature = "p0f-request")]
     if let Some(http_request) = http_package.http_request {
-        let (browser_quality, ua_os_family) = match matcher {
+        let (browser_quality, notes) = match matcher {
             Some(m) => match m.match_http_request(&http_request.matching) {
                 Some(req_match) => {
-                    let ua_family = http_request
-                        .user_agent
-                        .as_deref()
-                        .and_then(|ua| m.match_user_agent(ua))
-                        .map(|um| um.family);
+                    let notes = MatchedSignatureNotes {
+                        dishonest: req_match.dishonest,
+                        generic: req_match.browser.kind == OsKind::Generic,
+                    };
                     (
                         BrowserQualityMatched {
                             browser: Some(req_match.browser),
                             quality: MatchQuality::Matched(req_match.quality),
                         },
-                        ua_family,
+                        Some(notes),
                     )
                 }
-                None => {
-                    let ua_family = http_request
-                        .user_agent
-                        .as_deref()
-                        .and_then(|ua| m.match_user_agent(ua))
-                        .map(|um| um.family);
-                    (
-                        BrowserQualityMatched { browser: None, quality: MatchQuality::NotMatched },
-                        ua_family,
-                    )
-                }
+                None => (
+                    BrowserQualityMatched { browser: None, quality: MatchQuality::NotMatched },
+                    None,
+                ),
             },
             None => {
                 (BrowserQualityMatched { browser: None, quality: MatchQuality::Disabled }, None)
             }
         };
 
-        // TODO: (p0f-parity) https://github.com/biandratti/huginn-net/issues/278.
-        let network_os_name = browser_quality.browser.as_ref().map(|b| b.name.clone());
-
-        let diagnosis = crate::http::common::get_diagnostic(
-            http_request.user_agent.clone(),
-            ua_os_family.as_deref(),
-            network_os_name.as_deref(),
-        );
-
         let request_output = HttpRequestOutput {
             source: source.clone(),
             destination: destination.clone(),
             lang: http_request.lang.clone(),
-            diagnosis,
+            params: build_params(&http_request.matching.expsw, notes),
             browser_matched: browser_quality,
             sig: http_request,
         };
@@ -167,23 +150,36 @@ fn build_http_result(
 
     #[cfg(feature = "p0f-response")]
     if let Some(http_response) = http_package.http_response {
-        let web_server_quality = match matcher {
+        let (web_server_quality, notes) = match matcher {
             Some(m) => match m.match_http_response(&http_response.matching) {
-                Some(resp_match) => WebServerQualityMatched {
-                    web_server: Some(resp_match.web_server),
-                    quality: MatchQuality::Matched(resp_match.quality),
-                },
-                None => {
-                    WebServerQualityMatched { web_server: None, quality: MatchQuality::NotMatched }
+                Some(resp_match) => {
+                    let notes = MatchedSignatureNotes {
+                        dishonest: resp_match.dishonest,
+                        generic: resp_match.web_server.kind == OsKind::Generic,
+                    };
+                    (
+                        WebServerQualityMatched {
+                            web_server: Some(resp_match.web_server),
+                            quality: MatchQuality::Matched(resp_match.quality),
+                        },
+                        Some(notes),
+                    )
                 }
+                None => (
+                    WebServerQualityMatched { web_server: None, quality: MatchQuality::NotMatched },
+                    None,
+                ),
             },
-            None => WebServerQualityMatched { web_server: None, quality: MatchQuality::Disabled },
+            None => (
+                WebServerQualityMatched { web_server: None, quality: MatchQuality::Disabled },
+                None,
+            ),
         };
 
         let response_output = HttpResponseOutput {
             source,
             destination,
-            diagnosis: HttpDiagnosis::None,
+            params: build_params(&http_response.matching.expsw, notes),
             web_server_matched: web_server_quality,
             sig: http_response,
         };

--- a/huginn-net-http/tests/http1_process.rs
+++ b/huginn-net-http/tests/http1_process.rs
@@ -124,8 +124,6 @@ fn test_params_combine_because_p0f_reports_them_together() {
 
 #[test]
 fn test_params_without_a_match_cannot_be_dishonest_or_generic() {
-    // Both notes come from the winning signature, so with no match the only
-    // thing left to say is whether the client identified itself.
     let params = http_common::build_params("Mozilla/5.0", None);
 
     assert!(params.is_empty());

--- a/huginn-net-http/tests/http1_process.rs
+++ b/huginn-net-http/tests/http1_process.rs
@@ -89,37 +89,46 @@ fn test_parse_http1_response() {
 }
 
 #[test]
-fn test_get_diagnostic_for_empty_sw() {
-    let diagnosis: http::HttpDiagnosis = http_common::get_diagnostic(None, None, None);
-    assert_eq!(diagnosis, http::HttpDiagnosis::Anonymous);
+fn test_params_without_software_are_anonymous() {
+    let params = http_common::build_params(http::UNKNOWN_SOFTWARE, None);
+
+    assert_eq!(params, http::HttpParams { dishonest: false, anonymous: true, generic: false });
+    assert_eq!(params.to_string(), "anonymous");
 }
 
 #[test]
-fn test_get_diagnostic_with_existing_signature_matcher() {
-    let user_agent: Option<String> = Some("Mozilla/5.0".to_string());
-    let ua_os_family = Some("Linux");
-    let network_os_name = Some("Linux");
+fn test_params_are_empty_when_nothing_stands_out() {
+    let notes = http_common::MatchedSignatureNotes { dishonest: false, generic: false };
+    let params = http_common::build_params("Mozilla/5.0", Some(notes));
 
-    let diagnosis = http_common::get_diagnostic(user_agent, ua_os_family, network_os_name);
-    assert_eq!(diagnosis, http::HttpDiagnosis::Generic);
+    assert!(params.is_empty());
+    assert_eq!(params.to_string(), "none");
 }
 
 #[test]
-fn test_get_diagnostic_with_dishonest_user_agent() {
-    let user_agent = Some("Mozilla/5.0".to_string());
-    let ua_os_family = Some("Windows");
-    let network_os_name = Some("Linux");
+fn test_params_report_a_dishonest_software_string() {
+    let notes = http_common::MatchedSignatureNotes { dishonest: true, generic: false };
+    let params = http_common::build_params("Mozilla/5.0", Some(notes));
 
-    let diagnosis = http_common::get_diagnostic(user_agent, ua_os_family, network_os_name);
-    assert_eq!(diagnosis, http::HttpDiagnosis::Dishonest);
+    assert_eq!(params, http::HttpParams { dishonest: true, anonymous: false, generic: false });
+    assert_eq!(params.to_string(), "dishonest");
 }
 
 #[test]
-fn test_get_diagnostic_without_user_agent_and_signature_matcher() {
-    let user_agent = Some("Mozilla/5.0".to_string());
+fn test_params_combine_because_p0f_reports_them_together() {
+    let notes = http_common::MatchedSignatureNotes { dishonest: true, generic: true };
+    let params = http_common::build_params(http::UNKNOWN_SOFTWARE, Some(notes));
 
-    let diagnosis = http_common::get_diagnostic(user_agent, None, None);
-    assert_eq!(diagnosis, http::HttpDiagnosis::None);
+    assert_eq!(params.to_string(), "dishonest anonymous generic");
+}
+
+#[test]
+fn test_params_without_a_match_cannot_be_dishonest_or_generic() {
+    // Both notes come from the winning signature, so with no match the only
+    // thing left to say is whether the client identified itself.
+    let params = http_common::build_params("Mozilla/5.0", None);
+
+    assert!(params.is_empty());
 }
 
 #[test]

--- a/huginn-net-http/tests/http2_process.rs
+++ b/huginn-net-http/tests/http2_process.rs
@@ -69,19 +69,17 @@ fn test_http2_response_conversion() {
 }
 
 #[test]
-fn test_get_diagnostic_for_http2() {
-    let diagnosis = http_common::get_diagnostic(None, None, None);
-    assert_eq!(diagnosis, http::HttpDiagnosis::Anonymous);
+fn test_params_for_http2_without_software() {
+    let params = http_common::build_params(http::UNKNOWN_SOFTWARE, None);
+    assert!(params.anonymous);
 }
 
 #[test]
-fn test_get_diagnostic_with_http2_user_agent() {
-    let user_agent = Some("Mozilla/5.0 HTTP/2.0".to_string());
-    let ua_os_family = Some("Linux");
-    let network_os_name = Some("Linux");
+fn test_params_for_http2_with_user_agent() {
+    let notes = http_common::MatchedSignatureNotes { dishonest: false, generic: false };
+    let params = http_common::build_params("Mozilla/5.0 HTTP/2.0", Some(notes));
 
-    let diagnosis = http_common::get_diagnostic(user_agent, ua_os_family, network_os_name);
-    assert_eq!(diagnosis, http::HttpDiagnosis::Generic);
+    assert!(params.is_empty());
 }
 
 #[test]

--- a/huginn-net-http/tests/http2_process.rs
+++ b/huginn-net-http/tests/http2_process.rs
@@ -83,6 +83,26 @@ fn test_params_for_http2_with_user_agent() {
 }
 
 #[test]
+fn test_params_for_http2_generic() {
+    let notes = http_common::MatchedSignatureNotes { dishonest: false, generic: true };
+    let params = http_common::build_params("Mozilla/5.0 HTTP/2.0", Some(notes));
+
+    assert!(params.generic);
+    assert!(!params.dishonest);
+    assert!(!params.anonymous);
+}
+
+#[test]
+fn test_params_for_http2_dishonest() {
+    let notes = http_common::MatchedSignatureNotes { dishonest: true, generic: false };
+    let params = http_common::build_params("Mozilla/5.0 HTTP/2.0", Some(notes));
+
+    assert!(params.dishonest);
+    assert!(!params.generic);
+    assert!(!params.anonymous);
+}
+
+#[test]
 fn test_no_preface() {
     let data = b"GET /path HTTP/1.1\r\n";
     assert!(!has_complete_data(data));

--- a/huginn-net-http/tests/process_flow.rs
+++ b/huginn-net-http/tests/process_flow.rs
@@ -85,7 +85,7 @@ fn test_parse_http1_response() {
 }
 
 #[test]
-fn test_get_diagnostic_for_empty_sw() {
-    let diagnosis: http::HttpDiagnosis = http_common::get_diagnostic(None, None, None);
-    assert_eq!(diagnosis, http::HttpDiagnosis::Anonymous);
+fn test_params_for_empty_sw() {
+    let params: http::HttpParams = http_common::build_params("", None);
+    assert!(params.anonymous);
 }

--- a/huginn-net/src/analyzer/matchers.rs
+++ b/huginn-net/src/analyzer/matchers.rs
@@ -1,6 +1,6 @@
 use super::HuginnNet;
-#[cfg(feature = "http-p0f-request")]
-use huginn_net_http::http::HttpDiagnosis;
+#[cfg(any(feature = "http-p0f-request", feature = "http-p0f-response"))]
+use huginn_net_http::http::{build_params, HttpParams, MatchedSignatureNotes};
 #[cfg(feature = "http-p0f-request")]
 use huginn_net_http::observable::ObservableHttpRequest;
 #[cfg(feature = "http-p0f-response")]
@@ -56,7 +56,14 @@ use crate::AnalysisConfig;
 #[cfg(feature = "http-p0f-request")]
 pub(super) struct HttpRequestMatchResult {
     pub(super) browser_quality: BrowserQualityMatched,
-    pub(super) http_diagnosis: HttpDiagnosis,
+    pub(super) params: HttpParams,
+}
+
+/// Same, for responses.
+#[cfg(feature = "http-p0f-response")]
+pub(super) struct HttpResponseMatchResult {
+    pub(super) web_server_quality: WebServerQualityMatched,
+    pub(super) params: HttpParams,
 }
 
 /// Compute the connection-tracker and HTTP flow cache sizes based on which
@@ -170,67 +177,65 @@ impl<'a> HuginnNet<'a> {
     ) -> HttpRequestMatchResult {
         #[cfg(feature = "db")]
         {
-            let (signature_matcher, ua_matcher, browser_quality) = quality_match!(
+            let observed = &observable_http_request.matching;
+            let (browser_quality, notes) = quality_match!(
                 enabled: self.config.matcher_enabled,
                 matcher: self.http_matcher,
-                call: matcher => {
-                    let sig_match = matcher.matching_by_http_request(&observable_http_request.matching);
-                    let ua_match = observable_http_request.user_agent.clone()
-                        .and_then(|ua| matcher.matching_by_user_agent(&ua));
-                    Some((sig_match, ua_match))
-                },
-                matched: (signature_matcher, ua_matcher) => {
-                    let browser_quality = signature_matcher
-                        .map(|(label, _signature, quality)| BrowserQualityMatched {
-                            browser: Some(Browser::from(label)),
-                            quality: HttpMatchQuality::Matched(quality),
+                call: matcher => Some(matcher.matching_by_http_request(observed)),
+                matched: signature_matcher => {
+                    signature_matcher
+                        .map(|(label, signature, quality)| {
+                            let notes = MatchedSignatureNotes {
+                                dishonest: !huginn_net_db::http::expsw_matches(
+                                    &observed.expsw,
+                                    &signature.expsw,
+                                ),
+                                generic: label.ty == huginn_net_db::database::Type::Generic,
+                            };
+                            (
+                                BrowserQualityMatched {
+                                    browser: Some(Browser::from(label)),
+                                    quality: HttpMatchQuality::Matched(quality),
+                                },
+                                Some(notes),
+                            )
                         })
-                        .unwrap_or(BrowserQualityMatched {
-                            browser: None,
-                            quality: HttpMatchQuality::NotMatched,
-                        });
-                    (signature_matcher, ua_matcher, browser_quality)
+                        .unwrap_or((
+                            BrowserQualityMatched {
+                                browser: None,
+                                quality: HttpMatchQuality::NotMatched,
+                            },
+                            None,
+                        ))
                 },
-                not_matched: {
-                    let browser_quality = BrowserQualityMatched {
+                not_matched: (
+                    BrowserQualityMatched {
                         browser: None,
                         quality: HttpMatchQuality::NotMatched,
-                    };
-                    (None, None, browser_quality)
-                },
-                disabled: {
-                    let browser_quality = BrowserQualityMatched {
+                    },
+                    None
+                ),
+                disabled: (
+                    BrowserQualityMatched {
                         browser: None,
                         quality: HttpMatchQuality::Disabled,
-                    };
-                    (None, None, browser_quality)
-                }
+                    },
+                    None
+                )
             );
 
-            // TODO: (p0f-parity) https://github.com/biandratti/huginn-net/issues/278.
-            let http_diagnosis = huginn_net_http::http_common::get_diagnostic(
-                observable_http_request.user_agent.clone(),
-                ua_matcher.and_then(|(_, family)| family),
-                signature_matcher.map(|(label, _signature, _quality)| label.name.as_str()),
-            );
-
-            HttpRequestMatchResult { browser_quality, http_diagnosis }
+            HttpRequestMatchResult { params: build_params(&observed.expsw, notes), browser_quality }
         }
         #[cfg(not(feature = "db"))]
         {
-            // Without the `db` feature we can still report UA/network agreement
-            // based on the User-Agent string alone (UA → declared OS family).
-            let http_diagnosis = huginn_net_http::http_common::get_diagnostic(
-                observable_http_request.user_agent.clone(),
-                None,
-                None,
-            );
+            // Without the `db` feature nothing matched, so the only note we can
+            // still make is whether the client identified itself at all.
             HttpRequestMatchResult {
+                params: build_params(&observable_http_request.matching.expsw, None),
                 browser_quality: BrowserQualityMatched {
                     browser: None,
                     quality: HttpMatchQuality::Disabled,
                 },
-                http_diagnosis,
             }
         }
     }
@@ -239,31 +244,70 @@ impl<'a> HuginnNet<'a> {
     pub(super) fn match_http_response(
         &self,
         observable_http_response: &ObservableHttpResponse,
-    ) -> WebServerQualityMatched {
+    ) -> HttpResponseMatchResult {
         #[cfg(feature = "db")]
         {
-            simple_quality_match!(
+            let observed = &observable_http_response.matching;
+            let (web_server_quality, notes) = quality_match!(
                 enabled: self.config.matcher_enabled,
                 matcher: self.http_matcher,
-                method: matching_by_http_response(&observable_http_response.matching),
-                success: (label, _signature, quality) => WebServerQualityMatched {
-                    web_server: Some(WebServer::from(label)),
-                    quality: HttpMatchQuality::Matched(quality),
+                call: matcher => Some(matcher.matching_by_http_response(observed)),
+                matched: signature_matcher => {
+                    signature_matcher
+                        .map(|(label, signature, quality)| {
+                            let notes = MatchedSignatureNotes {
+                                dishonest: !huginn_net_db::http::expsw_matches(
+                                    &observed.expsw,
+                                    &signature.expsw,
+                                ),
+                                generic: label.ty == huginn_net_db::database::Type::Generic,
+                            };
+                            (
+                                WebServerQualityMatched {
+                                    web_server: Some(WebServer::from(label)),
+                                    quality: HttpMatchQuality::Matched(quality),
+                                },
+                                Some(notes),
+                            )
+                        })
+                        .unwrap_or((
+                            WebServerQualityMatched {
+                                web_server: None,
+                                quality: HttpMatchQuality::NotMatched,
+                            },
+                            None,
+                        ))
                 },
-                failure: WebServerQualityMatched {
-                    web_server: None,
-                    quality: HttpMatchQuality::NotMatched,
-                },
-                disabled: WebServerQualityMatched {
-                    web_server: None,
-                    quality: HttpMatchQuality::Disabled,
-                }
-            )
+                not_matched: (
+                    WebServerQualityMatched {
+                        web_server: None,
+                        quality: HttpMatchQuality::NotMatched,
+                    },
+                    None
+                ),
+                disabled: (
+                    WebServerQualityMatched {
+                        web_server: None,
+                        quality: HttpMatchQuality::Disabled,
+                    },
+                    None
+                )
+            );
+
+            HttpResponseMatchResult {
+                params: build_params(&observed.expsw, notes),
+                web_server_quality,
+            }
         }
         #[cfg(not(feature = "db"))]
         {
-            let _ = observable_http_response;
-            WebServerQualityMatched { web_server: None, quality: HttpMatchQuality::Disabled }
+            HttpResponseMatchResult {
+                params: build_params(&observable_http_response.matching.expsw, None),
+                web_server_quality: WebServerQualityMatched {
+                    web_server: None,
+                    quality: HttpMatchQuality::Disabled,
+                },
+            }
         }
     }
 }

--- a/huginn-net/src/analyzer/matchers.rs
+++ b/huginn-net/src/analyzer/matchers.rs
@@ -1,11 +1,11 @@
 use super::HuginnNet;
-#[cfg(any(feature = "http-p0f-request", feature = "http-p0f-response"))]
-use huginn_net_http::http::{build_params, HttpParams};
 #[cfg(all(
     feature = "db",
     any(feature = "http-p0f-request", feature = "http-p0f-response")
 ))]
 use huginn_net_http::http::MatchedSignatureNotes;
+#[cfg(any(feature = "http-p0f-request", feature = "http-p0f-response"))]
+use huginn_net_http::http::{build_params, HttpParams};
 #[cfg(feature = "http-p0f-request")]
 use huginn_net_http::observable::ObservableHttpRequest;
 #[cfg(feature = "http-p0f-response")]

--- a/huginn-net/src/analyzer/matchers.rs
+++ b/huginn-net/src/analyzer/matchers.rs
@@ -1,6 +1,11 @@
 use super::HuginnNet;
 #[cfg(any(feature = "http-p0f-request", feature = "http-p0f-response"))]
-use huginn_net_http::http::{build_params, HttpParams, MatchedSignatureNotes};
+use huginn_net_http::http::{build_params, HttpParams};
+#[cfg(all(
+    feature = "db",
+    any(feature = "http-p0f-request", feature = "http-p0f-response")
+))]
+use huginn_net_http::http::MatchedSignatureNotes;
 #[cfg(feature = "http-p0f-request")]
 use huginn_net_http::observable::ObservableHttpRequest;
 #[cfg(feature = "http-p0f-response")]

--- a/huginn-net/src/analyzer/mod.rs
+++ b/huginn-net/src/analyzer/mod.rs
@@ -2,12 +2,12 @@ mod matchers;
 use matchers::cache_sizes;
 #[cfg(feature = "http-p0f-request")]
 use matchers::HttpRequestMatchResult;
+#[cfg(feature = "http-p0f-response")]
+use matchers::HttpResponseMatchResult;
 
 use crate::error::HuginnNetError;
 use crate::output::FingerprintResult;
 use crate::process::ObservablePackage;
-#[cfg(feature = "http-p0f-response")]
-use huginn_net_http::http::HttpDiagnosis;
 use huginn_net_http::http_process::{FlowKey, HttpProcessors, TcpFlow};
 #[cfg(feature = "http-p0f-request")]
 use huginn_net_http::output::HttpRequestOutput;
@@ -473,7 +473,7 @@ impl<'a> HuginnNet<'a> {
                     observable_package
                         .http_request
                         .map(|observable_http_request| {
-                            let HttpRequestMatchResult { browser_quality, http_diagnosis } =
+                            let HttpRequestMatchResult { browser_quality, params } =
                                 self.match_http_request(&observable_http_request);
 
                             HttpRequestOutput {
@@ -487,7 +487,7 @@ impl<'a> HuginnNet<'a> {
                                 ),
                                 lang: observable_http_request.lang.clone(),
                                 browser_matched: browser_quality,
-                                diagnosis: http_diagnosis,
+                                params,
                                 sig: observable_http_request,
                             }
                         });
@@ -496,7 +496,7 @@ impl<'a> HuginnNet<'a> {
                 let http_response: Option<HttpResponseOutput> = observable_package
                     .http_response
                     .map(|observable_http_response| {
-                        let web_server_quality =
+                        let HttpResponseMatchResult { web_server_quality, params } =
                             self.match_http_response(&observable_http_response);
 
                         HttpResponseOutput {
@@ -509,7 +509,7 @@ impl<'a> HuginnNet<'a> {
                                 observable_package.destination.port,
                             ),
                             web_server_matched: web_server_quality,
-                            diagnosis: HttpDiagnosis::None,
+                            params,
                             sig: observable_http_response,
                         }
                     });


### PR DESCRIPTION
## Summary
- `horder`: binary subsequence match (required headers in order; extras free; value substring).
- `habsent`: reject if forbidden headers appear in traffic.
- Replace single `HttpDiagnosis` with combinable `HttpParams` (`dishonest` / `anonymous` / `generic`), including HTTP responses via `Server` → `expsw`.

## Why
Previous header distance budgeting could accept badly ordered layouts. Params must mirror p0f `dump_flags`, not a single enum.