### PR TITLE
Match tiers + FuzzyReason API

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,7 +9,68 @@
 The matcher now follows p0f's algorithm instead of summing soft penalties, so
 which signatures match changes: TCP gains coverage (p0f's fuzzy tolerances for
 quirks and TTL are honoured), HTTP loses it (no error budget — a header that
-does not fit is a rejection), and HTTP quality scores go up.
+does not fit is a rejection), and every field that p0f treats as a gate now
+rejects instead of costing points.
+
+---
+
+### Quality scores mean something different
+
+A score is no longer a normalised sum of per-field penalties. It reports which
+tier the match landed in, following p0f's order of preference:
+
+| Score | Match |
+|-------|-------|
+| `1.0` | Exact fit against a signature naming a concrete product |
+| `0.8` | Exact fit against a catch-all (generic) signature |
+| `0.5` | Only holds because a documented tolerance was applied (TCP only) |
+
+Nothing else is produced. If you compared scores against thresholds, note that
+the ordering is the contract and the numbers are free to be recalibrated; if you
+branched on specific values, switch to comparisons.
+
+Selection changed with it: a specific signature can no longer lose to a generic
+one because of database order, an exact generic match now outranks a fuzzy
+specific one, and TCP breaks ties within a tier by preferring the signature
+whose initial TTL is closest to what was observed. Application signatures
+(p0f's `s:!:…`, e.g. NMap) are no longer reported on a fuzzy match at all.
+
+---
+
+### `TcpMatchQuality::Matched` says what was tolerated
+
+The variant carries a struct instead of a bare float, so a fuzzy match can name
+the tolerance it needed rather than only scoring lower for it:
+
+```rust
+// v2.0
+match os_matched.quality {
+    MatchQuality::Matched(quality) => …,
+    …
+}
+
+// v2.1.0
+match os_matched.quality {
+    MatchQuality::Matched { quality, fuzzy: None } => …,        // exact fit
+    MatchQuality::Matched { quality, fuzzy: Some(reason) } => { // held by a tolerance
+        println!("{reason}");                    // "missing id+, extra ecn"
+        reason.implausible_hop_distance;         // Option<u32>
+        reason.added_quirks;                     // Vec<Quirk>
+        reason.missing_quirks;                   // Vec<Quirk>
+    }
+    …
+}
+```
+
+`MatchQuality::exact(q)` builds the fuzzy-free case, which is what the MTU match
+reports: an MTU either equals a known link's value or it does not.
+
+Whether the match is specific or generic is *not* in here — `os.kind` already
+carries it. HTTP is unchanged, since p0f defines no tolerances for it.
+
+The `Params:` line of the TCP output follows p0f's vocabulary now (`generic`,
+`fuzzy (…)`, or `none`) instead of printing `Specified`/`Generic`, which matches
+what the HTTP output already did.
 
 ---
 
@@ -35,10 +96,21 @@ contain the software the matched signature declares.
 
 ### Removed
 
+There is no distance model anymore, so the helpers that produced or scored one
+are gone. Each one is replaced by a check that answers the question directly.
+
 | v2.0 | v2.1 |
 |------|------|
 | `http_common::get_diagnostic` | `http_common::build_params` |
-| `huginn_net_db::http::distance_expsw` | `huginn_net_db::http::expsw_matches` (no longer part of the distance) |
+| `DatabaseSignature::calculate_distance` + `get_quality_score` | `DatabaseSignature::fit`, returning `Option<SignatureFit<Self::Fuzziness>>` |
+| `MatchQuality` trait, `TcpMatchQuality`, `HttpMatchQuality` (the database-side traits) | removed; use `MatchRank` |
+| `FingerprintDb::find_best_match` returning `(&Label, &DS, f32)` | returns `DatabaseMatch`, whose fields are named |
+| `matching_by_tcp_request`/`_response`, `matching_by_http_request`/`_response` returning tuples | the same `DatabaseMatch` |
+| `tcp::distance_ttl` | `tcp::ttl_fit` (returns the hop distance) |
+| `tcp::distance_ip_version`, `distance_window_size`, `distance_payload_size` | `ip_version_matches`, `window_size_matches`, `payload_size_matches` (`bool`) |
+| `http::distance_http_version`, `distance_header`, `distance_habsent` | `http_version_matches`, `headers_match`, `absent_headers_match` (`bool`) |
+| `huginn_net_db::http::distance_expsw` | `huginn_net_db::http::expsw_matches` (never part of the match) |
+| `HttpDistance::distance_*` methods | `version_matches`, `headers_match`, `horder_matches`, `absent_headers_match` |
 
 ---
 

--- a/huginn-net-db/src/database/collection.rs
+++ b/huginn-net-db/src/database/collection.rs
@@ -1,7 +1,10 @@
 //! Fingerprint collection and index-based matching.
 
-use crate::database::label::Label;
-use crate::db_matching_trait::{DatabaseSignature, FingerprintDb, IndexKey, ObservedFingerprint};
+use crate::database::label::{Label, Type};
+use crate::db_matching_trait::{
+    DatabaseMatch, DatabaseSignature, FingerprintDb, IndexKey, MatchRank, ObservedFingerprint,
+    SignatureFit,
+};
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::marker::PhantomData;
@@ -73,45 +76,61 @@ where
     DS: DatabaseSignature<OF> + Display,
     K: IndexKey,
 {
-    fn find_best_match(&self, observed: &OF) -> Option<(&Label, &DS, f32)> {
+    fn find_best_match(&self, observed: &OF) -> Option<DatabaseMatch<'_, DS, DS::Fuzziness>> {
         let observed_key = observed.generate_index_key();
 
-        let candidate_indices = match self.index.get(&observed_key) {
-            Some(indices) => indices,
-            None => {
-                return None;
-            }
-        };
+        let candidate_indices = self.index.get(&observed_key)?;
 
-        if candidate_indices.is_empty() {
-            return None;
-        }
-
-        let mut best_label_ref = None;
-        let mut best_sig_ref = None;
-        let mut min_distance = u32::MAX;
+        let mut best: Option<(&Label, &DS, MatchRank, SignatureFit<DS::Fuzziness>)> = None;
 
         for &(label_idx, sig_idx) in candidate_indices {
             let (label, sig_vec) = &self.entries[label_idx];
             let db_sig = &sig_vec[sig_idx];
 
-            if let Some(distance) = db_sig.calculate_distance(observed) {
-                if distance < min_distance {
-                    min_distance = distance;
-                    best_label_ref = Some(label);
-                    best_sig_ref = Some(db_sig);
+            let Some(fit) = db_sig.fit(observed) else {
+                continue;
+            };
+
+            let Some(rank) = rank_of(label, &fit) else {
+                continue;
+            };
+
+            debug!(
+                "fit: {rank:?} (deviation {}), label: {}, flavor: {:?}, sig: {db_sig}",
+                fit.deviation, label.name, label.flavor
+            );
+
+            let better = match &best {
+                Some((_, _, best_rank, best_fit)) => {
+                    (rank, fit.deviation) < (*best_rank, best_fit.deviation)
                 }
-                debug!(
-                    "distance: {}, label: {}, flavor: {:?}, sig: {}",
-                    distance, label.name, label.flavor, db_sig
-                );
+                None => true,
+            };
+            if better {
+                best = Some((label, db_sig, rank, fit));
             }
         }
 
-        if let (Some(label), Some(sig)) = (best_label_ref, best_sig_ref) {
-            Some((label, sig, sig.get_quality_score(min_distance)))
-        } else {
-            None
-        }
+        best.map(|(label, signature, rank, fit)| DatabaseMatch {
+            label,
+            signature,
+            quality: rank.as_quality(),
+            fuzzy: fit.fuzzy,
+        })
     }
+}
+
+/// [`MatchRank`] for this fit.
+///
+/// Fuzzy + no OS class (`label.class`) is `None`: applications are only
+/// reported on an exact fit.
+fn rank_of<F>(label: &Label, fit: &SignatureFit<F>) -> Option<MatchRank> {
+    if fit.fuzzy.is_some() {
+        return label.class.is_some().then_some(MatchRank::Fuzzy);
+    }
+
+    Some(match label.ty {
+        Type::Specified => MatchRank::Specific,
+        Type::Generic => MatchRank::Generic,
+    })
 }

--- a/huginn-net-db/src/http/distances.rs
+++ b/huginn-net-db/src/http/distances.rs
@@ -1,32 +1,27 @@
-//! Pure distance helpers between an observed HTTP value and a signature value.
+//! Pure gate helpers between an observed HTTP value and a signature value.
 //!
 //! These functions take **raw types** (versions, header slices, expected
 //! software strings), no observation structs, so they mirror the shape of
-//! [`crate::tcp`]'s `distance_*` helpers and can be reused from both the
+//! [`crate::tcp`]'s helpers and can be reused from both the
 //! `DatabaseSignature` impl and the public [`HttpDistance`] trait.
 //!
 //! [`HttpDistance`]: crate::observable_http_signals_matching::HttpDistance
 
-use super::signature::HttpMatchQuality;
 use super::{Header, Version};
 use huginn_net_http::http::UNKNOWN_SOFTWARE;
 use tracing::debug;
 
-/// Distance score between an observed [`Version`] and a database [`Version`].
+/// Whether an observed [`Version`] satisfies a database [`Version`].
 ///
 /// [`Version::Any`] in the signature matches everything; otherwise versions
 /// must be equal.
-pub fn distance_http_version(observed: Version, signature: Version) -> Option<u32> {
-    if signature == Version::Any || observed == signature {
-        Some(HttpMatchQuality::High.as_score())
-    } else {
-        None
-    }
+pub fn http_version_matches(observed: Version, signature: Version) -> bool {
+    signature == Version::Any || observed == signature
 }
 
 /// Signature `horder` vs traffic headers: required names in order, extras free.
 /// Signature values are substrings. `?` may be missing, not out of order.
-pub fn distance_header(observed: &[Header], signature: &[Header]) -> Option<u32> {
+pub fn headers_match(observed: &[Header], signature: &[Header]) -> bool {
     let mut position = 0usize;
 
     for expected in signature {
@@ -36,7 +31,9 @@ pub fn distance_header(observed: &[Header], signature: &[Header]) -> Option<u32>
 
         match found {
             Some(offset) => {
-                let header = observed.get(position.saturating_add(offset))?;
+                let Some(header) = observed.get(position.saturating_add(offset)) else {
+                    return false;
+                };
                 if let Some(expected_value) = expected.value.as_deref() {
                     if !header
                         .value
@@ -47,7 +44,7 @@ pub fn distance_header(observed: &[Header], signature: &[Header]) -> Option<u32>
                             "header {} value mismatch: expected substring {expected_value}",
                             expected.name
                         );
-                        return None;
+                        return false;
                     }
                 }
                 position = position.saturating_add(offset).saturating_add(1);
@@ -55,29 +52,29 @@ pub fn distance_header(observed: &[Header], signature: &[Header]) -> Option<u32>
             None => {
                 if !expected.optional {
                     debug!("required header {} missing", expected.name);
-                    return None;
+                    return false;
                 }
                 if observed.iter().any(|h| h.name == expected.name) {
                     debug!("optional header {} present but out of order", expected.name);
-                    return None;
+                    return false;
                 }
             }
         }
     }
 
-    Some(HttpMatchQuality::High.as_score())
+    true
 }
 
 /// Reject if any signature `habsent` name appears in the traffic headers.
-pub fn distance_habsent(observed: &[Header], signature_absent: &[Header]) -> Option<u32> {
+pub fn absent_headers_match(observed: &[Header], signature_absent: &[Header]) -> bool {
     for forbidden in signature_absent {
         if observed.iter().any(|h| h.name == forbidden.name) {
             debug!("forbidden header {} present in traffic", forbidden.name);
-            return None;
+            return false;
         }
     }
 
-    Some(HttpMatchQuality::High.as_score())
+    true
 }
 
 /// True if `observed` contains the signature `expsw` substring.

--- a/huginn-net-db/src/http/matching.rs
+++ b/huginn-net-db/src/http/matching.rs
@@ -3,15 +3,15 @@
 //!
 //! Provides:
 //! - The [`HttpDistance`] bridge trait. Each method delegates to a pure free
-//!   function ([`crate::http::distance_header`], etc., re-exported from the
+//!   function ([`crate::http::headers_match`], etc., re-exported from the
 //!   private `crate::http::distances` module); the trait exists to preserve
 //!   the public API (external callers use
-//!   `<X as HttpDistance>::distance_header`) and to give observation types a
+//!   `<X as HttpDistance>::headers_match`) and to give observation types a
 //!   uniform interface. New internal code should call the free functions
 //!   directly, mirroring TCP.
 //! - The [`crate::db_matching_trait::ObservedFingerprint`] impls for
 //!   [`HttpRequestObservation`] and [`HttpResponseObservation`].
-//! - The [`crate::db_matching_trait::DatabaseSignature`] impls scoring
+//! - The [`crate::db_matching_trait::DatabaseSignature`] impls comparing
 //!   `http::Signature` against either observation type.
 //!
 //! For backward compatibility this module is re-exposed at the crate root as
@@ -19,9 +19,9 @@
 //! `lib.rs`.
 
 use crate::database::HttpIndexKey;
-use crate::db_matching_trait::{DatabaseSignature, MatchQuality, ObservedFingerprint};
+use crate::db_matching_trait::{DatabaseSignature, NoFuzziness, ObservedFingerprint, SignatureFit};
 use crate::http::{
-    self, distance_habsent, distance_header, distance_http_version, expsw_matches, Header, Version,
+    self, absent_headers_match, expsw_matches, headers_match, http_version_matches, Header, Version,
 };
 use huginn_net_http::observable::{HttpRequestObservation, HttpResponseObservation};
 
@@ -41,43 +41,43 @@ impl ObservedFingerprint for HttpResponseObservation {
     }
 }
 
-/// Bridge between an observation type and the pure distance helpers in
+/// Bridge between an observation type and the pure gate helpers in
 /// [`crate::http`].
 ///
 /// Each method is a thin wrapper around the corresponding free function in
 /// `crate::http::distances`. The trait exists to give observations
 /// (`HttpRequestObservation`, `HttpResponseObservation`) a uniform interface
 /// and to preserve the public API; new code should prefer the free functions
-/// directly, mirroring how [`crate::tcp::distance_ttl`] etc. are used.
+/// directly, mirroring how [`crate::tcp::ttl_fit`] etc. are used.
 pub trait HttpDistance {
     fn get_version(&self) -> Version;
     fn get_horder(&self) -> &[Header];
     fn get_habsent(&self) -> &[Header];
     fn get_expsw(&self) -> &str;
 
-    fn distance_ip_version(&self, other: &http::Signature) -> Option<u32> {
-        distance_http_version(self.get_version(), other.version)
+    fn version_matches(&self, other: &http::Signature) -> bool {
+        http_version_matches(self.get_version(), other.version)
     }
 
     /// Check that every header the signature expects appears in the observed
-    /// list, in order. Delegates to [`crate::http::distance_header`].
-    fn distance_header(observed: &[Header], signature: &[Header]) -> Option<u32> {
-        distance_header(observed, signature)
+    /// list, in order. Delegates to [`crate::http::headers_match`].
+    fn headers_match(observed: &[Header], signature: &[Header]) -> bool {
+        headers_match(observed, signature)
     }
 
-    fn distance_horder(&self, other: &http::Signature) -> Option<u32> {
-        distance_header(self.get_horder(), &other.horder)
+    fn horder_matches(&self, other: &http::Signature) -> bool {
+        headers_match(self.get_horder(), &other.horder)
     }
 
     /// The signature's forbidden headers are checked against the headers
     /// actually seen, so this reads `horder`, not the observation's own
-    /// `habsent`. See [`crate::http::distance_habsent`].
-    fn distance_habsent(&self, other: &http::Signature) -> Option<u32> {
-        distance_habsent(self.get_horder(), &other.habsent)
+    /// `habsent`. See [`crate::http::absent_headers_match`].
+    fn absent_headers_match(&self, other: &http::Signature) -> bool {
+        absent_headers_match(self.get_horder(), &other.habsent)
     }
 
     /// Whether the traffic's software string backs up what the signature
-    /// declares. Not part of the distance; see [`crate::http::expsw_matches`].
+    /// declares. Not part of the fit; see [`crate::http::expsw_matches`].
     fn expsw_matches(&self, other: &http::Signature) -> bool {
         expsw_matches(self.get_expsw(), &other.expsw)
     }
@@ -114,28 +114,20 @@ impl HttpDistance for HttpResponseObservation {
 }
 
 trait HttpSignatureHelper {
-    fn calculate_http_distance<T: HttpDistance>(&self, observed: &T) -> Option<u32>;
+    fn http_fit<T: HttpDistance>(&self, observed: &T) -> Option<SignatureFit<NoFuzziness>>;
 
     fn generate_http_index_keys(&self) -> Vec<HttpIndexKey>;
-
-    /// Returns the quality score based on the distance.
-    ///
-    /// The score is a value between 0.0 and 1.0, where 1.0 is a perfect match.
-    ///
-    /// The score is calculated based on the distance of the observed signal to the database signature.
-    /// The distance is a value between 0 and 12, where 0 is a perfect match and 12 is the maximum possible distance.
-    fn get_quality_score_by_distance(&self, distance: u32) -> f32 {
-        http::HttpMatchQuality::distance_to_score(distance)
-    }
 }
 
 impl HttpSignatureHelper for http::Signature {
-    fn calculate_http_distance<T: HttpDistance>(&self, observed: &T) -> Option<u32> {
-        let distance = distance_http_version(observed.get_version(), self.version)?
-            .saturating_add(distance_header(observed.get_horder(), &self.horder)?)
-            .saturating_add(distance_habsent(observed.get_horder(), &self.habsent)?);
-        Some(distance)
+    fn http_fit<T: HttpDistance>(&self, observed: &T) -> Option<SignatureFit<NoFuzziness>> {
+        let gates = http_version_matches(observed.get_version(), self.version)
+            && headers_match(observed.get_horder(), &self.horder)
+            && absent_headers_match(observed.get_horder(), &self.habsent);
+
+        gates.then(|| SignatureFit::exact(0))
     }
+
     fn generate_http_index_keys(&self) -> Vec<HttpIndexKey> {
         let mut keys = Vec::new();
         if self.version == Version::Any {
@@ -149,11 +141,10 @@ impl HttpSignatureHelper for http::Signature {
 }
 
 impl DatabaseSignature<HttpRequestObservation> for http::Signature {
-    fn calculate_distance(&self, observed: &HttpRequestObservation) -> Option<u32> {
-        self.calculate_http_distance(observed)
-    }
-    fn get_quality_score(&self, distance: u32) -> f32 {
-        self.get_quality_score_by_distance(distance)
+    type Fuzziness = NoFuzziness;
+
+    fn fit(&self, observed: &HttpRequestObservation) -> Option<SignatureFit<NoFuzziness>> {
+        self.http_fit(observed)
     }
     fn generate_index_keys_for_db_entry(&self) -> Vec<HttpIndexKey> {
         self.generate_http_index_keys()
@@ -161,11 +152,10 @@ impl DatabaseSignature<HttpRequestObservation> for http::Signature {
 }
 
 impl DatabaseSignature<HttpResponseObservation> for http::Signature {
-    fn calculate_distance(&self, observed: &HttpResponseObservation) -> Option<u32> {
-        self.calculate_http_distance(observed)
-    }
-    fn get_quality_score(&self, distance: u32) -> f32 {
-        self.get_quality_score_by_distance(distance)
+    type Fuzziness = NoFuzziness;
+
+    fn fit(&self, observed: &HttpResponseObservation) -> Option<SignatureFit<NoFuzziness>> {
+        self.http_fit(observed)
     }
     fn generate_index_keys_for_db_entry(&self) -> Vec<HttpIndexKey> {
         self.generate_http_index_keys()

--- a/huginn-net-db/src/http/mod.rs
+++ b/huginn-net-db/src/http/mod.rs
@@ -1,4 +1,4 @@
-//! HTTP signature and scoring for the p0f database.
+//! HTTP signature and field-comparison helpers for the p0f database.
 
 pub use huginn_net_http::http::{
     request_common_headers, request_optional_headers, request_skip_value_headers,
@@ -9,5 +9,5 @@ pub use huginn_net_http::http::{
 mod distances;
 mod signature;
 
-pub use distances::{distance_habsent, distance_header, distance_http_version, expsw_matches};
-pub use signature::{HttpMatchQuality, Signature};
+pub use distances::{absent_headers_match, expsw_matches, headers_match, http_version_matches};
+pub use signature::Signature;

--- a/huginn-net-db/src/http/signature.rs
+++ b/huginn-net-db/src/http/signature.rs
@@ -1,4 +1,3 @@
-use crate::db_matching_trait::MatchQuality;
 use core::fmt;
 use huginn_net_http::display::HttpDisplayFormat;
 use huginn_net_http::http::{Header, Version};
@@ -14,45 +13,6 @@ pub struct Signature {
     pub habsent: Vec<super::Header>,
     /// expected substring in 'User-Agent' or 'Server'.
     pub expsw: String,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum HttpMatchQuality {
-    High,
-    Medium,
-    Low,
-    Bad,
-}
-
-impl HttpMatchQuality {
-    pub fn as_score(self) -> u32 {
-        match self {
-            HttpMatchQuality::High => 0,
-            HttpMatchQuality::Medium => 1,
-            HttpMatchQuality::Low => 2,
-            HttpMatchQuality::Bad => 3,
-        }
-    }
-}
-
-impl MatchQuality for HttpMatchQuality {
-    // HTTP has 4 components, each can contribute max 3 points (Bad)
-    const MAX_DISTANCE: u32 = 12;
-
-    fn distance_to_score(distance: u32) -> f32 {
-        match distance {
-            0 => 1.0,
-            1 => 0.95,
-            2 => 0.90,
-            3 => 0.80,
-            4..=5 => 0.70,
-            6..=7 => 0.60,
-            8..=9 => 0.40,
-            10..=11 => 0.20,
-            d if d <= Self::MAX_DISTANCE => 0.10,
-            _ => 0.05,
-        }
-    }
 }
 
 impl HttpDisplayFormat for Signature {

--- a/huginn-net-db/src/matcher/http_signature_matcher.rs
+++ b/huginn-net-db/src/matcher/http_signature_matcher.rs
@@ -1,5 +1,5 @@
 use crate::database::{HttpDatabase, Label, Type};
-use crate::db_matching_trait::FingerprintDb;
+use crate::db_matching_trait::{DatabaseMatch, FingerprintDb, NoFuzziness};
 use crate::http::expsw_matches;
 use huginn_net_http::matcher_api::{HttpMatcher, HttpRequestMatch, HttpResponseMatch, UaOsMatch};
 use huginn_net_http::observable::{HttpRequestObservation, HttpResponseObservation};
@@ -18,14 +18,14 @@ impl<'a> HttpSignatureMatcher<'a> {
     pub fn matching_by_http_request(
         &self,
         signature: &HttpRequestObservation,
-    ) -> Option<(&'a Label, &'a crate::http::Signature, f32)> {
+    ) -> Option<DatabaseMatch<'a, crate::http::Signature, NoFuzziness>> {
         self.database.http_request.find_best_match(signature)
     }
 
     pub fn matching_by_http_response(
         &self,
         signature: &HttpResponseObservation,
-    ) -> Option<(&'a Label, &'a crate::http::Signature, f32)> {
+    ) -> Option<DatabaseMatch<'a, crate::http::Signature, NoFuzziness>> {
         self.database.http_response.find_best_match(signature)
     }
 
@@ -79,11 +79,11 @@ fn match_http_request_impl(
     db: &HttpDatabase,
     obs: &HttpRequestObservation,
 ) -> Option<HttpRequestMatch> {
-    let (label, sig, quality) = db.http_request.find_best_match(obs)?;
+    let found = db.http_request.find_best_match(obs)?;
     Some(HttpRequestMatch {
-        browser: Browser::from(label),
-        quality,
-        dishonest: !expsw_matches(&obs.expsw, &sig.expsw),
+        browser: Browser::from(found.label),
+        quality: found.quality,
+        dishonest: !expsw_matches(&obs.expsw, &found.signature.expsw),
     })
 }
 
@@ -91,11 +91,11 @@ fn match_http_response_impl(
     db: &HttpDatabase,
     obs: &HttpResponseObservation,
 ) -> Option<HttpResponseMatch> {
-    let (label, sig, quality) = db.http_response.find_best_match(obs)?;
+    let found = db.http_response.find_best_match(obs)?;
     Some(HttpResponseMatch {
-        web_server: WebServer::from(label),
-        quality,
-        dishonest: !expsw_matches(&obs.expsw, &sig.expsw),
+        web_server: WebServer::from(found.label),
+        quality: found.quality,
+        dishonest: !expsw_matches(&obs.expsw, &found.signature.expsw),
     })
 }
 

--- a/huginn-net-db/src/matcher/tcp_signature_matcher.rs
+++ b/huginn-net-db/src/matcher/tcp_signature_matcher.rs
@@ -1,9 +1,9 @@
 use crate::database::{Label, TcpDatabase, Type};
-use crate::db_matching_trait::FingerprintDb;
+use crate::db_matching_trait::{DatabaseMatch, FingerprintDb};
 use huginn_net_tcp::matcher_api::{MtuMatch, TcpMatch, TcpMatcher};
 use huginn_net_tcp::observable::ObservableTcp;
 use huginn_net_tcp::observable::TcpObservation;
-use huginn_net_tcp::output::{OperativeSystem, OsKind};
+use huginn_net_tcp::output::{FuzzyReason, OperativeSystem, OsKind};
 use std::sync::Arc;
 
 pub struct TcpSignatureMatcher<'a> {
@@ -18,7 +18,7 @@ impl<'a> TcpSignatureMatcher<'a> {
     pub fn matching_by_tcp_request(
         &self,
         signature: &ObservableTcp,
-    ) -> Option<(&'a Label, &'a crate::tcp::Signature, f32)> {
+    ) -> Option<DatabaseMatch<'a, crate::tcp::Signature, FuzzyReason>> {
         self.database
             .tcp_request
             .find_best_match(&signature.matching)
@@ -27,7 +27,7 @@ impl<'a> TcpSignatureMatcher<'a> {
     pub fn matching_by_tcp_response(
         &self,
         signature: &ObservableTcp,
-    ) -> Option<(&'a Label, &'a crate::tcp::Signature, f32)> {
+    ) -> Option<DatabaseMatch<'a, crate::tcp::Signature, FuzzyReason>> {
         self.database
             .tcp_response
             .find_best_match(&signature.matching)
@@ -68,13 +68,21 @@ impl From<&Label> for OperativeSystem {
 // ---------------------------------------------------------------------------
 
 fn match_tcp_request_impl(db: &TcpDatabase, obs: &TcpObservation) -> Option<TcpMatch> {
-    let (label, _sig, quality) = db.tcp_request.find_best_match(obs)?;
-    Some(TcpMatch { os: OperativeSystem::from(label), quality })
+    let found = db.tcp_request.find_best_match(obs)?;
+    Some(TcpMatch {
+        os: OperativeSystem::from(found.label),
+        quality: found.quality,
+        fuzzy: found.fuzzy,
+    })
 }
 
 fn match_tcp_response_impl(db: &TcpDatabase, obs: &TcpObservation) -> Option<TcpMatch> {
-    let (label, _sig, quality) = db.tcp_response.find_best_match(obs)?;
-    Some(TcpMatch { os: OperativeSystem::from(label), quality })
+    let found = db.tcp_response.find_best_match(obs)?;
+    Some(TcpMatch {
+        os: OperativeSystem::from(found.label),
+        quality: found.quality,
+        fuzzy: found.fuzzy,
+    })
 }
 
 fn match_mtu_impl(db: &TcpDatabase, mtu: u16) -> Option<MtuMatch> {

--- a/huginn-net-db/src/matcher/traits.rs
+++ b/huginn-net-db/src/matcher/traits.rs
@@ -11,14 +11,52 @@ pub trait ObservedFingerprint: Clone + Debug {
     fn generate_index_key(&self) -> Self::Key;
 }
 
+/// How well a database signature fits an observation, when it fits at all.
+///
+/// There is no accumulated score here. Every field is either a gate the
+/// signature passes or fails, plus the narrow tolerances p0f documents, so what
+/// a comparison yields is "does it hold, and did it need a tolerance".
+///
+/// `F` describes the tolerance that was applied, which is protocol-specific.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureFit<F> {
+    /// The tolerance that had to be stretched for the match to hold, which ranks
+    /// this candidate below every signature that fit exactly.
+    pub fuzzy: Option<F>,
+    /// How far this candidate sits from the observation *within* its tier.
+    /// Used only to break ties between candidates of the same rank; lower is
+    /// closer. Protocols with nothing to measure report `0`.
+    pub deviation: u32,
+}
+
+impl<F> SignatureFit<F> {
+    /// Every field matched, nothing was stretched.
+    pub fn exact(deviation: u32) -> Self {
+        Self { fuzzy: None, deviation }
+    }
+
+    /// The match only holds because `reason` was tolerated.
+    pub fn fuzzy(reason: F, deviation: u32) -> Self {
+        Self { fuzzy: Some(reason), deviation }
+    }
+}
+
+/// Placeholder for a protocol with no tolerances at all: being uninhabited, it
+/// makes a fuzzy HTTP match unrepresentable rather than merely unused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NoFuzziness {}
+
 /// A fingerprint signature as defined in a database.
 /// `OF` is the type of `ObservedFingerprint` that this database signature can be compared against.
 pub trait DatabaseSignature<OF: ObservedFingerprint> {
-    /// Calculates a distance or dissimilarity score. Lower is better.
-    fn calculate_distance(&self, observed: &OF) -> Option<u32>;
+    /// How this protocol describes an applied tolerance. [`NoFuzziness`] for
+    /// protocols that have none.
+    type Fuzziness;
 
-    /// Returns the quality score based on the distance.
-    fn get_quality_score(&self, distance: u32) -> f32;
+    /// Compares this signature against an observation. `None` rejects it: a
+    /// signature that fails any gate is not a worse candidate, it is not a
+    /// candidate.
+    fn fit(&self, observed: &OF) -> Option<SignatureFit<Self::Fuzziness>>;
 
     /// Generates index keys from this database signature.
     /// It's a Vec because some DB signatures (like IpVersion::Any) might map to multiple keys.
@@ -30,19 +68,55 @@ pub trait DatabaseSignature<OF: ObservedFingerprint> {
 /// Base trait for keys used in fingerprint indexes.
 pub trait IndexKey: Debug + Clone + Eq + Hash {}
 
+/// Where a candidate sits in p0f's order of preference.
+///
+/// p0f returns the first exact match on a specific signature and only falls
+/// back to a generic one after exhausting the list; a match that needed a
+/// tolerance is the last resort, and does *not* keep its specific/generic
+/// distinction (`fp_tcp.c:221-271`). Declaration order is the preference
+/// order, so `Ord` sorts best-first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MatchRank {
+    /// Exact fit against a signature naming a concrete product.
+    Specific,
+    /// Exact fit against a catch-all signature.
+    Generic,
+    /// Only holds because a documented tolerance was applied.
+    Fuzzy,
+}
+
+impl MatchRank {
+    /// Quality score reported to consumers.
+    ///
+    /// The contract is the ordering, not the numbers: a specific match always
+    /// scores above a generic one, which always scores above a fuzzy one. The
+    /// values themselves are free to be recalibrated.
+    pub fn as_quality(self) -> f32 {
+        match self {
+            MatchRank::Specific => 1.0,
+            MatchRank::Generic => 0.8,
+            MatchRank::Fuzzy => 0.5,
+        }
+    }
+}
+
+/// The candidate that won selection.
+#[derive(Debug)]
+pub struct DatabaseMatch<'a, DS, F> {
+    /// Label of the matched entry.
+    pub label: &'a Label,
+    /// The signature that matched, as written in the database.
+    pub signature: &'a DS,
+    /// Quality score derived from the tier the match landed in.
+    pub quality: f32,
+    /// The tolerance that was applied, when the match is not exact.
+    pub fuzzy: Option<F>,
+}
+
 /// Represents a collection of database signatures of a specific type.
 /// `OF` is the `ObservedFingerprint` type.
 /// `DS` is the `DatabaseSignature` type that can be compared against `OF`.
 pub trait FingerprintDb<OF: ObservedFingerprint, DS: DatabaseSignature<OF>> {
     /// Finds the best match for an observed fingerprint within this database.
-    /// Returns the label of the match, the matching database signature, and a quality score.
-    fn find_best_match(&self, observed: &OF) -> Option<(&Label, &DS, f32)>;
-}
-
-pub trait MatchQuality {
-    /// Maximum possible distance for this quality type
-    const MAX_DISTANCE: u32;
-
-    /// Converts distance to a quality score between 0.0 and 1.0
-    fn distance_to_score(distance: u32) -> f32;
+    fn find_best_match(&self, observed: &OF) -> Option<DatabaseMatch<'_, DS, DS::Fuzziness>>;
 }

--- a/huginn-net-db/src/matcher/traits.rs
+++ b/huginn-net-db/src/matcher/traits.rs
@@ -68,13 +68,7 @@ pub trait DatabaseSignature<OF: ObservedFingerprint> {
 /// Base trait for keys used in fingerprint indexes.
 pub trait IndexKey: Debug + Clone + Eq + Hash {}
 
-/// Where a candidate sits in p0f's order of preference.
-///
-/// p0f returns the first exact match on a specific signature and only falls
-/// back to a generic one after exhausting the list; a match that needed a
-/// tolerance is the last resort, and does *not* keep its specific/generic
-/// distinction (`fp_tcp.c:221-271`). Declaration order is the preference
-/// order, so `Ord` sorts best-first.
+/// Preference order: Specific > Generic > Fuzzy (`Ord` is best-first).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MatchRank {
     /// Exact fit against a signature naming a concrete product.

--- a/huginn-net-db/src/tcp/distances.rs
+++ b/huginn-net-db/src/tcp/distances.rs
@@ -1,26 +1,17 @@
-use super::signature::TcpMatchQuality;
 use super::{IpVersion, PayloadSize, Ttl, WindowSize};
 use tracing::debug;
 
-/// Distance score between an observed `IpVersion` and a database `IpVersion`.
-pub fn distance_ip_version(observed: &IpVersion, signature: &IpVersion) -> Option<u32> {
-    if signature == &IpVersion::Any {
-        Some(TcpMatchQuality::High.as_score())
-    } else {
-        match (observed, signature) {
-            (IpVersion::V4, IpVersion::V4) | (IpVersion::V6, IpVersion::V6) => {
-                Some(TcpMatchQuality::High.as_score())
-            }
-            _ => None,
-        }
-    }
+/// Whether an observed IP version satisfies the one a signature declares.
+pub fn ip_version_matches(observed: &IpVersion, signature: &IpVersion) -> bool {
+    matches!(
+        (observed, signature),
+        (_, IpVersion::Any) | (IpVersion::V4, IpVersion::V4) | (IpVersion::V6, IpVersion::V6)
+    )
 }
 
-/// Largest hop count still considered plausible between the fingerprinted
-/// host and the sensor. Beyond it the observed TTL no longer supports the
-/// signature's initial TTL, and the match degrades to fuzzy. Mirrors
-/// `MAX_DIST` in `data/p0f/config.h`.
-pub const MAX_TTL_DISTANCE: u8 = 40;
+/// Largest hop count still considered plausible. Beyond it the match is fuzzy.
+/// Same as p0f `MAX_DIST`.
+pub const MAX_TTL_DISTANCE: u8 = 35;
 
 /// TTL as seen on the wire, whichever form the observation was classified
 /// into by `huginn_net_tcp::tcp::calculate_ttl`.
@@ -40,100 +31,64 @@ fn signature_initial_ttl(signature: &Ttl) -> u8 {
     }
 }
 
-/// Hop-distance vs the signature's initial TTL, not equality.
-/// Within [`MAX_TTL_DISTANCE`]: High. Outside: Low (not a reject).
-/// [`Ttl::Bad`] (`nnn-`): reject if observed > initial.
-pub fn distance_ttl(observed: &Ttl, signature: &Ttl) -> Option<u32> {
-    let observed = observed_ttl(observed);
-    let initial = signature_initial_ttl(signature);
-
-    if matches!(signature, Ttl::Bad(_)) {
-        return if observed > initial {
-            None
-        } else {
-            Some(TcpMatchQuality::High.as_score())
-        };
-    }
-
-    if observed > initial || initial.saturating_sub(observed) > MAX_TTL_DISTANCE {
-        debug!("ttl out of range: observed {observed}, signature initial {initial}");
-        Some(TcpMatchQuality::Low.as_score())
-    } else {
-        Some(TcpMatchQuality::High.as_score())
-    }
+/// Hop-distance vs the signature's initial TTL.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TtlFit {
+    pub hop_distance: u32,
+    /// True when hops exceed [`MAX_TTL_DISTANCE`] (fuzzy, not a reject).
+    pub out_of_range: bool,
 }
 
-/// Distance score between an observed `WindowSize` and a database `WindowSize`.
+/// Within [`MAX_TTL_DISTANCE`]: fit. Outside: still a fit, `out_of_range`.
+/// [`Ttl::Bad`] (`nnn-`): reject if observed > initial.
+pub fn ttl_fit(observed: &Ttl, signature: &Ttl) -> Option<TtlFit> {
+    let observed = observed_ttl(observed);
+    let initial = signature_initial_ttl(signature);
+    let hop_distance = u32::from(initial.saturating_sub(observed));
+
+    if matches!(signature, Ttl::Bad(_)) {
+        return (observed <= initial).then_some(TtlFit { hop_distance, out_of_range: false });
+    }
+
+    let out_of_range = observed > initial || initial.saturating_sub(observed) > MAX_TTL_DISTANCE;
+    if out_of_range {
+        debug!("ttl out of range: observed {observed}, signature initial {initial}");
+    }
+
+    Some(TtlFit { hop_distance, out_of_range })
+}
+
+/// Whether an observed `WindowSize` satisfies the one a signature declares.
 ///
 /// Takes the observed MSS as context to resolve `WindowSize::Mss(_)` patterns
-/// against a raw window value. Returns `None` for incompatible pairings.
-///
-/// A mismatch is always a hard reject (`None`), never a soft penalty: p0f's
-/// window-size check never tolerates a mismatch here, regardless of type. Only
+/// against a raw window value. A mismatch never degrades to fuzzy: p0f's
+/// window-size check does not tolerate one, regardless of type. Only
 /// `WindowSize::Any` in the signature is a true wildcard.
-pub fn distance_window_size(
+pub fn window_size_matches(
     observed: &WindowSize,
     signature: &WindowSize,
     mss: Option<u16>,
-) -> Option<u32> {
+) -> bool {
     match (observed, signature) {
-        (WindowSize::Mss(a), WindowSize::Mss(b)) => {
-            if a == b {
-                Some(TcpMatchQuality::High.as_score())
-            } else {
-                None
-            }
-        }
-        (WindowSize::Mtu(a), WindowSize::Mtu(b)) => {
-            if a == b {
-                Some(TcpMatchQuality::High.as_score())
-            } else {
-                None
-            }
-        }
+        (_, WindowSize::Any) => true,
+        (WindowSize::Mss(a), WindowSize::Mss(b)) => a == b,
+        (WindowSize::Mtu(a), WindowSize::Mtu(b)) => a == b,
+        (WindowSize::Mod(a), WindowSize::Mod(b)) => a == b,
+        (WindowSize::Value(a), WindowSize::Value(b)) => a == b,
         (WindowSize::Value(a), WindowSize::Mss(b)) => {
-            if let Some(mss_value) = mss {
-                if let Some(ratio_other) = a.checked_div(mss_value) {
-                    if *b as u16 == ratio_other {
-                        debug!(
-                            "window size difference: a {}, b {} == ratio_other {}",
-                            a, b, ratio_other
-                        );
-                        Some(TcpMatchQuality::High.as_score())
-                    } else {
-                        None
-                    }
-                } else {
-                    None
+            match mss.and_then(|mss| a.checked_div(mss)) {
+                Some(ratio) => {
+                    debug!("window size as mss multiple: value {a}, signature {b}, ratio {ratio}");
+                    u16::from(*b) == ratio
                 }
-            } else {
-                None
+                None => false,
             }
         }
-        (WindowSize::Mod(a), WindowSize::Mod(b)) => {
-            if a == b {
-                Some(TcpMatchQuality::High.as_score())
-            } else {
-                None
-            }
-        }
-        (WindowSize::Value(a), WindowSize::Value(b)) => {
-            if a == b {
-                Some(TcpMatchQuality::High.as_score())
-            } else {
-                None
-            }
-        }
-        (_, WindowSize::Any) => Some(TcpMatchQuality::High.as_score()),
-        _ => None,
+        _ => false,
     }
 }
 
-/// Distance score between an observed `PayloadSize` and a database `PayloadSize`.
-pub fn distance_payload_size(observed: &PayloadSize, signature: &PayloadSize) -> Option<u32> {
-    if signature == &PayloadSize::Any || observed == signature {
-        Some(TcpMatchQuality::High.as_score())
-    } else {
-        None
-    }
+/// Whether an observed `PayloadSize` satisfies the one a signature declares.
+pub fn payload_size_matches(observed: &PayloadSize, signature: &PayloadSize) -> bool {
+    signature == &PayloadSize::Any || observed == signature
 }

--- a/huginn-net-db/src/tcp/matching.rs
+++ b/huginn-net-db/src/tcp/matching.rs
@@ -2,15 +2,15 @@
 //! database matcher infrastructure.
 //!
 //! Provides:
-//! - `pub(crate)` distance helpers that read fields off a `TcpObservation`
-//!   (`distance_olen`, `distance_mss`, `distance_wscale`, `distance_olayout`,
-//!   `distance_quirks`). The pure helpers that compare two raw signature
-//!   types ([`crate::tcp::distance_ttl`], [`crate::tcp::distance_window_size`],
-//!   …) live in `crate::tcp::distances` (private module; re-exported through
+//! - `pub(crate)` gate helpers that read fields off a `TcpObservation`
+//!   (`olen_matches`, `mss_matches`, `wscale_matches`, `olayout_matches`,
+//!   `quirks_fit`). The pure helpers that compare two raw signature types
+//!   ([`crate::tcp::ttl_fit`], [`crate::tcp::window_size_matches`], …) live in
+//!   `crate::tcp::distances` (private module; re-exported through
 //!   [`crate::tcp`]).
 //! - The [`crate::db_matching_trait::ObservedFingerprint`] impl that turns an
 //!   observation into a [`crate::database::TcpIndexKey`].
-//! - The [`crate::db_matching_trait::DatabaseSignature`] impl that scores a
+//! - The [`crate::db_matching_trait::DatabaseSignature`] impl that compares a
 //!   `tcp::Signature` against a `TcpObservation`.
 //!
 //! For backward compatibility this module is re-exposed at the crate root as
@@ -18,54 +18,33 @@
 //! `lib.rs`.
 
 use crate::database::TcpIndexKey;
-use crate::db_matching_trait::{DatabaseSignature, MatchQuality, ObservedFingerprint};
+use crate::db_matching_trait::{DatabaseSignature, ObservedFingerprint, SignatureFit};
 use crate::tcp::{
-    self, distance_ip_version, distance_payload_size, distance_ttl, distance_window_size,
-    IpVersion, PayloadSize, Quirk,
+    self, ip_version_matches, payload_size_matches, ttl_fit, window_size_matches, IpVersion,
+    PayloadSize, Quirk,
 };
 use huginn_net_tcp::observable::TcpObservation;
+use huginn_net_tcp::output::FuzzyReason;
 
-/// `olen` is never wildcarded in p0f's format: a mismatch is a hard reject, not a soft penalty.
-pub(crate) fn distance_olen(observed: &TcpObservation, signature: &tcp::Signature) -> Option<u32> {
-    if observed.olen == signature.olen {
-        Some(tcp::TcpMatchQuality::High.as_score())
-    } else {
-        None
-    }
+/// `olen` is never wildcarded in p0f's format: a mismatch is a hard reject.
+pub(crate) fn olen_matches(observed: &TcpObservation, signature: &tcp::Signature) -> bool {
+    observed.olen == signature.olen
 }
 
 /// A signature-specified `mss` is a hard gate in p0f: only `mss == *`
 /// (wildcard, `None` here) tolerates any observed value.
-pub(crate) fn distance_mss(observed: &TcpObservation, signature: &tcp::Signature) -> Option<u32> {
-    if signature.mss.is_none() || observed.mss == signature.mss {
-        Some(tcp::TcpMatchQuality::High.as_score())
-    } else {
-        None
-    }
+pub(crate) fn mss_matches(observed: &TcpObservation, signature: &tcp::Signature) -> bool {
+    signature.mss.is_none() || observed.mss == signature.mss
 }
 
 /// A signature-specified `wscale` is a hard gate in p0f: only `wscale == *`
 /// (wildcard, `None` here) tolerates any observed value.
-pub(crate) fn distance_wscale(
-    observed: &TcpObservation,
-    signature: &tcp::Signature,
-) -> Option<u32> {
-    if signature.wscale.is_none() || observed.wscale == signature.wscale {
-        Some(tcp::TcpMatchQuality::High.as_score())
-    } else {
-        None
-    }
+pub(crate) fn wscale_matches(observed: &TcpObservation, signature: &tcp::Signature) -> bool {
+    signature.wscale.is_none() || observed.wscale == signature.wscale
 }
 
-pub(crate) fn distance_olayout(
-    observed: &TcpObservation,
-    signature: &tcp::Signature,
-) -> Option<u32> {
-    if observed.olayout == signature.olayout {
-        Some(tcp::TcpMatchQuality::High.as_score())
-    } else {
-        None
-    }
+pub(crate) fn olayout_matches(observed: &TcpObservation, signature: &tcp::Signature) -> bool {
+    observed.olayout == signature.olayout
 }
 
 /// Quirks a database signature may declare without the observation showing
@@ -94,24 +73,38 @@ fn quirk_masked_by_ip_version(
     }
 }
 
+/// The quirks that had to be tolerated for a signature to hold. Empty on both
+/// sides when the sets agreed exactly.
+#[derive(Debug, Default)]
+pub(crate) struct QuirksFit {
+    /// Shown by the traffic, not declared by the signature.
+    pub added: Vec<Quirk>,
+    /// Declared by the signature, not shown by the traffic.
+    pub missing: Vec<Quirk>,
+}
+
+impl QuirksFit {
+    fn is_exact(&self) -> bool {
+        self.added.is_empty() && self.missing.is_empty()
+    }
+}
+
 /// Quirks are compared as sets, not as ordered lists, and a narrow set of
 /// differences is tolerated as a fuzzy match: `df`/`id+` may be absent from
 /// the traffic, and `id-`/`ecn` may appear in it. Any other difference
 /// rejects the signature outright.
 ///
-/// The fuzzy case is currently reported as the worst non-rejecting score;
-/// once the match tiers land it becomes `Fuzzy(QuirksWhitelisted)` instead,
-/// which sorts below every exact match regardless of the other fields.
-pub(crate) fn distance_quirks(
+/// Returns which quirks the tolerance had to cover; `None` rejects.
+pub(crate) fn quirks_fit(
     observed: &TcpObservation,
     signature: &tcp::Signature,
-) -> Option<u32> {
+) -> Option<QuirksFit> {
     let declared_by_signature = |quirk: &Quirk| {
         signature.quirks.contains(quirk)
             && !quirk_masked_by_ip_version(quirk, signature.version, observed.version)
     };
 
-    let mut fuzzy = false;
+    let mut fit = QuirksFit::default();
 
     for quirk in &signature.quirks {
         if quirk_masked_by_ip_version(quirk, signature.version, observed.version)
@@ -122,7 +115,7 @@ pub(crate) fn distance_quirks(
         if !FUZZY_DELETABLE_QUIRKS.contains(quirk) {
             return None;
         }
-        fuzzy = true;
+        fit.missing.push(quirk.clone());
     }
 
     for quirk in &observed.quirks {
@@ -132,14 +125,10 @@ pub(crate) fn distance_quirks(
         if !FUZZY_ADDABLE_QUIRKS.contains(quirk) {
             return None;
         }
-        fuzzy = true;
+        fit.added.push(quirk.clone());
     }
 
-    if fuzzy {
-        Some(tcp::TcpMatchQuality::Low.as_score())
-    } else {
-        Some(tcp::TcpMatchQuality::High.as_score())
-    }
+    Some(fit)
 }
 
 impl ObservedFingerprint for TcpObservation {
@@ -156,28 +145,39 @@ impl ObservedFingerprint for TcpObservation {
 }
 
 impl DatabaseSignature<TcpObservation> for tcp::Signature {
-    fn calculate_distance(&self, observed: &TcpObservation) -> Option<u32> {
-        let distance = distance_ip_version(&observed.version, &self.version)?
-            .saturating_add(distance_ttl(&observed.ittl, &self.ittl)?)
-            .saturating_add(distance_olen(observed, self)?)
-            .saturating_add(distance_mss(observed, self)?)
-            .saturating_add(distance_window_size(&observed.wsize, &self.wsize, observed.mss)?)
-            .saturating_add(distance_wscale(observed, self)?)
-            .saturating_add(distance_olayout(observed, self)?)
-            .saturating_add(distance_quirks(observed, self)?)
-            .saturating_add(distance_payload_size(&observed.pclass, &self.pclass)?);
-        Some(distance)
-    }
+    type Fuzziness = FuzzyReason;
 
-    /// Returns the quality score based on the distance.
-    ///
-    /// The score is a value between 0.0 and 1.0, where 1.0 is a perfect match.
-    ///
-    /// The score is calculated based on the distance of the observed signal to the database signature.
-    /// The distance is a value between 0 and 18, where 0 is a perfect match and 18 is the maximum possible distance.
-    ///
-    fn get_quality_score(&self, distance: u32) -> f32 {
-        tcp::TcpMatchQuality::distance_to_score(distance)
+    /// Seven of the nine fields are gates. `ttl` and `quirks` may be
+    /// tolerated; either one (or both) makes the match fuzzy.
+    fn fit(&self, observed: &TcpObservation) -> Option<SignatureFit<FuzzyReason>> {
+        let gates = ip_version_matches(&observed.version, &self.version)
+            && olen_matches(observed, self)
+            && mss_matches(observed, self)
+            && window_size_matches(&observed.wsize, &self.wsize, observed.mss)
+            && wscale_matches(observed, self)
+            && olayout_matches(observed, self)
+            && payload_size_matches(&observed.pclass, &self.pclass);
+
+        if !gates {
+            return None;
+        }
+
+        let ttl = ttl_fit(&observed.ittl, &self.ittl)?;
+        let quirks = quirks_fit(observed, self)?;
+
+        // The hop distance ranks candidates inside a tier: given two signatures
+        // that both fit, the one whose initial TTL sits closer to what we saw
+        // is the better explanation.
+        if !ttl.out_of_range && quirks.is_exact() {
+            return Some(SignatureFit::exact(ttl.hop_distance));
+        }
+
+        let reason = FuzzyReason {
+            implausible_hop_distance: ttl.out_of_range.then_some(ttl.hop_distance),
+            added_quirks: quirks.added,
+            missing_quirks: quirks.missing,
+        };
+        Some(SignatureFit::fuzzy(reason, ttl.hop_distance))
     }
 
     fn generate_index_keys_for_db_entry(&self) -> Vec<TcpIndexKey> {

--- a/huginn-net-db/src/tcp/matching.rs
+++ b/huginn-net-db/src/tcp/matching.rs
@@ -165,9 +165,6 @@ impl DatabaseSignature<TcpObservation> for tcp::Signature {
         let ttl = ttl_fit(&observed.ittl, &self.ittl)?;
         let quirks = quirks_fit(observed, self)?;
 
-        // The hop distance ranks candidates inside a tier: given two signatures
-        // that both fit, the one whose initial TTL sits closer to what we saw
-        // is the better explanation.
         if !ttl.out_of_range && quirks.is_exact() {
             return Some(SignatureFit::exact(ttl.hop_distance));
         }

--- a/huginn-net-db/src/tcp/mod.rs
+++ b/huginn-net-db/src/tcp/mod.rs
@@ -1,4 +1,4 @@
-//! TCP signature, scoring, and distance helpers for the p0f database.
+//! TCP signature and field-comparison helpers for the p0f database.
 //!
 //! Pure data types ([`IpVersion`], [`Ttl`], [`WindowSize`], [`TcpOption`],
 //! [`Quirk`], [`PayloadSize`]) are re-exported from `huginn-net-tcp`. This
@@ -10,7 +10,7 @@ mod distances;
 mod signature;
 
 pub use distances::{
-    distance_ip_version, distance_payload_size, distance_ttl, distance_window_size,
+    ip_version_matches, payload_size_matches, ttl_fit, window_size_matches, TtlFit,
     MAX_TTL_DISTANCE,
 };
-pub use signature::{Signature, TcpMatchQuality};
+pub use signature::Signature;

--- a/huginn-net-db/src/tcp/signature.rs
+++ b/huginn-net-db/src/tcp/signature.rs
@@ -1,43 +1,5 @@
-use crate::db_matching_trait::MatchQuality;
 use core::fmt;
 use std::fmt::Formatter;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TcpMatchQuality {
-    High,
-    Medium,
-    Low,
-}
-
-impl TcpMatchQuality {
-    pub fn as_score(self) -> u32 {
-        match self {
-            TcpMatchQuality::High => 0,
-            TcpMatchQuality::Medium => 1,
-            TcpMatchQuality::Low => 2,
-        }
-    }
-}
-
-impl MatchQuality for TcpMatchQuality {
-    // TCP has 9 components, each can contribute max 2 points (Low)
-    const MAX_DISTANCE: u32 = 18;
-
-    fn distance_to_score(distance: u32) -> f32 {
-        match distance {
-            0 => 1.0,
-            1 => 0.95,
-            2 => 0.90,
-            3..=4 => 0.80,
-            5..=6 => 0.70,
-            7..=9 => 0.60,
-            10..=12 => 0.40,
-            13..=15 => 0.20,
-            d if d <= Self::MAX_DISTANCE => 0.10,
-            _ => 0.05,
-        }
-    }
-}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Signature {

--- a/huginn-net-db/tests/http_distance_habsent.rs
+++ b/huginn-net-db/tests/http_distance_habsent.rs
@@ -1,16 +1,12 @@
 #![cfg(feature = "http")]
 
-use huginn_net_db::http::{distance_habsent, Header, HttpMatchQuality};
-
-fn matches() -> Option<u32> {
-    Some(HttpMatchQuality::High.as_score())
-}
+use huginn_net_db::http::{absent_headers_match, Header};
 
 #[test]
 fn empty_absent_list_always_matches() {
     let observed = vec![Header::new("Host"), Header::new("Accept-Charset")];
 
-    assert_eq!(distance_habsent(&observed, &[]), matches());
+    assert!(absent_headers_match(&observed, &[]));
 }
 
 #[test]
@@ -18,7 +14,7 @@ fn forbidden_header_absent_from_traffic_matches() {
     let observed = vec![Header::new("Host"), Header::new("User-Agent")];
     let forbidden = vec![Header::new("Accept-Charset"), Header::new("Keep-Alive")];
 
-    assert_eq!(distance_habsent(&observed, &forbidden), matches());
+    assert!(absent_headers_match(&observed, &forbidden));
 }
 
 #[test]
@@ -30,7 +26,7 @@ fn forbidden_header_present_in_traffic_rejects() {
     ];
     let forbidden = vec![Header::new("Accept-Charset")];
 
-    assert_eq!(distance_habsent(&observed, &forbidden), None);
+    assert!(!absent_headers_match(&observed, &forbidden));
 }
 
 #[test]
@@ -40,7 +36,7 @@ fn only_the_header_name_is_considered() {
     let observed = vec![Header::new("Keep-Alive").with_value("timeout=5")];
     let forbidden = vec![Header::new("Keep-Alive").with_value("something else")];
 
-    assert_eq!(distance_habsent(&observed, &forbidden), None);
+    assert!(!absent_headers_match(&observed, &forbidden));
 }
 
 #[test]
@@ -53,5 +49,5 @@ fn position_in_the_traffic_is_irrelevant() {
     ];
     let forbidden = vec![Header::new("Keep-Alive")];
 
-    assert_eq!(distance_habsent(&observed, &forbidden), None);
+    assert!(!absent_headers_match(&observed, &forbidden));
 }

--- a/huginn-net-db/tests/http_distance_header.rs
+++ b/huginn-net-db/tests/http_distance_header.rs
@@ -1,10 +1,10 @@
 #![cfg(feature = "http")]
-use huginn_net_db::http::{Header, HttpMatchQuality};
+use huginn_net_db::http::Header;
 use huginn_net_db::observable_http_signals_matching::HttpDistance;
 use huginn_net_http::observable::{HttpRequestObservation, HttpResponseObservation};
 
 #[test]
-fn test_distance_header_with_one_optional_header_mismatch() {
+fn test_headers_with_one_optional_header_mismatch() {
     let a = vec![
         Header::new("Date"),
         Header::new("Server"),
@@ -39,16 +39,15 @@ fn test_distance_header_with_one_optional_header_mismatch() {
     assert!(!b[6].optional);
     assert_ne!(a[6], b[6]);
 
-    let result = <HttpResponseObservation as HttpDistance>::distance_header(&a, &b);
-    assert_eq!(
+    let result = <HttpResponseObservation as HttpDistance>::headers_match(&a, &b);
+    assert!(
         result,
-        Some(HttpMatchQuality::High.as_score()),
         "only the signature's optional flag is consulted, so the observation's differing flag is irrelevant"
     );
 }
 
 #[test]
-fn test_distance_header_optional_skip_in_middle() {
+fn test_headers_optional_skip_in_middle() {
     let observed = vec![
         Header::new("Host"),
         Header::new("User-Agent").with_value("Mozilla/5.0"),
@@ -64,16 +63,12 @@ fn test_distance_header_optional_skip_in_middle() {
         Header::new("Connection").with_value("keep-alive"),
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
-    assert_eq!(
-        result,
-        Some(HttpMatchQuality::High.as_score()),
-        "Optional header in middle should be skipped for perfect alignment"
-    );
+    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    assert!(result, "Optional header in middle should be skipped for perfect alignment");
 }
 
 #[test]
-fn test_distance_header_multiple_optional_skips() {
+fn test_headers_multiple_optional_skips() {
     let observed = vec![Header::new("Host"), Header::new("Connection").with_value("keep-alive")];
 
     let signature = vec![
@@ -85,16 +80,12 @@ fn test_distance_header_multiple_optional_skips() {
         Header::new("Connection").with_value("keep-alive"),
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
-    assert_eq!(
-        result,
-        Some(HttpMatchQuality::High.as_score()),
-        "Multiple optional headers should be skipped"
-    );
+    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    assert!(result, "Multiple optional headers should be skipped");
 }
 
 #[test]
-fn test_distance_header_missing_required_header_in_middle_rejects() {
+fn test_headers_missing_required_header_in_middle_rejects() {
     let observed = vec![Header::new("Host"), Header::new("Connection").with_value("keep-alive")];
 
     let signature = vec![
@@ -103,12 +94,12 @@ fn test_distance_header_missing_required_header_in_middle_rejects() {
         Header::new("Connection").with_value("keep-alive"),
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
-    assert_eq!(result, None, "a required header missing rejects the signature outright");
+    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    assert!(!result, "a required header missing rejects the signature outright");
 }
 
 #[test]
-fn test_distance_header_realistic_browser_with_optional_skips() {
+fn test_headers_realistic_browser_with_optional_skips() {
     let observed = vec![
         Header::new("Host"),
         Header::new("User-Agent").with_value("Mozilla/5.0"),
@@ -128,16 +119,12 @@ fn test_distance_header_realistic_browser_with_optional_skips() {
         Header::new("Connection").with_value("keep-alive"),
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
-    assert_eq!(
-        result,
-        Some(HttpMatchQuality::High.as_score()),
-        "Browser should match signature even with optional headers missing"
-    );
+    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    assert!(result, "Browser should match signature even with optional headers missing");
 }
 
 #[test]
-fn test_distance_header_missing_optional_header() {
+fn test_headers_missing_optional_header() {
     let observed = vec![Header::new("Host"), Header::new("User-Agent").with_value("Mozilla/5.0")];
 
     let signature = vec![
@@ -148,16 +135,12 @@ fn test_distance_header_missing_optional_header() {
             .with_value("en-US"), // Missing but optional
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
-    assert_eq!(
-        result,
-        Some(HttpMatchQuality::High.as_score()),
-        "Missing optional headers should not cause errors"
-    );
+    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    assert!(result, "Missing optional headers should not cause errors");
 }
 
 #[test]
-fn test_distance_header_missing_required_header_at_end_rejects() {
+fn test_headers_missing_required_header_at_end_rejects() {
     let observed = vec![Header::new("Host")];
 
     let signature = vec![
@@ -165,12 +148,12 @@ fn test_distance_header_missing_required_header_at_end_rejects() {
         Header::new("User-Agent").with_value("Mozilla/5.0"), // Missing and NOT optional
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
-    assert_eq!(result, None, "a required header missing rejects the signature outright");
+    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    assert!(!result, "a required header missing rejects the signature outright");
 }
 
 #[test]
-fn test_distance_header_extra_headers_in_observed_are_free() {
+fn test_headers_extra_headers_in_observed_are_free() {
     let observed = vec![
         Header::new("Host"),
         Header::new("X-Custom-Header").with_value("custom"), // Not in the signature
@@ -180,16 +163,15 @@ fn test_distance_header_extra_headers_in_observed_are_free() {
 
     let signature = vec![Header::new("Host"), Header::new("User-Agent").with_value("Mozilla/5.0")];
 
-    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
-    assert_eq!(
+    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    assert!(
         result,
-        Some(HttpMatchQuality::High.as_score()),
         "headers the signature does not mention never penalise, wherever they appear"
     );
 }
 
 #[test]
-fn test_distance_header_expected_value_matches_as_substring() {
+fn test_headers_expected_value_matches_as_substring() {
     let observed = vec![
         Header::new("Host"),
         Header::new("Accept").with_value("image/avif,image/webp,image/*,*/*;q=0.8"),
@@ -197,26 +179,22 @@ fn test_distance_header_expected_value_matches_as_substring() {
 
     let signature = vec![Header::new("Host"), Header::new("Accept").with_value("*/*")];
 
-    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
-    assert_eq!(
-        result,
-        Some(HttpMatchQuality::High.as_score()),
-        "the expected value only has to be contained in the observed one"
-    );
+    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    assert!(result, "the expected value only has to be contained in the observed one");
 }
 
 #[test]
-fn test_distance_header_expects_value_but_observed_has_none_rejects() {
+fn test_headers_expects_value_but_observed_has_none_rejects() {
     let observed = vec![Header::new("Host"), Header::new("User-Agent")];
 
     let signature = vec![Header::new("Host"), Header::new("User-Agent").with_value("Mozilla/5.0")];
 
-    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
-    assert_eq!(result, None, "a valueless observed header cannot satisfy an expected value");
+    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    assert!(!result, "a valueless observed header cannot satisfy an expected value");
 }
 
 #[test]
-fn test_distance_header_optional_header_out_of_order_rejects() {
+fn test_headers_optional_header_out_of_order_rejects() {
     // The signature wants Referer between Host and User-Agent. It does appear
     // in the traffic, just in the wrong place: p0f treats that as a mismatch
     // rather than as a missing optional header.
@@ -232,22 +210,22 @@ fn test_distance_header_optional_header_out_of_order_rejects() {
         Header::new("User-Agent").with_value("Mozilla/5.0"),
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
-    assert_eq!(result, None, "an optional header present out of order rejects the signature");
+    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    assert!(!result, "an optional header present out of order rejects the signature");
 }
 
 #[test]
-fn test_distance_header_required_header_out_of_order_rejects() {
+fn test_headers_required_header_out_of_order_rejects() {
     let observed = vec![Header::new("Connection").with_value("keep-alive"), Header::new("Host")];
 
     let signature = vec![Header::new("Host"), Header::new("Connection").with_value("keep-alive")];
 
-    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
-    assert_eq!(result, None, "header order is part of the signature");
+    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    assert!(!result, "header order is part of the signature");
 }
 
 #[test]
-fn test_distance_header_optional_header_at_end() {
+fn test_headers_optional_header_at_end() {
     let observed = vec![Header::new("Host"), Header::new("User-Agent").with_value("Mozilla/5.0")];
 
     let signature = vec![
@@ -258,16 +236,12 @@ fn test_distance_header_optional_header_at_end() {
             .with_value("en-US"), // Optional, missing
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
-    assert_eq!(
-        result,
-        Some(HttpMatchQuality::High.as_score()),
-        "Missing optional headers at end should not cause errors"
-    );
+    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    assert!(result, "Missing optional headers at end should not cause errors");
 }
 
 #[test]
-fn test_distance_header_observed_vs_signature_with_optional() {
+fn test_headers_observed_vs_signature_with_optional() {
     let observed = vec![
         Header::new("Host"),
         Header::new("User-Agent").with_value("Mozilla/5.0"),
@@ -284,16 +258,15 @@ fn test_distance_header_observed_vs_signature_with_optional() {
             .with_value("en-US"), // Optional but value must match
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
-    assert_eq!(
+    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    assert!(
         result,
-        Some(HttpMatchQuality::High.as_score()),
         "Should match perfectly: all headers match including values for optional headers"
     );
 }
 
 #[test]
-fn test_distance_header_value_mismatch_rejects() {
+fn test_headers_value_mismatch_rejects() {
     let observed = vec![Header::new("Host"), Header::new("Connection").with_value("keep-alive")];
 
     let signature = vec![
@@ -301,12 +274,12 @@ fn test_distance_header_value_mismatch_rejects() {
         Header::new("Connection").with_value("close"), // Different value
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
-    assert_eq!(result, None, "a value that is not a substring of the observed one rejects");
+    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    assert!(!result, "a value that is not a substring of the observed one rejects");
 }
 
 #[test]
-fn test_distance_header_value_mismatch_rejects_even_when_optional() {
+fn test_headers_value_mismatch_rejects_even_when_optional() {
     let observed = vec![Header::new("Host"), Header::new("Referer").with_value("http://other")];
 
     let signature = vec![
@@ -316,12 +289,12 @@ fn test_distance_header_value_mismatch_rejects_even_when_optional() {
             .with_value("http://example.com"),
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
-    assert_eq!(result, None, "optional headers that are present must still match their value");
+    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    assert!(!result, "optional headers that are present must still match their value");
 }
 
 #[test]
-fn test_distance_header_realistic_browser_scenario() {
+fn test_headers_realistic_browser_scenario() {
     let observed = vec![
         Header::new("Host"),
         Header::new("User-Agent")
@@ -345,10 +318,9 @@ fn test_distance_header_realistic_browser_scenario() {
         Header::new("Connection").with_value("keep-alive"),
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::distance_header(&observed, &signature);
-    assert_eq!(
+    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    assert!(
         result,
-        Some(HttpMatchQuality::High.as_score()),
         "Should match perfectly for realistic Chrome signature with value matching"
     );
 }

--- a/huginn-net-db/tests/http_expsw.rs
+++ b/huginn-net-db/tests/http_expsw.rs
@@ -51,7 +51,7 @@ fn a_contradicting_software_string_is_dishonest() {
 }
 
 #[test]
-fn software_string_does_not_change_the_distance() {
+fn software_string_does_not_change_the_fit() {
     let db = HttpDatabase::load_default()
         .unwrap_or_else(|e| panic!("failed to create default database: {e}"));
 
@@ -72,18 +72,20 @@ fn software_string_does_not_change_the_distance() {
     };
 
     let matcher = HttpSignatureMatcher::new(&db);
-    let (_label, signature, honest_quality) = matcher
+    let honest_match = matcher
         .matching_by_http_request(&observation("Firefox/"))
         .unwrap_or_else(|| panic!("no match found for the Firefox 2.x signature"));
 
-    let honest = signature.calculate_distance(&observation("Firefox/"));
-    let lying = signature.calculate_distance(&observation("definitely-not-firefox"));
-    assert_eq!(honest, lying, "expsw must not contribute to the distance");
+    let honest = honest_match.signature.fit(&observation("Firefox/"));
+    let lying = honest_match
+        .signature
+        .fit(&observation("definitely-not-firefox"));
+    assert_eq!(honest, lying, "expsw must not affect how well the signature fits");
 
-    let (_label, _signature, lying_quality) = matcher
+    let lying_match = matcher
         .matching_by_http_request(&observation("definitely-not-firefox"))
         .unwrap_or_else(|| panic!("a dishonest software string must not reject the signature"));
-    assert_eq!(honest_quality, lying_quality);
+    assert_eq!(honest_match.quality, lying_match.quality);
 }
 
 #[test]

--- a/huginn-net-db/tests/http_matcher.rs
+++ b/huginn-net-db/tests/http_matcher.rs
@@ -27,14 +27,12 @@ fn matching_firefox2_by_http_request() {
 
     let matcher = HttpSignatureMatcher::new(&db);
 
-    if let Some((label, _matched_db_sig, quality)) =
-        matcher.matching_by_http_request(&firefox_signature)
-    {
-        assert_eq!(label.name, "Firefox");
-        assert_eq!(label.class, None);
-        assert_eq!(label.flavor, Some("2.x".to_string()));
-        assert_eq!(label.ty, Type::Specified);
-        assert_eq!(quality, 1.0);
+    if let Some(found) = matcher.matching_by_http_request(&firefox_signature) {
+        assert_eq!(found.label.name, "Firefox");
+        assert_eq!(found.label.class, None);
+        assert_eq!(found.label.flavor, Some("2.x".to_string()));
+        assert_eq!(found.label.ty, Type::Specified);
+        assert_eq!(found.quality, 1.0);
     } else {
         panic!("No match found for Firefox 2.x HTTP signature");
     }
@@ -71,14 +69,12 @@ fn matching_apache_by_http_response() {
 
     let matcher = HttpSignatureMatcher::new(&db);
 
-    if let Some((label, _matched_db_sig, quality)) =
-        matcher.matching_by_http_response(&apache_signature)
-    {
-        assert_eq!(label.name, "Apache");
-        assert_eq!(label.class, None);
-        assert_eq!(label.flavor, Some("2.x".to_string()));
-        assert_eq!(label.ty, Type::Specified);
-        assert_eq!(quality, 1.0);
+    if let Some(found) = matcher.matching_by_http_response(&apache_signature) {
+        assert_eq!(found.label.name, "Apache");
+        assert_eq!(found.label.class, None);
+        assert_eq!(found.label.flavor, Some("2.x".to_string()));
+        assert_eq!(found.label.ty, Type::Specified);
+        assert_eq!(found.quality, 1.0);
     } else {
         panic!("No match found for Apache 2.x HTTP response signature");
     }
@@ -111,14 +107,12 @@ fn matching_chrome11_by_http_request() {
 
     let matcher = HttpSignatureMatcher::new(&db);
 
-    if let Some((label, _matched_db_sig, quality)) =
-        matcher.matching_by_http_request(&chrome_signature)
-    {
-        assert_eq!(label.name, "Chrome");
-        assert_eq!(label.class, None);
-        assert_eq!(label.flavor, Some("11 or newer".to_string()));
-        assert_eq!(label.ty, Type::Specified);
-        assert_eq!(quality, 1.0);
+    if let Some(found) = matcher.matching_by_http_request(&chrome_signature) {
+        assert_eq!(found.label.name, "Chrome");
+        assert_eq!(found.label.class, None);
+        assert_eq!(found.label.flavor, Some("11 or newer".to_string()));
+        assert_eq!(found.label.ty, Type::Specified);
+        assert_eq!(found.quality, 1.0);
     } else {
         panic!("No match found for Chrome 11 HTTP signature");
     }
@@ -188,7 +182,7 @@ fn unknown_request_signature_does_not_match() {
     assert!(
         result.is_none(),
         "expected no match for synthetic signature, got {:?}",
-        result.map(|(label, _, q)| (label.name.clone(), q))
+        result.map(|found| (found.label.name.clone(), found.quality))
     );
 }
 

--- a/huginn-net-db/tests/snapshots/macos_tcp_flags.pcap.json
+++ b/huginn-net-db/tests/snapshots/macos_tcp_flags.pcap.json
@@ -17,7 +17,8 @@
           "os_name": "Mac OS X",
           "os_family": "unix",
           "os_variant": "10.x",
-          "quality": "Matched(0.9)",
+          "quality": "Matched(0.5)",
+          "fuzzy": "missing id+, extra ecn",
           "raw_signature": "4:64+0:0:1460:65535,6:mss,nop,ws,nop,nop,ts,sok,eol+1:df,ecn:0"
         },
         "syn_ack": null,

--- a/huginn-net-db/tests/tcp_distances.rs
+++ b/huginn-net-db/tests/tcp_distances.rs
@@ -1,113 +1,96 @@
 #![cfg(feature = "tcp")]
-use huginn_net_db::tcp::{
-    distance_ttl, distance_window_size, TcpMatchQuality, Ttl, WindowSize, MAX_TTL_DISTANCE,
-};
+use huginn_net_db::tcp::{ttl_fit, window_size_matches, Ttl, TtlFit, WindowSize, MAX_TTL_DISTANCE};
 
-fn exact() -> Option<u32> {
-    Some(TcpMatchQuality::High.as_score())
+/// The observation supports the signature's initial TTL, `hops` routers away.
+fn exact(hops: u32) -> Option<TtlFit> {
+    Some(TtlFit { hop_distance: hops, out_of_range: false })
 }
 
-/// Score of a TTL that no longer supports the signature's initial TTL: still
-/// a match, but only a fuzzy one.
-fn fuzzy() -> Option<u32> {
-    Some(TcpMatchQuality::Low.as_score())
+/// The observed TTL no longer supports the signature's initial TTL: still a
+/// match, but only a fuzzy one.
+fn fuzzy(hops: u32) -> Option<TtlFit> {
+    Some(TtlFit { hop_distance: hops, out_of_range: true })
 }
 
 #[test]
-fn test_distance_ttl_matches_when_observed_equals_initial() {
-    assert_eq!(distance_ttl(&Ttl::Value(64), &Ttl::Value(64)), exact());
-    assert_eq!(distance_ttl(&Ttl::Value(64), &Ttl::Guess(64)), exact());
+fn test_ttl_fit_matches_when_observed_equals_initial() {
+    assert_eq!(ttl_fit(&Ttl::Value(64), &Ttl::Value(64)), exact(0));
+    assert_eq!(ttl_fit(&Ttl::Value(64), &Ttl::Guess(64)), exact(0));
     // `nnn+d` in the database means "initial TTL is nnn + d".
-    assert_eq!(distance_ttl(&Ttl::Value(64), &Ttl::Distance(57, 7)), exact());
+    assert_eq!(ttl_fit(&Ttl::Value(64), &Ttl::Distance(57, 7)), exact(0));
 }
 
 #[test]
-fn test_distance_ttl_matches_within_hop_distance() {
+fn test_ttl_fit_matches_within_hop_distance() {
     // Observed TTL below the signature's initial TTL is the normal case: the
     // difference is the hop count, and any plausible count matches exactly.
-    assert_eq!(distance_ttl(&Ttl::Distance(57, 7), &Ttl::Value(64)), exact());
-    assert_eq!(distance_ttl(&Ttl::Value(50), &Ttl::Value(64)), exact());
-    assert_eq!(distance_ttl(&Ttl::Guess(100), &Ttl::Value(128)), exact());
+    assert_eq!(ttl_fit(&Ttl::Distance(57, 7), &Ttl::Value(64)), exact(7));
+    assert_eq!(ttl_fit(&Ttl::Value(50), &Ttl::Value(64)), exact(14));
+    assert_eq!(ttl_fit(&Ttl::Guess(100), &Ttl::Value(128)), exact(28));
     // The old implementation compared the enum contents, so a signature
     // written as `60+7` (initial TTL 67) failed against an observed 64.
-    assert_eq!(distance_ttl(&Ttl::Value(64), &Ttl::Distance(60, 7)), exact());
+    assert_eq!(ttl_fit(&Ttl::Value(64), &Ttl::Distance(60, 7)), exact(3));
 }
 
 #[test]
-fn test_distance_ttl_hop_distance_boundary() {
+fn test_ttl_fit_hop_distance_boundary() {
     let initial = 64;
     let at_limit = initial - MAX_TTL_DISTANCE;
-    assert_eq!(distance_ttl(&Ttl::Value(at_limit), &Ttl::Value(initial)), exact());
-    assert_eq!(distance_ttl(&Ttl::Value(at_limit - 1), &Ttl::Value(initial)), fuzzy());
+    assert_eq!(
+        ttl_fit(&Ttl::Value(at_limit), &Ttl::Value(initial)),
+        exact(u32::from(MAX_TTL_DISTANCE))
+    );
+    assert_eq!(
+        ttl_fit(&Ttl::Value(at_limit - 1), &Ttl::Value(initial)),
+        fuzzy(u32::from(MAX_TTL_DISTANCE) + 1)
+    );
 }
 
 #[test]
-fn test_distance_ttl_is_fuzzy_beyond_hop_distance() {
-    assert_eq!(distance_ttl(&Ttl::Value(64), &Ttl::Value(128)), fuzzy());
-    assert_eq!(distance_ttl(&Ttl::Distance(57, 7), &Ttl::Value(128)), fuzzy());
+fn test_ttl_fit_is_fuzzy_beyond_hop_distance() {
+    assert_eq!(ttl_fit(&Ttl::Value(64), &Ttl::Value(128)), fuzzy(64));
+    assert_eq!(ttl_fit(&Ttl::Distance(57, 7), &Ttl::Value(128)), fuzzy(71));
     // TTL 0 (parsed as `Bad` on the observed side) against a normal signature.
-    assert_eq!(distance_ttl(&Ttl::Bad(0), &Ttl::Value(64)), fuzzy());
+    assert_eq!(ttl_fit(&Ttl::Bad(0), &Ttl::Value(64)), fuzzy(64));
 }
 
 #[test]
-fn test_distance_ttl_is_fuzzy_when_observed_exceeds_initial() {
-    // A TTL can only decrease in transit, so this cannot be a clean match.
-    assert_eq!(distance_ttl(&Ttl::Value(128), &Ttl::Value(64)), fuzzy());
+fn test_ttl_fit_is_fuzzy_when_observed_exceeds_initial() {
+    // A TTL can only decrease in transit, so this cannot be a clean match, and
+    // there are no hops to report.
+    assert_eq!(ttl_fit(&Ttl::Value(128), &Ttl::Value(64)), fuzzy(0));
 }
 
 #[test]
-fn test_distance_ttl_randomised_signature_only_enforces_upper_bound() {
+fn test_ttl_fit_randomised_signature_only_enforces_upper_bound() {
     // `nnn-` in the database: the value carries no hop information, so any
     // observation at or below it matches, and anything above is rejected.
-    assert_eq!(distance_ttl(&Ttl::Value(64), &Ttl::Bad(64)), exact());
-    assert_eq!(distance_ttl(&Ttl::Value(1), &Ttl::Bad(64)), exact());
-    assert_eq!(distance_ttl(&Ttl::Distance(64, 7), &Ttl::Bad(0)), None);
-    assert_eq!(distance_ttl(&Ttl::Value(65), &Ttl::Bad(64)), None);
+    assert_eq!(ttl_fit(&Ttl::Value(64), &Ttl::Bad(64)), exact(0));
+    assert_eq!(ttl_fit(&Ttl::Value(1), &Ttl::Bad(64)), exact(63));
+    assert_eq!(ttl_fit(&Ttl::Distance(64, 7), &Ttl::Bad(0)), None);
+    assert_eq!(ttl_fit(&Ttl::Value(65), &Ttl::Bad(64)), None);
 }
 
-/// p0f never tolerates a window-size mismatch: every branch below must reject (`None`) rather than fall back to a soft `Low` penalty.
+/// p0f never tolerates a window-size mismatch: every branch below must reject
+/// rather than degrade into a fuzzy match.
 #[test]
-fn test_distance_window_size_matching_cases() {
-    assert_eq!(
-        distance_window_size(&WindowSize::Mss(4), &WindowSize::Mss(4), None),
-        Some(TcpMatchQuality::High.as_score())
-    );
-    assert_eq!(
-        distance_window_size(&WindowSize::Mtu(2), &WindowSize::Mtu(2), None),
-        Some(TcpMatchQuality::High.as_score())
-    );
-    assert_eq!(
-        distance_window_size(&WindowSize::Mod(8192), &WindowSize::Mod(8192), None),
-        Some(TcpMatchQuality::High.as_score())
-    );
-    assert_eq!(
-        distance_window_size(&WindowSize::Value(65535), &WindowSize::Value(65535), None),
-        Some(TcpMatchQuality::High.as_score())
-    );
-    assert_eq!(
-        distance_window_size(&WindowSize::Value(5840), &WindowSize::Mss(4), Some(1460)),
-        Some(TcpMatchQuality::High.as_score())
-    );
-    assert_eq!(
-        distance_window_size(&WindowSize::Value(12345), &WindowSize::Any, None),
-        Some(TcpMatchQuality::High.as_score())
-    );
+fn test_window_size_matching_cases() {
+    assert!(window_size_matches(&WindowSize::Mss(4), &WindowSize::Mss(4), None));
+    assert!(window_size_matches(&WindowSize::Mtu(2), &WindowSize::Mtu(2), None));
+    assert!(window_size_matches(&WindowSize::Mod(8192), &WindowSize::Mod(8192), None));
+    assert!(window_size_matches(&WindowSize::Value(65535), &WindowSize::Value(65535), None));
+    assert!(window_size_matches(&WindowSize::Value(5840), &WindowSize::Mss(4), Some(1460)));
+    assert!(window_size_matches(&WindowSize::Value(12345), &WindowSize::Any, None));
 }
 
 #[test]
-fn test_distance_window_size_rejects_on_mismatch() {
-    assert_eq!(distance_window_size(&WindowSize::Mss(4), &WindowSize::Mss(5), None), None);
-    assert_eq!(distance_window_size(&WindowSize::Mtu(2), &WindowSize::Mtu(3), None), None);
-    assert_eq!(distance_window_size(&WindowSize::Mod(8192), &WindowSize::Mod(4096), None), None);
-    assert_eq!(
-        distance_window_size(&WindowSize::Value(65535), &WindowSize::Value(1), None),
-        None
-    );
+fn test_window_size_rejects_on_mismatch() {
+    assert!(!window_size_matches(&WindowSize::Mss(4), &WindowSize::Mss(5), None));
+    assert!(!window_size_matches(&WindowSize::Mtu(2), &WindowSize::Mtu(3), None));
+    assert!(!window_size_matches(&WindowSize::Mod(8192), &WindowSize::Mod(4096), None));
+    assert!(!window_size_matches(&WindowSize::Value(65535), &WindowSize::Value(1), None));
     // Wrong ratio for the observed MSS.
-    assert_eq!(
-        distance_window_size(&WindowSize::Value(5840), &WindowSize::Mss(3), Some(1460)),
-        None
-    );
+    assert!(!window_size_matches(&WindowSize::Value(5840), &WindowSize::Mss(3), Some(1460)));
     // No observed MSS available to resolve the ratio against.
-    assert_eq!(distance_window_size(&WindowSize::Value(5840), &WindowSize::Mss(4), None), None);
+    assert!(!window_size_matches(&WindowSize::Value(5840), &WindowSize::Mss(4), None));
 }

--- a/huginn-net-db/tests/tcp_match_selection.rs
+++ b/huginn-net-db/tests/tcp_match_selection.rs
@@ -1,6 +1,4 @@
 #![cfg(feature = "tcp")]
-//! Selection when several signatures fit: Specific > Generic > Fuzzy.
-//! Within a tier, the closer initial TTL wins.
 
 use huginn_net_db::database::{FingerprintCollection, Label, TcpIndexKey, Type};
 use huginn_net_db::db_matching_trait::FingerprintDb;

--- a/huginn-net-db/tests/tcp_match_selection.rs
+++ b/huginn-net-db/tests/tcp_match_selection.rs
@@ -1,0 +1,140 @@
+#![cfg(feature = "tcp")]
+//! Selection when several signatures fit: Specific > Generic > Fuzzy.
+//! Within a tier, the closer initial TTL wins.
+
+use huginn_net_db::database::{FingerprintCollection, Label, TcpIndexKey, Type};
+use huginn_net_db::db_matching_trait::FingerprintDb;
+use huginn_net_db::tcp::{IpVersion, PayloadSize, Quirk, Signature, Ttl, WindowSize};
+use huginn_net_tcp::observable::TcpObservation;
+
+type TcpCollection = FingerprintCollection<TcpObservation, Signature, TcpIndexKey>;
+
+fn observation() -> TcpObservation {
+    TcpObservation {
+        version: IpVersion::V4,
+        ittl: Ttl::Value(64),
+        olen: 0,
+        mss: Some(1460),
+        wsize: WindowSize::Value(65535),
+        wscale: Some(6),
+        olayout: Vec::new(),
+        quirks: Vec::new(),
+        pclass: PayloadSize::Zero,
+    }
+}
+
+/// Fits [`observation`] exactly.
+fn signature() -> Signature {
+    Signature {
+        version: IpVersion::V4,
+        ittl: Ttl::Value(64),
+        olen: 0,
+        mss: Some(1460),
+        wsize: WindowSize::Value(65535),
+        wscale: Some(6),
+        olayout: Vec::new(),
+        quirks: Vec::new(),
+        pclass: PayloadSize::Zero,
+    }
+}
+
+/// Only fits [`observation`] through the quirks whitelist: p0f lets `df`
+/// disappear from the traffic, but the match is fuzzy.
+fn fuzzy_signature() -> Signature {
+    Signature { quirks: vec![Quirk::Df], ..signature() }
+}
+
+fn label(name: &str, ty: Type) -> Label {
+    Label { ty, class: Some("unix".to_string()), name: name.to_string(), flavor: None }
+}
+
+/// An application rather than an OS: p0f writes these as `s:!:…`, which parses
+/// to a label with no class.
+fn application_label(name: &str) -> Label {
+    Label { ty: Type::Specified, class: None, name: name.to_string(), flavor: None }
+}
+
+fn best_match(entries: Vec<(Label, Vec<Signature>)>) -> Option<(String, f32)> {
+    let collection = TcpCollection::new(entries);
+    collection
+        .find_best_match(&observation())
+        .map(|found| (found.label.name.clone(), found.quality))
+}
+
+#[test]
+fn a_specific_signature_wins_over_a_generic_one_whatever_the_database_order() {
+    for reversed in [false, true] {
+        let mut entries = vec![
+            (label("Generic OS", Type::Generic), vec![signature()]),
+            (label("Specific OS", Type::Specified), vec![signature()]),
+        ];
+        if reversed {
+            entries.reverse();
+        }
+
+        let (name, quality) = best_match(entries).unwrap_or_else(|| panic!("expected a match"));
+        assert_eq!(name, "Specific OS");
+        assert_eq!(quality, 1.0);
+    }
+}
+
+#[test]
+fn an_exact_generic_match_wins_over_a_fuzzy_specific_one() {
+    // p0f keeps its fuzzy candidate aside and only reaches for it once no
+    // generic signature fit either, so a tolerance never outranks an exact fit.
+    let (name, quality) = best_match(vec![
+        (label("Fuzzy Specific OS", Type::Specified), vec![fuzzy_signature()]),
+        (label("Generic OS", Type::Generic), vec![signature()]),
+    ])
+    .unwrap_or_else(|| panic!("expected a match"));
+
+    assert_eq!(name, "Generic OS");
+    assert_eq!(quality, 0.8);
+}
+
+#[test]
+fn a_fuzzy_match_is_reported_when_nothing_fits_exactly() {
+    let (name, quality) =
+        best_match(vec![(label("Fuzzy OS", Type::Specified), vec![fuzzy_signature()])])
+            .unwrap_or_else(|| panic!("expected a fuzzy match"));
+
+    assert_eq!(name, "Fuzzy OS");
+    assert_eq!(quality, 0.5);
+}
+
+#[test]
+fn an_application_is_never_reported_on_a_fuzzy_match() {
+    // "No fuzzy matching for userland tools": guessing which tool sent a packet
+    // from an approximate match is worse than saying nothing.
+    assert_eq!(best_match(vec![(application_label("NMap"), vec![fuzzy_signature()])]), None);
+}
+
+#[test]
+fn an_application_is_still_reported_on_an_exact_match() {
+    let (name, _quality) = best_match(vec![(application_label("NMap"), vec![signature()])])
+        .unwrap_or_else(|| panic!("an exact fit against an application signature is a match"));
+
+    assert_eq!(name, "NMap");
+}
+
+#[test]
+fn within_a_tier_the_closest_initial_ttl_wins() {
+    // Both fit: the observed TTL of 64 is plausible for a host 0 hops away with
+    // an initial TTL of 64, and for one 191 hops away with an initial TTL of
+    // 255. Only the first is a sensible explanation.
+    for reversed in [false, true] {
+        let mut entries = vec![
+            (
+                label("Far OS", Type::Specified),
+                vec![Signature { ittl: Ttl::Bad(255), ..signature() }],
+            ),
+            (label("Near OS", Type::Specified), vec![signature()]),
+        ];
+        if reversed {
+            entries.reverse();
+        }
+
+        let (name, _quality) = best_match(entries).unwrap_or_else(|| panic!("expected a match"));
+        assert_eq!(name, "Near OS");
+    }
+}

--- a/huginn-net-db/tests/tcp_matcher.rs
+++ b/huginn-net-db/tests/tcp_matcher.rs
@@ -28,8 +28,13 @@ fn match_request(
         Err(e) => panic!("Failed to parse signature {raw}: {e}"),
     };
     let obs = ObservableTcp { matching: observation_from_signature(&sig) };
-    let (label, _, quality) = matcher.matching_by_tcp_request(&obs)?;
-    Some((label.name.clone(), label.class.clone(), label.flavor.clone(), quality))
+    let found = matcher.matching_by_tcp_request(&obs)?;
+    Some((
+        found.label.name.clone(),
+        found.label.class.clone(),
+        found.label.flavor.clone(),
+        found.quality,
+    ))
 }
 
 #[test]
@@ -64,14 +69,15 @@ fn matching_linux_by_tcp_request() {
 
     let matcher = TcpSignatureMatcher::new(&db);
 
-    if let Some((label, _matched_db_sig, quality)) =
-        matcher.matching_by_tcp_request(&linux_signature)
-    {
-        assert_eq!(label.name, "Linux");
-        assert_eq!(label.class, Some("unix".to_string()));
-        assert_eq!(label.flavor, Some("2.2.x-3.x".to_string()));
-        assert_eq!(label.ty, Type::Generic);
-        assert_eq!(quality, 1.0);
+    if let Some(found) = matcher.matching_by_tcp_request(&linux_signature) {
+        assert_eq!(found.label.name, "Linux");
+        assert_eq!(found.label.class, Some("unix".to_string()));
+        assert_eq!(found.label.flavor, Some("2.2.x-3.x".to_string()));
+        assert_eq!(found.label.ty, Type::Generic);
+        // A catch-all signature fits, so the match is real but ranks below what
+        // a signature naming a concrete release would have scored.
+        assert_eq!(found.quality, 0.8);
+        assert_eq!(found.fuzzy, None, "every field fit, nothing was tolerated");
     } else {
         panic!("No match found");
     }
@@ -130,26 +136,26 @@ fn matching_android_by_tcp_request() {
 
     let matcher = TcpSignatureMatcher::new(&db);
 
-    if let Some((label, _matched_db_sig, quality)) =
-        matcher.matching_by_tcp_request(&android_signature)
-    {
-        assert_eq!(label.name, "Linux");
-        assert_eq!(label.class, Some("unix".to_string()));
-        assert_eq!(label.flavor, Some("Android".to_string()));
-        assert_eq!(label.ty, Type::Specified);
-        assert_eq!(quality, 1.0);
+    if let Some(found) = matcher.matching_by_tcp_request(&android_signature) {
+        assert_eq!(found.label.name, "Linux");
+        assert_eq!(found.label.class, Some("unix".to_string()));
+        assert_eq!(found.label.flavor, Some("Android".to_string()));
+        assert_eq!(found.label.ty, Type::Specified);
+        assert_eq!(found.quality, 1.0);
+        assert_eq!(found.fuzzy, None);
     } else {
         panic!("No match found");
     }
 
-    if let Some((label, _matched_db_sig, quality)) =
-        matcher.matching_by_tcp_request(&android_signature_with_distance)
-    {
-        assert_eq!(label.name, "Linux");
-        assert_eq!(label.class, Some("unix".to_string()));
-        assert_eq!(label.flavor, Some("Android".to_string()));
-        assert_eq!(label.ty, Type::Specified);
-        assert_eq!(quality, 1.0);
+    if let Some(found) = matcher.matching_by_tcp_request(&android_signature_with_distance) {
+        assert_eq!(found.label.name, "Linux");
+        assert_eq!(found.label.class, Some("unix".to_string()));
+        assert_eq!(found.label.flavor, Some("Android".to_string()));
+        assert_eq!(found.label.ty, Type::Specified);
+        assert_eq!(found.quality, 1.0);
+        // The packet crossed routers, which is ordinary: a plausible hop count
+        // is not a tolerance.
+        assert_eq!(found.fuzzy, None);
     } else {
         panic!("No match found");
     }

--- a/huginn-net-db/tests/tcp_matching.rs
+++ b/huginn-net-db/tests/tcp_matching.rs
@@ -1,9 +1,8 @@
 #![cfg(feature = "tcp")]
-use huginn_net_db::db_matching_trait::DatabaseSignature;
-use huginn_net_db::tcp::{
-    IpVersion, PayloadSize, Quirk, Signature, TcpMatchQuality, Ttl, WindowSize,
-};
+use huginn_net_db::db_matching_trait::{DatabaseSignature, SignatureFit};
+use huginn_net_db::tcp::{IpVersion, PayloadSize, Quirk, Signature, Ttl, WindowSize};
 use huginn_net_tcp::observable::TcpObservation;
+use huginn_net_tcp::output::FuzzyReason;
 
 fn base_observation() -> TcpObservation {
     TcpObservation {
@@ -33,9 +32,28 @@ fn base_signature() -> Signature {
     }
 }
 
+/// Every field agrees, and the signature's initial TTL is exactly the observed
+/// one, so there are no hops to report either.
+fn exact() -> Option<SignatureFit<FuzzyReason>> {
+    Some(SignatureFit::exact(0))
+}
+
+/// The match only holds because these quirks were tolerated, the TTL being
+/// plausible.
+fn tolerating_quirks(missing: Vec<Quirk>, added: Vec<Quirk>) -> Option<SignatureFit<FuzzyReason>> {
+    Some(SignatureFit::fuzzy(
+        FuzzyReason {
+            implausible_hop_distance: None,
+            added_quirks: added,
+            missing_quirks: missing,
+        },
+        0,
+    ))
+}
+
 #[test]
-fn identical_signature_has_zero_distance() {
-    assert_eq!(base_signature().calculate_distance(&base_observation()), Some(0));
+fn identical_signature_fits_exactly() {
+    assert_eq!(base_signature().fit(&base_observation()), exact());
 }
 
 #[test]
@@ -43,7 +61,7 @@ fn olen_mismatch_rejects_signature() {
     let mut signature = base_signature();
     signature.olen = 4;
     assert_eq!(
-        signature.calculate_distance(&base_observation()),
+        signature.fit(&base_observation()),
         None,
         "olen is never wildcarded in p0f, so a mismatch must reject"
     );
@@ -53,25 +71,21 @@ fn olen_mismatch_rejects_signature() {
 fn wildcard_mss_matches_any_observed_value() {
     let mut signature = base_signature();
     signature.mss = None;
-    assert_eq!(signature.calculate_distance(&base_observation()), Some(0));
+    assert_eq!(signature.fit(&base_observation()), exact());
 }
 
 #[test]
 fn mss_mismatch_rejects_signature() {
     let mut signature = base_signature();
     signature.mss = Some(1400);
-    assert_eq!(
-        signature.calculate_distance(&base_observation()),
-        None,
-        "a concrete mss is a hard gate in p0f"
-    );
+    assert_eq!(signature.fit(&base_observation()), None, "a concrete mss is a hard gate in p0f");
 }
 
 #[test]
 fn wildcard_wscale_matches_any_observed_value() {
     let mut signature = base_signature();
     signature.wscale = None;
-    assert_eq!(signature.calculate_distance(&base_observation()), Some(0));
+    assert_eq!(signature.fit(&base_observation()), exact());
 }
 
 #[test]
@@ -79,7 +93,7 @@ fn wscale_mismatch_rejects_signature() {
     let mut signature = base_signature();
     signature.wscale = Some(7);
     assert_eq!(
-        signature.calculate_distance(&base_observation()),
+        signature.fit(&base_observation()),
         None,
         "a concrete wscale is a hard gate in p0f"
     );
@@ -90,7 +104,7 @@ fn window_size_mismatch_rejects_signature() {
     let mut signature = base_signature();
     signature.wsize = WindowSize::Value(8192);
     assert_eq!(
-        signature.calculate_distance(&base_observation()),
+        signature.fit(&base_observation()),
         None,
         "p0f never tolerates a window size mismatch"
     );
@@ -100,18 +114,12 @@ fn window_size_mismatch_rejects_signature() {
 fn wildcard_window_size_matches_any_observed_value() {
     let mut signature = base_signature();
     signature.wsize = WindowSize::Any;
-    assert_eq!(signature.calculate_distance(&base_observation()), Some(0));
+    assert_eq!(signature.fit(&base_observation()), exact());
 }
 
 // ---------------------------------------------------------------------------
 // Quirks: set comparison, fuzziness whitelist and IP-version masking.
 // ---------------------------------------------------------------------------
-
-/// Distance of a quirks-only fuzzy match: every other field is identical, so
-/// the whole distance comes from the tolerated quirk difference.
-fn fuzzy_quirks_distance() -> Option<u32> {
-    Some(TcpMatchQuality::Low.as_score())
-}
 
 #[test]
 fn quirks_are_compared_as_sets_not_ordered_lists() {
@@ -119,7 +127,7 @@ fn quirks_are_compared_as_sets_not_ordered_lists() {
     signature.quirks = vec![Quirk::Df, Quirk::NonZeroID];
     let mut observed = base_observation();
     observed.quirks = vec![Quirk::NonZeroID, Quirk::Df];
-    assert_eq!(signature.calculate_distance(&observed), Some(0));
+    assert_eq!(signature.fit(&observed), exact());
 }
 
 #[test]
@@ -128,8 +136,8 @@ fn missing_df_or_non_zero_id_is_a_fuzzy_match() {
         let mut signature = base_signature();
         signature.quirks = vec![quirk.clone()];
         assert_eq!(
-            signature.calculate_distance(&base_observation()),
-            fuzzy_quirks_distance(),
+            signature.fit(&base_observation()),
+            tolerating_quirks(vec![quirk.clone()], vec![]),
             "p0f tolerates {quirk:?} disappearing from the traffic"
         );
     }
@@ -141,8 +149,8 @@ fn extra_zero_id_or_ecn_is_a_fuzzy_match() {
         let mut observed = base_observation();
         observed.quirks = vec![quirk.clone()];
         assert_eq!(
-            base_signature().calculate_distance(&observed),
-            fuzzy_quirks_distance(),
+            base_signature().fit(&observed),
+            tolerating_quirks(vec![], vec![quirk.clone()]),
             "p0f tolerates {quirk:?} appearing in the traffic"
         );
     }
@@ -152,22 +160,14 @@ fn extra_zero_id_or_ecn_is_a_fuzzy_match() {
 fn other_missing_quirk_rejects_signature() {
     let mut signature = base_signature();
     signature.quirks = vec![Quirk::MustBeZero];
-    assert_eq!(
-        signature.calculate_distance(&base_observation()),
-        None,
-        "only df and id+ may disappear"
-    );
+    assert_eq!(signature.fit(&base_observation()), None, "only df and id+ may disappear");
 }
 
 #[test]
 fn other_extra_quirk_rejects_signature() {
     let mut observed = base_observation();
     observed.quirks = vec![Quirk::SeqNumZero];
-    assert_eq!(
-        base_signature().calculate_distance(&observed),
-        None,
-        "only id- and ecn may appear"
-    );
+    assert_eq!(base_signature().fit(&observed), None, "only id- and ecn may appear");
 }
 
 #[test]
@@ -176,8 +176,8 @@ fn version_agnostic_signature_ignores_ipv6_only_quirks_on_ipv4() {
     signature.version = IpVersion::Any;
     signature.quirks = vec![Quirk::FlowID];
     assert_eq!(
-        signature.calculate_distance(&base_observation()),
-        Some(0),
+        signature.fit(&base_observation()),
+        exact(),
         "flow cannot appear in IPv4 traffic, so it must be masked out, not counted as fuzzy"
     );
 }
@@ -190,8 +190,8 @@ fn version_agnostic_signature_ignores_ipv4_only_quirks_on_ipv6() {
     let mut observed = base_observation();
     observed.version = IpVersion::V6;
     assert_eq!(
-        signature.calculate_distance(&observed),
-        Some(0),
+        signature.fit(&observed),
+        exact(),
         "df/id+/id- cannot appear in IPv6 traffic, so they must be masked out"
     );
 }
@@ -202,8 +202,58 @@ fn version_specific_signature_does_not_mask_quirks() {
     signature.version = IpVersion::V4;
     signature.quirks = vec![Quirk::FlowID];
     assert_eq!(
-        signature.calculate_distance(&base_observation()),
+        signature.fit(&base_observation()),
         None,
         "masking only applies to version-agnostic signatures"
+    );
+}
+
+#[test]
+fn a_decremented_ttl_still_fits_and_reports_the_hops() {
+    let mut observed = base_observation();
+    observed.ittl = Ttl::Value(59);
+    assert_eq!(
+        base_signature().fit(&observed),
+        Some(SignatureFit::exact(5)),
+        "five routers between us and a host with an initial TTL of 64"
+    );
+}
+
+#[test]
+fn an_implausible_hop_count_is_a_fuzzy_match() {
+    let mut observed = base_observation();
+    observed.ittl = Ttl::Value(10);
+    assert_eq!(
+        base_signature().fit(&observed),
+        Some(SignatureFit::fuzzy(
+            FuzzyReason {
+                implausible_hop_distance: Some(54),
+                added_quirks: vec![],
+                missing_quirks: vec![],
+            },
+            54
+        )),
+        "54 hops is beyond p0f's MAX_DIST, so the signature only holds as fuzzy"
+    );
+}
+
+#[test]
+fn the_reason_reports_both_tolerances_when_both_apply() {
+    let mut signature = base_signature();
+    signature.quirks = vec![Quirk::Df];
+    let mut observed = base_observation();
+    observed.ittl = Ttl::Value(10);
+    observed.quirks = vec![Quirk::Ecn];
+    assert_eq!(
+        signature.fit(&observed),
+        Some(SignatureFit::fuzzy(
+            FuzzyReason {
+                implausible_hop_distance: Some(54),
+                added_quirks: vec![Quirk::Ecn],
+                missing_quirks: vec![Quirk::Df],
+            },
+            54
+        )),
+        "the TTL and the quirks are independent tolerances, so neither hides the other"
     );
 }

--- a/huginn-net-db/tests/tcp_pcap_golden.rs
+++ b/huginn-net-db/tests/tcp_pcap_golden.rs
@@ -44,6 +44,8 @@ struct TcpSignalSnapshot {
     os_family: Option<String>,
     os_variant: Option<String>,
     quality: Option<String>,
+    #[serde(default)]
+    fuzzy: Option<String>,
     raw_signature: String,
 }
 
@@ -93,7 +95,7 @@ fn run_pcap_with_matcher(pcap_path: &str) -> Vec<TcpAnalysisResult> {
 
 fn assert_quality(actual: &MatchQuality, expected: &str, ctx: &str) {
     match actual {
-        MatchQuality::Matched(q) => {
+        MatchQuality::Matched { quality, .. } => {
             let expected_q: f32 = expected
                 .strip_prefix("Matched(")
                 .and_then(|s| s.strip_suffix(")"))
@@ -101,13 +103,21 @@ fn assert_quality(actual: &MatchQuality, expected: &str, ctx: &str) {
                 .parse()
                 .unwrap_or_else(|_| panic!("{ctx}: cannot parse quality float: {expected}"));
             assert!(
-                (q - expected_q).abs() < 0.01,
-                "{ctx}: quality mismatch, expected {expected_q}, got {q}"
+                (quality - expected_q).abs() < 0.01,
+                "{ctx}: quality mismatch, expected {expected_q}, got {quality}"
             );
         }
         MatchQuality::NotMatched => assert_eq!(expected, "NotMatched", "{ctx}"),
         MatchQuality::Disabled => assert_eq!(expected, "Disabled", "{ctx}"),
     }
+}
+
+fn assert_fuzzy(actual: &MatchQuality, expected: &str, ctx: &str) {
+    let rendered = match actual {
+        MatchQuality::Matched { fuzzy: Some(reason), .. } => reason.to_string(),
+        _ => "none".to_string(),
+    };
+    assert_eq!(rendered, expected, "{ctx}: tolerated difference");
 }
 
 fn assert_connection(actual: &TcpAnalysisResult, expected: &ConnectionSnapshot, idx: usize) {
@@ -183,6 +193,14 @@ fn assert_connection(actual: &TcpAnalysisResult, expected: &ConnectionSnapshot, 
                 &format!("connection {idx} SYN"),
             );
         }
+
+        if let Some(expected_fuzzy) = &exp_syn.fuzzy {
+            assert_fuzzy(
+                &actual_syn.os_matched.quality,
+                expected_fuzzy,
+                &format!("connection {idx} SYN"),
+            );
+        }
     }
 
     if let (Some(actual_syn_ack), Some(exp_syn_ack)) =
@@ -220,6 +238,14 @@ fn assert_connection(actual: &TcpAnalysisResult, expected: &ConnectionSnapshot, 
             assert_quality(
                 &actual_syn_ack.os_matched.quality,
                 expected_quality,
+                &format!("connection {idx} SYN-ACK"),
+            );
+        }
+
+        if let Some(expected_fuzzy) = &exp_syn_ack.fuzzy {
+            assert_fuzzy(
+                &actual_syn_ack.os_matched.quality,
+                expected_fuzzy,
                 &format!("connection {idx} SYN-ACK"),
             );
         }

--- a/huginn-net-tcp/src/matcher_api.rs
+++ b/huginn-net-tcp/src/matcher_api.rs
@@ -10,18 +10,21 @@
 //! trait.
 
 use crate::observable::TcpObservation;
-use crate::output::OperativeSystem;
+use crate::output::{FuzzyReason, OperativeSystem};
 
 /// A matched OS for a single observed TCP fingerprint.
 ///
 /// `quality` is a similarity score in `[0.0, 1.0]`, where `1.0` is a perfect
-/// match. The exact distance/score formula is up to the matcher implementer.
+/// match. The exact scoring is up to the matcher implementer, but it must rank
+/// an exact match above one that needed a tolerance.
 #[derive(Debug, Clone)]
 pub struct TcpMatch {
     /// Operating system / application identified by the matcher.
     pub os: OperativeSystem,
     /// Quality of the match, in `[0.0, 1.0]`.
     pub quality: f32,
+    /// Set when the match only holds because a tolerance was applied.
+    pub fuzzy: Option<FuzzyReason>,
 }
 
 /// A matched MTU/link-type estimate.

--- a/huginn-net-tcp/src/output/common.rs
+++ b/huginn-net-tcp/src/output/common.rs
@@ -1,3 +1,4 @@
+use crate::tcp::Quirk;
 use std::fmt;
 use std::fmt::Formatter;
 
@@ -34,6 +35,62 @@ impl fmt::Display for OsKind {
     }
 }
 
+/// Why a match only holds approximately.
+///
+/// A signature is otherwise made of gates: a field that disagrees rejects it.
+/// These are the two exceptions, the tolerances p0f documents, and both can
+/// apply to the same signature, so at least one field here is always set.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FuzzyReason {
+    /// Hops between the initial TTL the signature declares and the observed
+    /// one, when that count is too large to be plausible. A packet crossing
+    /// more routers than this cannot be told apart from one whose OS simply
+    /// uses a different initial TTL.
+    pub implausible_hop_distance: Option<u32>,
+    /// Quirks the traffic showed that the signature does not declare. Only
+    /// `id-` and `ecn` ever appear here; anything else rejects the signature.
+    pub added_quirks: Vec<Quirk>,
+    /// Quirks the signature declares that the traffic did not show. Only `df`
+    /// and `id+` ever appear here.
+    pub missing_quirks: Vec<Quirk>,
+}
+
+impl fmt::Display for FuzzyReason {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut first = true;
+        let mut separate = |f: &mut Formatter<'_>| -> fmt::Result {
+            if !first {
+                f.write_str(", ")?;
+            }
+            first = false;
+            Ok(())
+        };
+
+        if let Some(hops) = self.implausible_hop_distance {
+            separate(f)?;
+            write!(f, "{hops} hops")?;
+        }
+        if !self.missing_quirks.is_empty() {
+            separate(f)?;
+            write!(f, "missing {}", join_quirks(&self.missing_quirks))?;
+        }
+        if !self.added_quirks.is_empty() {
+            separate(f)?;
+            write!(f, "extra {}", join_quirks(&self.added_quirks))?;
+        }
+
+        Ok(())
+    }
+}
+
+fn join_quirks(quirks: &[Quirk]) -> String {
+    quirks
+        .iter()
+        .map(|quirk| quirk.to_string())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
 /// Outcome of matching an observation against a fingerprint database.
 ///
 /// Independent of any specific database type so that consumers of this
@@ -41,13 +98,34 @@ impl fmt::Display for OsKind {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "json", derive(serde::Serialize))]
 pub enum MatchQuality {
-    /// Successful match. ScThe sre is in `[0.0, 1.0]` with `1.0` being a
-    /// perfect match and lower scores indicating fuzzier matches.
-    Matched(f32),
-    /// A matcher was attached b,ut no signature matched the observation.
+    /// A signature matched.
+    Matched {
+        /// Which tier the match landed in, as a number in `[0.0, 1.0]`: an
+        /// exact fit against a signature naming a concrete product scores
+        /// highest, a catch-all signature lower, and a match that needed a
+        /// tolerance lowest. The ordering is the contract; the values are free
+        /// to be recalibrated.
+        quality: f32,
+        /// Set when the match only holds because a tolerance was applied. The
+        /// matched product is still the best explanation available, but it was
+        /// not an exact fit.
+        #[cfg_attr(
+            feature = "json",
+            serde(serialize_with = "super::serialize_optional_display")
+        )]
+        fuzzy: Option<FuzzyReason>,
+    },
+    /// A matcher was attached but no signature matched the observation.
     NotMatched,
     /// No matcher was attached, so matching was skipped entirely.
     Disabled,
+}
+
+impl MatchQuality {
+    /// A match that fit every field exactly.
+    pub fn exact(quality: f32) -> Self {
+        MatchQuality::Matched { quality, fuzzy: None }
+    }
 }
 
 /// Represents an operative system.
@@ -70,4 +148,31 @@ pub struct OperativeSystem {
 pub struct OSQualityMatched {
     pub os: Option<OperativeSystem>,
     pub quality: MatchQuality,
+}
+
+impl OSQualityMatched {
+    /// Flags qualifying the match, in p0f's `params` vocabulary, or `"none"`.
+    ///
+    /// p0f also reports `random_ttl` and `excess_dist` here, which need data
+    /// this crate does not carry yet.
+    pub fn params(&self) -> String {
+        let mut flags = Vec::new();
+
+        if self
+            .os
+            .as_ref()
+            .is_some_and(|os| os.kind == OsKind::Generic)
+        {
+            flags.push("generic".to_string());
+        }
+        if let MatchQuality::Matched { fuzzy: Some(reason), .. } = &self.quality {
+            flags.push(format!("fuzzy ({reason})"));
+        }
+
+        if flags.is_empty() {
+            "none".to_string()
+        } else {
+            flags.join(" ")
+        }
+    }
 }

--- a/huginn-net-tcp/src/output/mod.rs
+++ b/huginn-net-tcp/src/output/mod.rs
@@ -16,6 +16,17 @@ pub(crate) fn serialize_display<T: std::fmt::Display, S: serde::Serializer>(
     s.serialize_str(&val.to_string())
 }
 
+#[cfg(feature = "json")]
+pub(crate) fn serialize_optional_display<T: std::fmt::Display, S: serde::Serializer>(
+    val: &Option<T>,
+    s: S,
+) -> Result<S::Ok, S::Error> {
+    match val {
+        Some(val) => s.serialize_some(&val.to_string()),
+        None => s.serialize_none(),
+    }
+}
+
 pub use common::*;
 #[cfg(feature = "mtu")]
 pub use mtu::*;

--- a/huginn-net-tcp/src/output/syn.rs
+++ b/huginn-net-tcp/src/output/syn.rs
@@ -46,10 +46,7 @@ impl fmt::Display for SynTCPOutput {
                 Ttl::Value(value) => value,
                 Ttl::Guess(value) => value,
             },
-            self.os_matched
-                .os
-                .as_ref()
-                .map_or("none".to_string(), |os| os.kind.to_string()),
+            self.os_matched.params(),
             self.sig,
         )
     }

--- a/huginn-net-tcp/src/output/syn_ack.rs
+++ b/huginn-net-tcp/src/output/syn_ack.rs
@@ -46,10 +46,7 @@ impl fmt::Display for SynAckTCPOutput {
                 Ttl::Value(value) => value,
                 Ttl::Guess(value) => value,
             },
-            self.os_matched
-                .os
-                .as_ref()
-                .map_or("none".to_string(), |os| os.kind.to_string()),
+            self.os_matched.params(),
             self.sig,
         )
     }

--- a/huginn-net-tcp/src/process/mod.rs
+++ b/huginn-net-tcp/src/process/mod.rs
@@ -325,9 +325,7 @@ where
 #[cfg(feature = "mtu")]
 fn classify_mtu_match(matcher: Option<&dyn TcpMatcher>, mtu: u16) -> MTUQualityMatched {
     match matcher {
-        Some(m) => match m.match_mtu(mtu) {
-            // An MTU either equals a known link's value or it does not; there is
-            // no signature to fit approximately.
+        Some(m) => match m.match_mtu(mtu) {.
             Some(found) => {
                 MTUQualityMatched { link: Some(found.link), quality: MatchQuality::exact(1.0) }
             }

--- a/huginn-net-tcp/src/process/mod.rs
+++ b/huginn-net-tcp/src/process/mod.rs
@@ -325,7 +325,7 @@ where
 #[cfg(feature = "mtu")]
 fn classify_mtu_match(matcher: Option<&dyn TcpMatcher>, mtu: u16) -> MTUQualityMatched {
     match matcher {
-        Some(m) => match m.match_mtu(mtu) {.
+        Some(m) => match m.match_mtu(mtu) {
             Some(found) => {
                 MTUQualityMatched { link: Some(found.link), quality: MatchQuality::exact(1.0) }
             }

--- a/huginn-net-tcp/src/process/mod.rs
+++ b/huginn-net-tcp/src/process/mod.rs
@@ -314,7 +314,7 @@ where
         Some(m) => match call(m) {
             Some(found) => OSQualityMatched {
                 os: Some(found.os),
-                quality: MatchQuality::Matched(found.quality),
+                quality: MatchQuality::Matched { quality: found.quality, fuzzy: found.fuzzy },
             },
             None => OSQualityMatched { os: None, quality: MatchQuality::NotMatched },
         },
@@ -326,8 +326,10 @@ where
 fn classify_mtu_match(matcher: Option<&dyn TcpMatcher>, mtu: u16) -> MTUQualityMatched {
     match matcher {
         Some(m) => match m.match_mtu(mtu) {
+            // An MTU either equals a known link's value or it does not; there is
+            // no signature to fit approximately.
             Some(found) => {
-                MTUQualityMatched { link: Some(found.link), quality: MatchQuality::Matched(1.0) }
+                MTUQualityMatched { link: Some(found.link), quality: MatchQuality::exact(1.0) }
             }
             None => MTUQualityMatched { link: None, quality: MatchQuality::NotMatched },
         },

--- a/huginn-net/src/analyzer/matchers.rs
+++ b/huginn-net/src/analyzer/matchers.rs
@@ -96,9 +96,11 @@ impl<'a> HuginnNet<'a> {
                 enabled: self.config.matcher_enabled,
                 matcher: self.tcp_matcher,
                 method: matching_by_mtu(mtu),
+                // An MTU either equals a known link's value or it does not;
+                // there is no signature to fit approximately.
                 success: (link, _) => MTUQualityMatched {
                     link: Some(link.clone()),
-                    quality: TcpMatchQuality::Matched(1.0),
+                    quality: TcpMatchQuality::exact(1.0),
                 },
                 failure: MTUQualityMatched {
                     link: None,
@@ -125,9 +127,12 @@ impl<'a> HuginnNet<'a> {
                 enabled: self.config.matcher_enabled,
                 matcher: self.tcp_matcher,
                 method: matching_by_tcp_request(observable_tcp),
-                success: (label, _signature, quality) => OSQualityMatched {
-                    os: Some(OperativeSystem::from(label)),
-                    quality: TcpMatchQuality::Matched(quality),
+                success: found => OSQualityMatched {
+                    os: Some(OperativeSystem::from(found.label)),
+                    quality: TcpMatchQuality::Matched {
+                        quality: found.quality,
+                        fuzzy: found.fuzzy,
+                    },
                 },
                 failure: OSQualityMatched {
                     os: None,
@@ -154,9 +159,12 @@ impl<'a> HuginnNet<'a> {
                 enabled: self.config.matcher_enabled,
                 matcher: self.tcp_matcher,
                 method: matching_by_tcp_response(observable_tcp),
-                success: (label, _signature, quality) => OSQualityMatched {
-                    os: Some(OperativeSystem::from(label)),
-                    quality: TcpMatchQuality::Matched(quality),
+                success: found => OSQualityMatched {
+                    os: Some(OperativeSystem::from(found.label)),
+                    quality: TcpMatchQuality::Matched {
+                        quality: found.quality,
+                        fuzzy: found.fuzzy,
+                    },
                 },
                 failure: OSQualityMatched {
                     os: None,
@@ -189,18 +197,18 @@ impl<'a> HuginnNet<'a> {
                 call: matcher => Some(matcher.matching_by_http_request(observed)),
                 matched: signature_matcher => {
                     signature_matcher
-                        .map(|(label, signature, quality)| {
+                        .map(|found| {
                             let notes = MatchedSignatureNotes {
                                 dishonest: !huginn_net_db::http::expsw_matches(
                                     &observed.expsw,
-                                    &signature.expsw,
+                                    &found.signature.expsw,
                                 ),
-                                generic: label.ty == huginn_net_db::database::Type::Generic,
+                                generic: found.label.ty == huginn_net_db::database::Type::Generic,
                             };
                             (
                                 BrowserQualityMatched {
-                                    browser: Some(Browser::from(label)),
-                                    quality: HttpMatchQuality::Matched(quality),
+                                    browser: Some(Browser::from(found.label)),
+                                    quality: HttpMatchQuality::Matched(found.quality),
                                 },
                                 Some(notes),
                             )
@@ -259,18 +267,18 @@ impl<'a> HuginnNet<'a> {
                 call: matcher => Some(matcher.matching_by_http_response(observed)),
                 matched: signature_matcher => {
                     signature_matcher
-                        .map(|(label, signature, quality)| {
+                        .map(|found| {
                             let notes = MatchedSignatureNotes {
                                 dishonest: !huginn_net_db::http::expsw_matches(
                                     &observed.expsw,
-                                    &signature.expsw,
+                                    &found.signature.expsw,
                                 ),
-                                generic: label.ty == huginn_net_db::database::Type::Generic,
+                                generic: found.label.ty == huginn_net_db::database::Type::Generic,
                             };
                             (
                                 WebServerQualityMatched {
-                                    web_server: Some(WebServer::from(label)),
-                                    quality: HttpMatchQuality::Matched(quality),
+                                    web_server: Some(WebServer::from(found.label)),
+                                    quality: HttpMatchQuality::Matched(found.quality),
                                 },
                                 Some(notes),
                             )

--- a/huginn-net/src/analyzer/matchers.rs
+++ b/huginn-net/src/analyzer/matchers.rs
@@ -96,8 +96,6 @@ impl<'a> HuginnNet<'a> {
                 enabled: self.config.matcher_enabled,
                 matcher: self.tcp_matcher,
                 method: matching_by_mtu(mtu),
-                // An MTU either equals a known link's value or it does not;
-                // there is no signature to fit approximately.
                 success: (link, _) => MTUQualityMatched {
                     link: Some(link.clone()),
                     quality: TcpMatchQuality::exact(1.0),

--- a/huginn-net/src/matcher.rs
+++ b/huginn-net/src/matcher.rs
@@ -20,7 +20,7 @@
 ///     call: matcher => None::<(Label, String, f32)>,
 ///     matched: (label, _signature, quality) => OSQualityMatched {
 ///         os: Some(OperativeSystem::from(&label)),
-///         quality: MatchQuality::Matched(quality),
+///         quality: MatchQuality::exact(quality),
 ///     },
 ///     not_matched: OSQualityMatched {
 ///         os: None,
@@ -79,7 +79,7 @@ macro_rules! quality_match {
 ///     method: matching_by_mtu(&observable_mtu.value),
 ///     success: (link, _) => MTUQualityMatched {
 ///         link: Some(link.clone()),
-///         quality: MatchQuality::Matched(1.0),
+///         quality: MatchQuality::exact(1.0),
 ///     },
 ///     failure: MTUQualityMatched {
 ///         link: None,

--- a/huginn-net/tests/smoke.rs
+++ b/huginn-net/tests/smoke.rs
@@ -16,6 +16,7 @@
 
 use huginn_net::{Database, HuginnNet, TcpMatchQuality};
 use huginn_net_http::output::MatchQuality as HttpMatchQuality;
+use huginn_net_tcp::tcp::Quirk;
 use std::path::Path;
 use std::sync::mpsc;
 
@@ -53,10 +54,23 @@ fn e2e_tcp_syn_and_mtu_are_identified() {
         .as_ref()
         .unwrap_or_else(|| panic!("expected an OS match for the first SYN"));
     assert_eq!(os.name, "Mac OS X", "first SYN OS name");
+    match &first_syn.os_matched.quality {
+        TcpMatchQuality::Matched { fuzzy: Some(reason), .. } => {
+            assert_eq!(reason.missing_quirks, vec![Quirk::NonZeroID]);
+            assert_eq!(reason.added_quirks, vec![Quirk::Ecn]);
+            assert_eq!(
+                reason.implausible_hop_distance, None,
+                "the TTL is plausible; only the quirks were tolerated"
+            );
+        }
+        other => panic!("matcher must run and return a fuzzy match, got {other:?}"),
+    }
+
     assert!(
-        matches!(first_syn.os_matched.quality, TcpMatchQuality::Matched(_)),
-        "matcher must run and return a fuzzy match, got {:?}",
-        first_syn.os_matched.quality
+        first_syn
+            .to_string()
+            .contains("Params: fuzzy (missing id+, extra ecn)"),
+        "the human-readable output must say what was tolerated, got:\n{first_syn}"
     );
 
     let first_mtu = results


### PR DESCRIPTION
## Summary
- Selection/ranking via `MatchRank`: Specific > Generic > Fuzzy (`quality` 1.0 / 0.8 / 0.5).
- `MatchQuality::Matched { quality, fuzzy }` with typed `FuzzyReason` (hops / missing / extra quirks).
- TCP output `Params:` reflects fuzzy/generic notes (full Dist/tos params land in a later PR).

## Why
Flat distance sums hid *why* a match was weak. Tiers match p0f preference order; `FuzzyReason` is the explainability win over upstream.