### PR TITLE
p0f-like TCP selection and Dist/params output

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -29,11 +29,12 @@ Nothing else is produced. If you compared scores against thresholds, note that
 the ordering is the contract and the numbers are free to be recalibrated; if you
 branched on specific values, switch to comparisons.
 
-Selection changed with it: a specific signature can no longer lose to a generic
-one because of database order, an exact generic match now outranks a fuzzy
-specific one, and TCP breaks ties within a tier by preferring the signature
-whose initial TTL is closest to what was observed. Application signatures
-(p0f's `s:!:…`, e.g. NMap) are no longer reported on a fuzzy match at all.
+Selection follows p0f's first-match-wins rule within each tier: the first
+exact specific in `.fp` / bucket order wins immediately; otherwise the first
+exact generic; otherwise the first fuzzy. An exact generic still outranks a
+fuzzy specific. Application signatures (p0f's `s:!:…`, e.g. NMap) are never
+reported on a fuzzy match — and if the *first* fuzzy candidate is userland,
+nothing is reported even when a later fuzzy OS signature would also fit.
 
 ---
 
@@ -169,6 +170,40 @@ Consequences for feature builds:
 - With only `syn-ack` enabled, SYN packets are still inspected far enough to
   store the client's MSS. No `SynTCPOutput` is emitted unless `syn` is also on.
 - `ConnectionTracker` is no longer a no-op when `syn-ack` is on without `uptime`.
+
+---
+
+### TCP `params` / `Dist:` align with p0f (`dump_flags`, `guess_dist`)
+
+`OSQualityMatched` and `TcpMatch` now carry the fields p0f prints beside the OS
+label:
+
+| Field | Meaning |
+|-------|---------|
+| `dist` | Hop count for `Dist:` (signature hops when TTL is usable, else `guess_dist`) |
+| `random_ttl` | Winning signature used a randomised TTL (`nnn-`) |
+| `excess_dist` | Reported `dist` is above `MAX_DIST` (35) |
+| `tos` | IPv4 DSCP / IPv6 traffic-class bits 2–7 (`0` omits `tos:` from params) |
+
+`TcpObservation` gained `tos: u8` (not used for matching).  
+`params()` may also emit `random_ttl`, `excess_dist`, and `tos:0xNN`, still
+keeping the typed `fuzzy (…)` detail. Without a match, `tos` / `excess_dist`
+can still appear (same as p0f).
+
+```rust
+// v2.0
+OSQualityMatched { os, quality }
+println!("{}", os_matched.params()); // "generic" | "fuzzy (…)" | "none"
+// Dist: line used calculate_ttl's heuristic on the observation
+
+// v2.1
+OSQualityMatched { os, quality, dist, random_ttl, excess_dist, tos }
+println!("{}", os_matched.params()); // e.g. "fuzzy (…) random_ttl tos:0x2e"
+// Dist: uses os_matched.dist
+```
+
+Call sites that construct `OSQualityMatched` or `TcpMatch` by hand must set the
+new fields (or use `OSQualityMatched::without_match` when there is no OS hit).
 
 ---
 

--- a/huginn-net-db/README.md
+++ b/huginn-net-db/README.md
@@ -30,7 +30,7 @@ want database-backed matching.
 
 - **P0f Database Parsing** - Complete parser for p0f signature format
 - **TCP & HTTP Matching** - Efficient signature matching algorithms  
-- **Quality Scoring** - Distance-based quality metrics for matches
+- **Tiered Match Quality** - Specific / generic / fuzzy (not a continuous score)
 - **Extensible Design** - Easy to add new signature types
 
 ## Cargo Features
@@ -80,6 +80,23 @@ let matcher: SharedTcpMatcher = Arc::new(SharedTcpSignatureMatcher::from_databas
 let analyzer = HuginnNetTcp::new(1000).with_matcher(matcher);
 # Ok::<_, Box<dyn std::error::Error>>(())
 ```
+
+## Reading match results
+
+The matcher either returns a label or nothing. When it returns one, `quality`
+is one of three fixed tiers:
+
+| Outcome | `quality` | Meaning |
+|---------|-----------|---------|
+| Specific exact | `1.0` | Named product, every field fit |
+| Generic exact | `0.8` | Family catch-all, still exact |
+| Fuzzy | `0.5` | Held only with a documented tolerance (`FuzzyReason`) |
+| No match | - | No signature passed the gates |
+| Disabled | - | No matcher was attached |
+
+Prefer `1.0` without `fuzzy`. Treat `0.5` as a hint and inspect `FuzzyReason`
+plus TCP `params` (`dist`, `random_ttl`, `excess_dist`, `tos`). HTTP has no
+fuzzy tier: a hit is exact, and `HttpParams` flags annotate the claim.
 
 ## Documentation
 

--- a/huginn-net-db/src/database/collection.rs
+++ b/huginn-net-db/src/database/collection.rs
@@ -3,7 +3,6 @@
 use crate::database::label::{Label, Type};
 use crate::db_matching_trait::{
     DatabaseMatch, DatabaseSignature, FingerprintDb, IndexKey, MatchRank, ObservedFingerprint,
-    SignatureFit,
 };
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -68,6 +67,12 @@ where
             _key_marker: PhantomData,
         }
     }
+
+    /// Buckets of `(label_idx, sig_idx)` in declaration order, for coverage checks.
+    #[cfg(feature = "tcp")]
+    pub(crate) fn index_buckets(&self) -> impl Iterator<Item = (&K, &Vec<(usize, usize)>)> {
+        self.index.iter()
+    }
 }
 
 impl<OF, DS, K> FingerprintDb<OF, DS> for FingerprintCollection<OF, DS, K>
@@ -76,12 +81,14 @@ where
     DS: DatabaseSignature<OF> + Display,
     K: IndexKey,
 {
+    /// First specific exact, else first generic exact, else first fuzzy.
+    /// A fuzzy application (`label.class` empty) is not reported.
     fn find_best_match(&self, observed: &OF) -> Option<DatabaseMatch<'_, DS, DS::Fuzziness>> {
         let observed_key = observed.generate_index_key();
-
         let candidate_indices = self.index.get(&observed_key)?;
 
-        let mut best: Option<(&Label, &DS, MatchRank, SignatureFit<DS::Fuzziness>)> = None;
+        let mut gmatch: Option<(&Label, &DS)> = None;
+        let mut fmatch: Option<(&Label, &DS, DS::Fuzziness)> = None;
 
         for &(label_idx, sig_idx) in candidate_indices {
             let (label, sig_vec) = &self.entries[label_idx];
@@ -91,46 +98,58 @@ where
                 continue;
             };
 
-            let Some(rank) = rank_of(label, &fit) else {
-                continue;
-            };
-
-            debug!(
-                "fit: {rank:?} (deviation {}), label: {}, flavor: {:?}, sig: {db_sig}",
-                fit.deviation, label.name, label.flavor
-            );
-
-            let better = match &best {
-                Some((_, _, best_rank, best_fit)) => {
-                    (rank, fit.deviation) < (*best_rank, best_fit.deviation)
+            if fit.fuzzy.is_none() {
+                match label.ty {
+                    Type::Specified => {
+                        debug!(
+                            "fit: Specific (early exit), label: {}, flavor: {:?}, sig: {db_sig}",
+                            label.name, label.flavor
+                        );
+                        return Some(DatabaseMatch {
+                            label,
+                            signature: db_sig,
+                            quality: MatchRank::Specific.as_quality(),
+                            fuzzy: None,
+                        });
+                    }
+                    Type::Generic => {
+                        if gmatch.is_none() {
+                            debug!(
+                                "fit: Generic (remembered), label: {}, flavor: {:?}, sig: {db_sig}",
+                                label.name, label.flavor
+                            );
+                            gmatch = Some((label, db_sig));
+                        }
+                    }
                 }
-                None => true,
-            };
-            if better {
-                best = Some((label, db_sig, rank, fit));
+            } else if let (None, Some(reason)) = (&fmatch, fit.fuzzy) {
+                debug!(
+                    "fit: Fuzzy (remembered), label: {}, flavor: {:?}, sig: {db_sig}",
+                    label.name, label.flavor
+                );
+                fmatch = Some((label, db_sig, reason));
             }
         }
 
-        best.map(|(label, signature, rank, fit)| DatabaseMatch {
-            label,
-            signature,
-            quality: rank.as_quality(),
-            fuzzy: fit.fuzzy,
-        })
-    }
-}
+        if let Some((label, signature)) = gmatch {
+            return Some(DatabaseMatch {
+                label,
+                signature,
+                quality: MatchRank::Generic.as_quality(),
+                fuzzy: None,
+            });
+        }
 
-/// [`MatchRank`] for this fit.
-///
-/// Fuzzy + no OS class (`label.class`) is `None`: applications are only
-/// reported on an exact fit.
-fn rank_of<F>(label: &Label, fit: &SignatureFit<F>) -> Option<MatchRank> {
-    if fit.fuzzy.is_some() {
-        return label.class.is_some().then_some(MatchRank::Fuzzy);
-    }
+        if let Some((label, signature, fuzzy)) = fmatch {
+            label.class.as_ref()?;
+            return Some(DatabaseMatch {
+                label,
+                signature,
+                quality: MatchRank::Fuzzy.as_quality(),
+                fuzzy: Some(fuzzy),
+            });
+        }
 
-    Some(match label.ty {
-        Type::Specified => MatchRank::Specific,
-        Type::Generic => MatchRank::Generic,
-    })
+        None
+    }
 }

--- a/huginn-net-db/src/http/matching.rs
+++ b/huginn-net-db/src/http/matching.rs
@@ -125,7 +125,7 @@ impl HttpSignatureHelper for http::Signature {
             && headers_match(observed.get_horder(), &self.horder)
             && absent_headers_match(observed.get_horder(), &self.habsent);
 
-        gates.then(|| SignatureFit::exact(0))
+        gates.then(SignatureFit::exact)
     }
 
     fn generate_http_index_keys(&self) -> Vec<HttpIndexKey> {

--- a/huginn-net-db/src/matcher/tcp_signature_matcher.rs
+++ b/huginn-net-db/src/matcher/tcp_signature_matcher.rs
@@ -1,5 +1,6 @@
 use crate::database::{Label, TcpDatabase, Type};
 use crate::db_matching_trait::{DatabaseMatch, FingerprintDb};
+use crate::tcp::{report_hop_distance, Ttl, MAX_TTL_DISTANCE};
 use huginn_net_tcp::matcher_api::{MtuMatch, TcpMatch, TcpMatcher};
 use huginn_net_tcp::observable::ObservableTcp;
 use huginn_net_tcp::observable::TcpObservation;
@@ -67,22 +68,29 @@ impl From<&Label> for OperativeSystem {
 // Shared matching helpers
 // ---------------------------------------------------------------------------
 
-fn match_tcp_request_impl(db: &TcpDatabase, obs: &TcpObservation) -> Option<TcpMatch> {
-    let found = db.tcp_request.find_best_match(obs)?;
-    Some(TcpMatch {
+fn tcp_match_from_db(
+    found: DatabaseMatch<'_, crate::tcp::Signature, FuzzyReason>,
+    obs: &TcpObservation,
+) -> TcpMatch {
+    let dist = report_hop_distance(&obs.ittl, &found.signature.ittl);
+    TcpMatch {
         os: OperativeSystem::from(found.label),
         quality: found.quality,
         fuzzy: found.fuzzy,
-    })
+        dist,
+        random_ttl: matches!(found.signature.ittl, Ttl::Bad(_)),
+        excess_dist: dist > MAX_TTL_DISTANCE,
+    }
+}
+
+fn match_tcp_request_impl(db: &TcpDatabase, obs: &TcpObservation) -> Option<TcpMatch> {
+    let found = db.tcp_request.find_best_match(obs)?;
+    Some(tcp_match_from_db(found, obs))
 }
 
 fn match_tcp_response_impl(db: &TcpDatabase, obs: &TcpObservation) -> Option<TcpMatch> {
     let found = db.tcp_response.find_best_match(obs)?;
-    Some(TcpMatch {
-        os: OperativeSystem::from(found.label),
-        quality: found.quality,
-        fuzzy: found.fuzzy,
-    })
+    Some(tcp_match_from_db(found, obs))
 }
 
 fn match_mtu_impl(db: &TcpDatabase, mtu: u16) -> Option<MtuMatch> {
@@ -127,7 +135,7 @@ impl SharedTcpSignatureMatcher {
         Self { database }
     }
 
-    /// composed [`crate::Database`] requires both).
+    /// TCP half of a composed [`crate::Database`] (`tcp` + `http` features).
     #[cfg(all(feature = "tcp", feature = "http"))]
     pub fn from_database(database: &crate::Database) -> Self {
         Self { database: Arc::new(database.tcp.clone()) }

--- a/huginn-net-db/src/matcher/traits.rs
+++ b/huginn-net-db/src/matcher/traits.rs
@@ -23,21 +23,17 @@ pub struct SignatureFit<F> {
     /// The tolerance that had to be stretched for the match to hold, which ranks
     /// this candidate below every signature that fit exactly.
     pub fuzzy: Option<F>,
-    /// How far this candidate sits from the observation *within* its tier.
-    /// Used only to break ties between candidates of the same rank; lower is
-    /// closer. Protocols with nothing to measure report `0`.
-    pub deviation: u32,
 }
 
 impl<F> SignatureFit<F> {
     /// Every field matched, nothing was stretched.
-    pub fn exact(deviation: u32) -> Self {
-        Self { fuzzy: None, deviation }
+    pub fn exact() -> Self {
+        Self { fuzzy: None }
     }
 
     /// The match only holds because `reason` was tolerated.
-    pub fn fuzzy(reason: F, deviation: u32) -> Self {
-        Self { fuzzy: Some(reason), deviation }
+    pub fn fuzzy(reason: F) -> Self {
+        Self { fuzzy: Some(reason) }
     }
 }
 

--- a/huginn-net-db/src/parse/mod.rs
+++ b/huginn-net-db/src/parse/mod.rs
@@ -245,12 +245,12 @@ impl FromStr for Database {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let out = parse_sections(s)?;
-        let tcp = TcpDatabase {
+        let tcp = finish_tcp_database(TcpDatabase {
             classes: out.classes.clone(),
             mtu: out.mtu,
             tcp_request: FingerprintCollection::new(out.tcp_request),
             tcp_response: FingerprintCollection::new(out.tcp_response),
-        };
+        });
         let http = HttpDatabase {
             classes: out.classes,
             ua_os: out.ua_os,
@@ -270,13 +270,20 @@ impl FromStr for TcpDatabase {
     /// HTTP-related sections present in the input are silently ignored.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let out = parse_sections(s)?;
-        Ok(TcpDatabase {
+        Ok(finish_tcp_database(TcpDatabase {
             classes: out.classes,
             mtu: out.mtu,
             tcp_request: FingerprintCollection::new(out.tcp_request),
             tcp_response: FingerprintCollection::new(out.tcp_response),
-        })
+        }))
     }
+}
+
+#[cfg(feature = "tcp")]
+fn finish_tcp_database(db: TcpDatabase) -> TcpDatabase {
+    crate::tcp::warn_ambiguous_coverage("tcp:request", &db.tcp_request);
+    crate::tcp::warn_ambiguous_coverage("tcp:response", &db.tcp_response);
+    db
 }
 
 #[cfg(feature = "http")]

--- a/huginn-net-db/src/tcp/coverage.rs
+++ b/huginn-net-db/src/tcp/coverage.rs
@@ -1,0 +1,143 @@
+//! Load-time check for TCP signatures that cover each other.
+//!
+//! `warn!` when two signatures in a bucket both fit exactly at the same tier.
+//! Tests freeze the known list so a new pair in `p0f.fp` fails CI.
+
+use crate::database::{FingerprintCollection, TcpIndexKey};
+use crate::db_matching_trait::DatabaseSignature;
+use crate::tcp::{IpVersion, PayloadSize, Signature, Ttl, WindowSize};
+use huginn_net_tcp::observable::TcpObservation;
+use tracing::warn;
+
+type TcpCollection = FingerprintCollection<TcpObservation, Signature, TcpIndexKey>;
+
+/// A pair of signatures in the same bucket that both fit the same observation
+/// exactly at the same tier. The first name is the one that would win under
+/// p0f's first-match-wins rule (earlier in the `.fp` / index).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AmbiguousExactPair {
+    pub section_hint: &'static str,
+    pub winner: String,
+    pub shadowed: String,
+}
+
+/// Build a packet that the signature itself would match exactly, when the
+/// signature is concrete enough to pin one down.
+fn synthetic_observation(sig: &Signature) -> Option<TcpObservation> {
+    let version = match sig.version {
+        IpVersion::Any => IpVersion::V4,
+        v => v,
+    };
+
+    let ittl = match &sig.ittl {
+        Ttl::Value(v) | Ttl::Bad(v) | Ttl::Guess(v) => Ttl::Value(*v),
+        Ttl::Distance(observed, _) => Ttl::Value(*observed),
+    };
+
+    let mss = sig.mss.or(Some(1460));
+    let tot_hdr = 40u16;
+    let wsize = match &sig.wsize {
+        WindowSize::Any => 65535,
+        WindowSize::Value(v) => *v,
+        WindowSize::Mod(modulus) => {
+            if *modulus == 0 {
+                return None;
+            }
+            *modulus
+        }
+        WindowSize::Mss(multiple) => {
+            let m = sig.mss?;
+            m.checked_mul(u16::from(*multiple))?
+        }
+        WindowSize::Mtu(multiple) => {
+            // Prefer the `mss + tot_hdr` MTU divisor so `detect_win_multi`
+            // recovers `mtu*n` with `of_mtu = true`.
+            let m = mss?;
+            let mtu = m.checked_add(tot_hdr)?;
+            mtu.checked_mul(u16::from(*multiple))?
+        }
+    };
+
+    let pclass = match sig.pclass {
+        PayloadSize::Any => PayloadSize::Zero,
+        p => p,
+    };
+
+    Some(TcpObservation {
+        version,
+        ittl,
+        olen: sig.olen,
+        mss,
+        wsize,
+        tot_hdr,
+        wscale: sig.wscale,
+        olayout: sig.olayout.clone(),
+        quirks: sig.quirks.clone(),
+        pclass,
+        peer_mss: None,
+        tos: 0,
+    })
+}
+
+fn entry_name(label: &crate::database::Label, sig: &Signature) -> String {
+    format!("{label} :: {sig}")
+}
+
+/// Ambiguous exact pairs in `collection`, using `section_hint` only for display.
+pub fn ambiguous_exact_pairs(
+    section_hint: &'static str,
+    collection: &TcpCollection,
+) -> Vec<AmbiguousExactPair> {
+    let mut pairs = Vec::new();
+
+    for (_key, bucket) in collection.index_buckets() {
+        for (i, &(li, si)) in bucket.iter().enumerate() {
+            let (label_i, sigs_i) = &collection.entries[li];
+            let sig_i = &sigs_i[si];
+            let Some(obs) = synthetic_observation(sig_i) else {
+                continue;
+            };
+            let Some(fit_i) = sig_i.fit(&obs) else {
+                continue;
+            };
+            if fit_i.fuzzy.is_some() {
+                continue;
+            }
+            // Same-tier only: specific always outranks generic, so mixed pairs
+            // are not ambiguous under p0f selection.
+            for &(lj, sj) in bucket.iter().skip(i.saturating_add(1)) {
+                let (label_j, sigs_j) = &collection.entries[lj];
+                let sig_j = &sigs_j[sj];
+                if label_j.ty != label_i.ty {
+                    continue;
+                }
+                let Some(fit_j) = sig_j.fit(&obs) else {
+                    continue;
+                };
+                if fit_j.fuzzy.is_some() {
+                    continue;
+                }
+                pairs.push(AmbiguousExactPair {
+                    section_hint,
+                    winner: entry_name(label_i, sig_i),
+                    shadowed: entry_name(label_j, sig_j),
+                });
+            }
+        }
+    }
+
+    pairs.sort();
+    pairs.dedup();
+    pairs
+}
+
+/// Emit one `warn!` per ambiguous pair found in the section.
+pub fn warn_ambiguous_coverage(section_hint: &'static str, collection: &TcpCollection) {
+    for pair in ambiguous_exact_pairs(section_hint, collection) {
+        warn!(
+            target: "huginn_net_db::coverage",
+            "[{}] ambiguous exact signatures (first wins): {}  shadows  {}",
+            pair.section_hint, pair.winner, pair.shadowed
+        );
+    }
+}

--- a/huginn-net-db/src/tcp/distances.rs
+++ b/huginn-net-db/src/tcp/distances.rs
@@ -59,6 +59,19 @@ pub fn ttl_fit(observed: &Ttl, signature: &Ttl) -> Option<TtlFit> {
     Some(TtlFit { hop_distance, out_of_range })
 }
 
+/// `Dist:` hop count: `initial - observed`, or `guess_distance` when unusable.
+pub fn report_hop_distance(observed: &Ttl, signature: &Ttl) -> u8 {
+    let obs = observed_ttl(observed);
+    let initial = signature_initial_ttl(signature);
+    let bad_ttl = matches!(signature, Ttl::Bad(_));
+
+    if obs > initial || (!bad_ttl && initial.saturating_sub(obs) > MAX_TTL_DISTANCE) {
+        huginn_net_tcp::ttl::guess_distance(obs)
+    } else {
+        initial.saturating_sub(obs)
+    }
+}
+
 /// Signature window vs the raw value. `mss*n` / `mtu*n` use the derived multiplier.
 pub fn window_size_matches(
     observed: u16,

--- a/huginn-net-db/src/tcp/matching.rs
+++ b/huginn-net-db/src/tcp/matching.rs
@@ -166,7 +166,7 @@ impl DatabaseSignature<TcpObservation> for tcp::Signature {
         let quirks = quirks_fit(observed, self)?;
 
         if !ttl.out_of_range && quirks.is_exact() {
-            return Some(SignatureFit::exact(ttl.hop_distance));
+            return Some(SignatureFit::exact());
         }
 
         let reason = FuzzyReason {
@@ -174,7 +174,7 @@ impl DatabaseSignature<TcpObservation> for tcp::Signature {
             added_quirks: quirks.added,
             missing_quirks: quirks.missing,
         };
-        Some(SignatureFit::fuzzy(reason, ttl.hop_distance))
+        Some(SignatureFit::fuzzy(reason))
     }
 
     fn generate_index_keys_for_db_entry(&self) -> Vec<TcpIndexKey> {

--- a/huginn-net-db/src/tcp/mod.rs
+++ b/huginn-net-db/src/tcp/mod.rs
@@ -6,11 +6,13 @@
 
 pub use huginn_net_tcp::tcp::{IpVersion, PayloadSize, Quirk, TcpOption, Ttl, WindowSize};
 
+mod coverage;
 mod distances;
 mod signature;
 
+pub use coverage::{ambiguous_exact_pairs, warn_ambiguous_coverage, AmbiguousExactPair};
 pub use distances::{
-    ip_version_matches, payload_size_matches, ttl_fit, window_size_matches, TtlFit,
-    MAX_TTL_DISTANCE,
+    ip_version_matches, payload_size_matches, report_hop_distance, ttl_fit, window_size_matches,
+    TtlFit, MAX_TTL_DISTANCE,
 };
 pub use signature::Signature;

--- a/huginn-net-db/tests/tcp_db_coverage.rs
+++ b/huginn-net-db/tests/tcp_db_coverage.rs
@@ -1,0 +1,75 @@
+#![cfg(feature = "tcp")]
+//! Frozen list of same-tier exact ambiguities in the embedded `p0f.fp`.
+//!
+//! Selection is first-match-wins within a tier, so these pairs are decided only
+//! by `.fp` order. Adding a new pair must fail this test so it gets a look.
+
+use huginn_net_db::tcp::{ambiguous_exact_pairs, AmbiguousExactPair};
+use huginn_net_db::TcpDatabase;
+
+fn pair(section: &'static str, winner: &str, shadowed: &str) -> AmbiguousExactPair {
+    AmbiguousExactPair {
+        section_hint: section,
+        winner: winner.to_string(),
+        shadowed: shadowed.to_string(),
+    }
+}
+
+#[test]
+fn embedded_p0f_exact_ambiguities_match_the_frozen_list() {
+    let db =
+        TcpDatabase::load_default().unwrap_or_else(|e| panic!("embedded p0f.fp must parse: {e}"));
+
+    let mut actual = ambiguous_exact_pairs("tcp:request", &db.tcp_request);
+    actual.extend(ambiguous_exact_pairs("tcp:response", &db.tcp_response));
+    actual.sort();
+
+    let mut expected = vec![
+        pair(
+            "tcp:request",
+            "Generic:win:Windows:NT kernel 5.x :: *:128:0:*:16384,*:mss,nop,nop,sok:df,id+:0",
+            "Generic:win:Windows:NT kernel :: *:128:0:*:*,*:mss,nop,nop,sok:df,id+:0",
+        ),
+        pair(
+            "tcp:request",
+            "Generic:win:Windows:NT kernel 5.x :: *:128:0:*:16384,*:mss,nop,ws,nop,nop,sok:df,id+:0",
+            "Generic:win:Windows:NT kernel :: *:128:0:*:*,*:mss,nop,ws,nop,nop,sok:df,id+:0",
+        ),
+        pair(
+            "tcp:request",
+            "Generic:win:Windows:NT kernel 5.x :: *:128:0:*:65535,*:mss,nop,nop,sok:df,id+:0",
+            "Generic:win:Windows:NT kernel :: *:128:0:*:*,*:mss,nop,nop,sok:df,id+:0",
+        ),
+        pair(
+            "tcp:request",
+            "Generic:win:Windows:NT kernel 5.x :: *:128:0:*:65535,*:mss,nop,ws,nop,nop,sok:df,id+:0",
+            "Generic:win:Windows:NT kernel :: *:128:0:*:*,*:mss,nop,ws,nop,nop,sok:df,id+:0",
+        ),
+        pair(
+            "tcp:request",
+            "Generic:win:Windows:NT kernel 6.x :: *:128:0:*:8192,*:mss,nop,nop,sok:df,id+:0",
+            "Generic:win:Windows:NT kernel :: *:128:0:*:*,*:mss,nop,nop,sok:df,id+:0",
+        ),
+        pair(
+            "tcp:request",
+            "Generic:win:Windows:NT kernel 6.x :: *:128:0:*:8192,*:mss,nop,ws,nop,nop,sok:df,id+:0",
+            "Generic:win:Windows:NT kernel :: *:128:0:*:*,*:mss,nop,ws,nop,nop,sok:df,id+:0",
+        ),
+        pair(
+            "tcp:response",
+            "Specified:unix:FreeBSD:8.x-9.x :: *:64:0:*:65535,0:mss,nop,nop,ts:df,id+:0",
+            "Specified:unix:Mac OS X:10.x :: *:64:0:*:65535,0:mss,nop,nop,ts:df,id+:0",
+        ),
+        pair(
+            "tcp:response",
+            "Specified:unix:FreeBSD:8.x-9.x :: *:64:0:*:65535,0:mss,sok,eol+1:df,id+:0",
+            "Specified:unix:Mac OS X:10.x :: *:64:0:*:65535,0:mss,sok,eol+1:df,id+:0",
+        ),
+    ];
+    expected.sort();
+
+    assert_eq!(
+        actual, expected,
+        "p0f.fp same-tier exact ambiguities changed; update the frozen list after review"
+    );
+}

--- a/huginn-net-db/tests/tcp_db_reachable.rs
+++ b/huginn-net-db/tests/tcp_db_reachable.rs
@@ -47,6 +47,7 @@ fn replay(sig: &Signature) -> ObservableTcp {
                 sig.pclass
             },
             peer_mss: None,
+            tos: 0,
         },
     }
 }

--- a/huginn-net-db/tests/tcp_match_selection.rs
+++ b/huginn-net-db/tests/tcp_match_selection.rs
@@ -20,6 +20,7 @@ fn observation() -> TcpObservation {
         quirks: Vec::new(),
         pclass: PayloadSize::Zero,
         peer_mss: None,
+        tos: 0,
     }
 }
 
@@ -118,23 +119,32 @@ fn an_application_is_still_reported_on_an_exact_match() {
 }
 
 #[test]
-fn within_a_tier_the_closest_initial_ttl_wins() {
-    // Both fit: the observed TTL of 64 is plausible for a host 0 hops away with
-    // an initial TTL of 64, and for one 191 hops away with an initial TTL of
-    // 255. Only the first is a sensible explanation.
-    for reversed in [false, true] {
-        let mut entries = vec![
-            (
-                label("Far OS", Type::Specified),
-                vec![Signature { ittl: Ttl::Bad(255), ..signature() }],
-            ),
-            (label("Near OS", Type::Specified), vec![signature()]),
-        ];
-        if reversed {
-            entries.reverse();
-        }
+fn a_userland_fuzzy_first_blocks_a_later_fuzzy_os_match() {
+    assert_eq!(
+        best_match(vec![
+            (application_label("NMap"), vec![fuzzy_signature()]),
+            (label("Linux", Type::Specified), vec![fuzzy_signature()]),
+        ]),
+        None
+    );
+}
 
-        let (name, _quality) = best_match(entries).unwrap_or_else(|| panic!("expected a match"));
-        assert_eq!(name, "Near OS");
-    }
+#[test]
+fn within_a_tier_the_first_signature_in_database_order_wins() {
+    let far = Signature { ittl: Ttl::Bad(255), ..signature() };
+    let near = signature();
+
+    let (name, _) = best_match(vec![
+        (label("Far OS", Type::Specified), vec![far.clone()]),
+        (label("Near OS", Type::Specified), vec![near.clone()]),
+    ])
+    .unwrap_or_else(|| panic!("expected a match"));
+    assert_eq!(name, "Far OS");
+
+    let (name, _) = best_match(vec![
+        (label("Near OS", Type::Specified), vec![near]),
+        (label("Far OS", Type::Specified), vec![far]),
+    ])
+    .unwrap_or_else(|| panic!("expected a match"));
+    assert_eq!(name, "Near OS");
 }

--- a/huginn-net-db/tests/tcp_matcher.rs
+++ b/huginn-net-db/tests/tcp_matcher.rs
@@ -30,6 +30,7 @@ fn observation_from_signature(sig: &Signature) -> TcpObservation {
         quirks: sig.quirks.clone(),
         pclass: sig.pclass,
         peer_mss: None,
+        tos: 0,
     }
 }
 
@@ -81,6 +82,7 @@ fn matching_linux_by_tcp_request() {
             quirks: vec![Quirk::Df, Quirk::NonZeroID],
             pclass: PayloadSize::Zero,
             peer_mss: None,
+            tos: 0,
         },
     };
 
@@ -129,6 +131,7 @@ fn matching_android_by_tcp_request() {
             quirks: vec![Quirk::Df, Quirk::NonZeroID],
             pclass: PayloadSize::Zero,
             peer_mss: None,
+            tos: 0,
         },
     };
 
@@ -152,6 +155,7 @@ fn matching_android_by_tcp_request() {
             quirks: vec![Quirk::Df, Quirk::NonZeroID],
             pclass: PayloadSize::Zero,
             peer_mss: None,
+            tos: 0,
         },
     };
 

--- a/huginn-net-db/tests/tcp_matching.rs
+++ b/huginn-net-db/tests/tcp_matching.rs
@@ -17,6 +17,7 @@ fn base_observation() -> TcpObservation {
         quirks: Vec::new(),
         pclass: PayloadSize::Zero,
         peer_mss: None,
+        tos: 0,
     }
 }
 
@@ -37,20 +38,17 @@ fn base_signature() -> Signature {
 /// Every field agrees, and the signature's initial TTL is exactly the observed
 /// one, so there are no hops to report either.
 fn exact() -> Option<SignatureFit<FuzzyReason>> {
-    Some(SignatureFit::exact(0))
+    Some(SignatureFit::exact())
 }
 
 /// The match only holds because these quirks were tolerated, the TTL being
 /// plausible.
 fn tolerating_quirks(missing: Vec<Quirk>, added: Vec<Quirk>) -> Option<SignatureFit<FuzzyReason>> {
-    Some(SignatureFit::fuzzy(
-        FuzzyReason {
-            implausible_hop_distance: None,
-            added_quirks: added,
-            missing_quirks: missing,
-        },
-        0,
-    ))
+    Some(SignatureFit::fuzzy(FuzzyReason {
+        implausible_hop_distance: None,
+        added_quirks: added,
+        missing_quirks: missing,
+    }))
 }
 
 #[test]
@@ -211,13 +209,13 @@ fn version_specific_signature_does_not_mask_quirks() {
 }
 
 #[test]
-fn a_decremented_ttl_still_fits_and_reports_the_hops() {
+fn a_decremented_ttl_still_fits_exactly() {
     let mut observed = base_observation();
     observed.ittl = Ttl::Value(59);
     assert_eq!(
         base_signature().fit(&observed),
-        Some(SignatureFit::exact(5)),
-        "five routers between us and a host with an initial TTL of 64"
+        Some(SignatureFit::exact()),
+        "five routers between us and a host with an initial TTL of 64 is still exact"
     );
 }
 
@@ -227,14 +225,11 @@ fn an_implausible_hop_count_is_a_fuzzy_match() {
     observed.ittl = Ttl::Value(10);
     assert_eq!(
         base_signature().fit(&observed),
-        Some(SignatureFit::fuzzy(
-            FuzzyReason {
-                implausible_hop_distance: Some(54),
-                added_quirks: vec![],
-                missing_quirks: vec![],
-            },
-            54
-        )),
+        Some(SignatureFit::fuzzy(FuzzyReason {
+            implausible_hop_distance: Some(54),
+            added_quirks: vec![],
+            missing_quirks: vec![],
+        })),
         "54 hops is beyond p0f's MAX_DIST, so the signature only holds as fuzzy"
     );
 }
@@ -248,14 +243,11 @@ fn the_reason_reports_both_tolerances_when_both_apply() {
     observed.quirks = vec![Quirk::Ecn];
     assert_eq!(
         signature.fit(&observed),
-        Some(SignatureFit::fuzzy(
-            FuzzyReason {
-                implausible_hop_distance: Some(54),
-                added_quirks: vec![Quirk::Ecn],
-                missing_quirks: vec![Quirk::Df],
-            },
-            54
-        )),
+        Some(SignatureFit::fuzzy(FuzzyReason {
+            implausible_hop_distance: Some(54),
+            added_quirks: vec![Quirk::Ecn],
+            missing_quirks: vec![Quirk::Df],
+        })),
         "the TTL and the quirks are independent tolerances, so neither hides the other"
     );
 }

--- a/huginn-net-db/tests/tcp_params.rs
+++ b/huginn-net-db/tests/tcp_params.rs
@@ -1,0 +1,108 @@
+#![cfg(feature = "tcp")]
+//! `Dist:` / `params` from a TCP match: hop distance, `random_ttl`, `excess_dist`, `tos`.
+
+use huginn_net_db::database::{FingerprintCollection, Label, Type};
+use huginn_net_db::tcp::{
+    report_hop_distance, IpVersion, PayloadSize, Signature, Ttl, WindowSize, MAX_TTL_DISTANCE,
+};
+use huginn_net_db::{TcpDatabase, TcpSignatureMatcher};
+use huginn_net_tcp::matcher_api::TcpMatcher;
+use huginn_net_tcp::observable::TcpObservation;
+use huginn_net_tcp::output::{MatchQuality, OSQualityMatched};
+use huginn_net_tcp::ttl::guess_distance;
+
+fn observation(ittl: Ttl, tos: u8) -> TcpObservation {
+    TcpObservation {
+        version: IpVersion::V4,
+        ittl,
+        olen: 0,
+        mss: Some(1460),
+        wsize: 65535,
+        tot_hdr: 40,
+        wscale: Some(6),
+        olayout: Vec::new(),
+        quirks: Vec::new(),
+        pclass: PayloadSize::Zero,
+        peer_mss: None,
+        tos,
+    }
+}
+
+fn signature(ittl: Ttl) -> Signature {
+    Signature {
+        version: IpVersion::V4,
+        ittl,
+        olen: 0,
+        mss: Some(1460),
+        wsize: WindowSize::Value(65535),
+        wscale: Some(6),
+        olayout: Vec::new(),
+        quirks: Vec::new(),
+        pclass: PayloadSize::Zero,
+    }
+}
+
+fn label(name: &str) -> Label {
+    Label {
+        name: name.into(),
+        class: Some("unix".into()),
+        flavor: Some("test".into()),
+        ty: Type::Specified,
+    }
+}
+
+#[test]
+fn report_hop_distance_uses_signature_hops_when_in_range() {
+    assert_eq!(report_hop_distance(&Ttl::Value(58), &Ttl::Value(64)), 6);
+}
+
+#[test]
+fn report_hop_distance_guesses_when_out_of_range() {
+    let observed = Ttl::Value(20);
+    assert_eq!(report_hop_distance(&observed, &Ttl::Value(64)), guess_distance(20));
+}
+
+#[test]
+fn tcp_matcher_fills_random_ttl_dist_and_params_tos() {
+    let db = TcpDatabase {
+        classes: vec!["unix".into()],
+        mtu: vec![],
+        tcp_request: FingerprintCollection::new(vec![(
+            label("RandomTTL"),
+            vec![signature(Ttl::Bad(64))],
+        )]),
+        tcp_response: FingerprintCollection::default(),
+    };
+    let obs = observation(Ttl::Value(50), 0x2e);
+    let found = TcpSignatureMatcher::new(&db)
+        .match_tcp_request(&obs)
+        .unwrap_or_else(|| panic!("bad-ttl signature should match"));
+
+    assert!(found.random_ttl);
+    assert_eq!(found.dist, 14);
+    assert!(!found.excess_dist);
+
+    let matched = OSQualityMatched {
+        os: Some(found.os),
+        quality: MatchQuality::Matched { quality: found.quality, fuzzy: found.fuzzy },
+        dist: found.dist,
+        random_ttl: found.random_ttl,
+        excess_dist: found.excess_dist,
+        tos: obs.tos,
+    };
+    let params = matched.params();
+    assert!(params.contains("random_ttl"), "{params}");
+    assert!(params.contains("tos:0x2e"), "{params}");
+}
+
+#[test]
+fn unmatched_params_can_still_report_tos_and_excess_dist() {
+    // Observed TTL 65 → guess_dist = 63 (> 35).
+    let obs = observation(Ttl::Value(65), 0x10);
+    let unmatched = OSQualityMatched::without_match(MatchQuality::NotMatched, &obs);
+    let params = unmatched.params();
+    assert!(params.contains("excess_dist"), "{params}");
+    assert!(params.contains("tos:0x10"), "{params}");
+    assert_eq!(unmatched.dist, guess_distance(65));
+    assert!(unmatched.dist > MAX_TTL_DISTANCE);
+}

--- a/huginn-net-db/tests/tcp_pcap_golden.rs
+++ b/huginn-net-db/tests/tcp_pcap_golden.rs
@@ -82,14 +82,9 @@ fn run_pcap_with_matcher(pcap_path: &str) -> Vec<TcpAnalysisResult> {
         .analyze_pcap(pcap_path, tx, None)
         .unwrap_or_else(|e| panic!("PCAP analysis failed: {e}"));
 
+    // Ignore uptime-only ACKs (wall-clock `MIN_TWAIT` fires under tarpaulin).
     rx.into_iter()
-        .filter(|r| {
-            r.syn.is_some()
-                || r.syn_ack.is_some()
-                || r.mtu.is_some()
-                || r.client_uptime.is_some()
-                || r.server_uptime.is_some()
-        })
+        .filter(|r| r.syn.is_some() || r.syn_ack.is_some() || r.mtu.is_some())
         .collect()
 }
 

--- a/huginn-net-db/tests/tcp_window_size.rs
+++ b/huginn-net-db/tests/tcp_window_size.rs
@@ -34,6 +34,7 @@ fn observed(
             quirks,
             pclass: PayloadSize::Zero,
             peer_mss,
+            tos: 0,
         },
     }
 }

--- a/huginn-net-tcp/src/matcher_api.rs
+++ b/huginn-net-tcp/src/matcher_api.rs
@@ -25,6 +25,12 @@ pub struct TcpMatch {
     pub quality: f32,
     /// Set when the match only holds because a tolerance was applied.
     pub fuzzy: Option<FuzzyReason>,
+    /// Hop distance reported in `Dist:` (signature hops, or `guess_dist`).
+    pub dist: u8,
+    /// Winning signature used a randomised TTL (`nnn-` / `bad_ttl`).
+    pub random_ttl: bool,
+    /// Reported [`Self::dist`] exceeds p0f's `MAX_DIST` (35).
+    pub excess_dist: bool,
 }
 
 /// A matched MTU/link-type estimate.

--- a/huginn-net-tcp/src/output/common.rs
+++ b/huginn-net-tcp/src/output/common.rs
@@ -1,3 +1,5 @@
+use crate::observable::TcpObservation;
+use crate::tcp::ttl::{guess_distance, observed_ttl, MAX_DIST};
 use crate::tcp::Quirk;
 use std::fmt;
 use std::fmt::Formatter;
@@ -148,13 +150,31 @@ pub struct OperativeSystem {
 pub struct OSQualityMatched {
     pub os: Option<OperativeSystem>,
     pub quality: MatchQuality,
+    /// Hop distance for the `Dist:` line (post-match or `guess_dist`).
+    pub dist: u8,
+    /// Winning signature used a randomised TTL (`nnn-`).
+    pub random_ttl: bool,
+    /// [`Self::dist`] is above p0f's `MAX_DIST` (35).
+    pub excess_dist: bool,
+    /// IPv4 DSCP / IPv6 traffic-class bits 2–7; `0` omits `tos:` from params.
+    pub tos: u8,
 }
 
 impl OSQualityMatched {
-    /// Flags qualifying the match, in p0f's `params` vocabulary, or `"none"`.
-    ///
-    /// p0f also reports `random_ttl` and `excess_dist` here, which need data
-    /// this crate does not carry yet.
+    /// No OS match (or matching disabled): `Dist:` uses `guess_dist`, ToS from the observation.
+    pub fn without_match(quality: MatchQuality, obs: &TcpObservation) -> Self {
+        let dist = guess_distance(observed_ttl(&obs.ittl));
+        Self {
+            os: None,
+            quality,
+            dist,
+            random_ttl: false,
+            excess_dist: dist > MAX_DIST,
+            tos: obs.tos,
+        }
+    }
+
+    /// `generic`, `fuzzy (…)`, `random_ttl`, `excess_dist`, `tos:0xNN`, or `"none"`.
     pub fn params(&self) -> String {
         let mut flags = Vec::new();
 
@@ -167,6 +187,15 @@ impl OSQualityMatched {
         }
         if let MatchQuality::Matched { fuzzy: Some(reason), .. } = &self.quality {
             flags.push(format!("fuzzy ({reason})"));
+        }
+        if self.random_ttl {
+            flags.push("random_ttl".to_string());
+        }
+        if self.excess_dist {
+            flags.push("excess_dist".to_string());
+        }
+        if self.tos != 0 {
+            flags.push(format!("tos:0x{:02x}", self.tos));
         }
 
         if flags.is_empty() {

--- a/huginn-net-tcp/src/output/syn.rs
+++ b/huginn-net-tcp/src/output/syn.rs
@@ -1,6 +1,5 @@
 use super::common::{IpPort, OSQualityMatched};
 use crate::observable::ObservableTcp;
-use crate::tcp::Ttl;
 use std::fmt;
 use std::fmt::Formatter;
 
@@ -40,12 +39,7 @@ impl fmt::Display for SynTCPOutput {
                     os.variant.as_deref().unwrap_or("??")
                 )
             }),
-            match self.sig.matching.ittl {
-                Ttl::Distance(_, distance) => distance,
-                Ttl::Bad(value) => value,
-                Ttl::Value(value) => value,
-                Ttl::Guess(value) => value,
-            },
+            self.os_matched.dist,
             self.os_matched.params(),
             self.sig,
         )

--- a/huginn-net-tcp/src/output/syn_ack.rs
+++ b/huginn-net-tcp/src/output/syn_ack.rs
@@ -1,6 +1,5 @@
 use super::common::{IpPort, OSQualityMatched};
 use crate::observable::ObservableTcp;
-use crate::tcp::Ttl;
 use std::fmt;
 use std::fmt::Formatter;
 
@@ -40,12 +39,7 @@ impl fmt::Display for SynAckTCPOutput {
                     os.variant.as_deref().unwrap_or("??")
                 )
             }),
-            match self.sig.matching.ittl {
-                Ttl::Distance(_, distance) => distance,
-                Ttl::Bad(value) => value,
-                Ttl::Value(value) => value,
-                Ttl::Guess(value) => value,
-            },
+            self.os_matched.dist,
             self.os_matched.params(),
             self.sig,
         )

--- a/huginn-net-tcp/src/process/flow.rs
+++ b/huginn-net-tcp/src/process/flow.rs
@@ -129,6 +129,7 @@ pub fn process_tcp_ipv4(
     let version = IpVersion::V4;
     let ttl_observed: u8 = packet.get_ttl();
     let ttl: Ttl = tcp::ttl::calculate_ttl(ttl_observed);
+    let tos: u8 = packet.get_dscp();
     let olen: u8 = IpOptions::calculate_ipv4_length(packet);
     let mut quirks: Vec<Quirk> = Vec::with_capacity(8);
 
@@ -165,6 +166,7 @@ pub fn process_tcp_ipv4(
                 &tcp_packet,
                 version,
                 ttl,
+                tos,
                 ip_package_header_length,
                 // IHL counts 32-bit words.
                 u16::from(ip_package_header_length).saturating_mul(4),
@@ -187,6 +189,7 @@ pub fn process_tcp_ipv6(
     let version = IpVersion::V6;
     let ttl_observed: u8 = packet.get_hop_limit();
     let ttl: Ttl = tcp::ttl::calculate_ttl(ttl_observed);
+    let tos: u8 = packet.get_traffic_class() >> 2;
     let olen: u8 = IpOptions::calculate_ipv6_length(packet);
     let mut quirks: Vec<Quirk> = Vec::with_capacity(8);
 
@@ -210,6 +213,7 @@ pub fn process_tcp_ipv6(
                 &tcp_packet,
                 version,
                 ttl,
+                tos,
                 ip_package_header_length,
                 u16::from(ip_package_header_length),
                 olen,
@@ -226,6 +230,7 @@ pub fn process_tcp_ipv6(
 fn tcp_observation(
     version: IpVersion,
     ittl: Ttl,
+    tos: u8,
     olen: u8,
     mss: Option<u16>,
     wsize: u16,
@@ -255,6 +260,7 @@ fn tcp_observation(
             PayloadSize::NonZero
         },
         peer_mss,
+        tos,
     }
 }
 
@@ -276,6 +282,7 @@ fn visit_tcp(
     tcp: &TcpPacket,
     version: IpVersion,
     ittl: Ttl,
+    tos: u8,
     ip_package_header_length: u8,
     ip_header_bytes: u16,
     olen: u8,
@@ -487,6 +494,7 @@ fn visit_tcp(
                         matching: tcp_observation(
                             version,
                             ittl,
+                            tos,
                             olen,
                             mss,
                             tcp.get_window(),
@@ -526,6 +534,7 @@ fn visit_tcp(
                             matching: tcp_observation(
                                 version,
                                 ittl,
+                                tos,
                                 olen,
                                 mss,
                                 tcp.get_window(),

--- a/huginn-net-tcp/src/process/mod.rs
+++ b/huginn-net-tcp/src/process/mod.rs
@@ -118,8 +118,9 @@ fn create_observable_package_ipv4(
 
     #[cfg(feature = "syn")]
     if let Some(tcp_request) = tcp_package.tcp_request {
-        let os_quality =
-            classify_tcp_match(matcher, |m| m.match_tcp_request(&tcp_request.matching));
+        let os_quality = classify_tcp_match(matcher, &tcp_request.matching, |m| {
+            m.match_tcp_request(&tcp_request.matching)
+        });
 
         let syn_output = SynTCPOutput {
             source: IpPort::new(IpAddr::V4(ipv4.get_source()), tcp.get_source()),
@@ -132,8 +133,9 @@ fn create_observable_package_ipv4(
 
     #[cfg(feature = "syn-ack")]
     if let Some(tcp_response) = tcp_package.tcp_response {
-        let os_quality =
-            classify_tcp_match(matcher, |m| m.match_tcp_response(&tcp_response.matching));
+        let os_quality = classify_tcp_match(matcher, &tcp_response.matching, |m| {
+            m.match_tcp_response(&tcp_response.matching)
+        });
 
         let syn_ack_output = SynAckTCPOutput {
             source: IpPort::new(IpAddr::V4(ipv4.get_source()), tcp.get_source()),
@@ -242,8 +244,9 @@ fn create_observable_package_ipv6(
 
     #[cfg(feature = "syn")]
     if let Some(tcp_request) = tcp_package.tcp_request {
-        let os_quality =
-            classify_tcp_match(matcher, |m| m.match_tcp_request(&tcp_request.matching));
+        let os_quality = classify_tcp_match(matcher, &tcp_request.matching, |m| {
+            m.match_tcp_request(&tcp_request.matching)
+        });
 
         let syn_output = SynTCPOutput {
             source: IpPort::new(IpAddr::V6(ipv6.get_source()), tcp.get_source()),
@@ -256,8 +259,9 @@ fn create_observable_package_ipv6(
 
     #[cfg(feature = "syn-ack")]
     if let Some(tcp_response) = tcp_package.tcp_response {
-        let os_quality =
-            classify_tcp_match(matcher, |m| m.match_tcp_response(&tcp_response.matching));
+        let os_quality = classify_tcp_match(matcher, &tcp_response.matching, |m| {
+            m.match_tcp_response(&tcp_response.matching)
+        });
 
         let syn_ack_output = SynAckTCPOutput {
             source: IpPort::new(IpAddr::V6(ipv6.get_source()), tcp.get_source()),
@@ -315,7 +319,11 @@ fn create_observable_package_ipv6(
 }
 
 #[cfg(any(feature = "syn", feature = "syn-ack"))]
-fn classify_tcp_match<F>(matcher: Option<&dyn TcpMatcher>, call: F) -> OSQualityMatched
+fn classify_tcp_match<F>(
+    matcher: Option<&dyn TcpMatcher>,
+    obs: &crate::observable::TcpObservation,
+    call: F,
+) -> OSQualityMatched
 where
     F: FnOnce(&dyn TcpMatcher) -> Option<crate::matcher_api::TcpMatch>,
 {
@@ -324,10 +332,14 @@ where
             Some(found) => OSQualityMatched {
                 os: Some(found.os),
                 quality: MatchQuality::Matched { quality: found.quality, fuzzy: found.fuzzy },
+                dist: found.dist,
+                random_ttl: found.random_ttl,
+                excess_dist: found.excess_dist,
+                tos: obs.tos,
             },
-            None => OSQualityMatched { os: None, quality: MatchQuality::NotMatched },
+            None => OSQualityMatched::without_match(MatchQuality::NotMatched, obs),
         },
-        None => OSQualityMatched { os: None, quality: MatchQuality::Disabled },
+        None => OSQualityMatched::without_match(MatchQuality::Disabled, obs),
     }
 }
 

--- a/huginn-net-tcp/src/tcp/mod.rs
+++ b/huginn-net-tcp/src/tcp/mod.rs
@@ -7,7 +7,7 @@ pub mod window_size;
 pub use ip_options::IpOptions;
 pub use observable::{ObservableTcp, TcpObservation};
 pub use syn_options::{parse_options_raw, ParsedTcpOptions};
-pub use ttl::{calculate_ttl, guess_distance};
+pub use ttl::{calculate_ttl, guess_distance, observed_ttl, MAX_DIST};
 pub use window_size::{detect_win_multi, WindowMultiplier};
 
 use core::fmt;

--- a/huginn-net-tcp/src/tcp/observable.rs
+++ b/huginn-net-tcp/src/tcp/observable.rs
@@ -31,6 +31,8 @@ pub struct TcpObservation {
     pub pclass: PayloadSize,
     /// Peer SYN MSS on a SYN+ACK, when the SYN was seen. Always `None` on a SYN.
     pub peer_mss: Option<u16>,
+    /// IPv4 DSCP / IPv6 traffic-class bits 2-7. Zero omits `tos:` from params.
+    pub tos: u8,
 }
 
 impl TcpObservation {

--- a/huginn-net-tcp/src/tcp/ttl.rs
+++ b/huginn-net-tcp/src/tcp/ttl.rs
@@ -1,5 +1,17 @@
 use super::Ttl;
 
+/// Largest hop count still considered plausible. Same value as p0f's `MAX_DIST`
+/// and `huginn_net_db::tcp::MAX_TTL_DISTANCE`.
+pub const MAX_DIST: u8 = 35;
+
+/// TTL byte as seen on the wire, whichever form [`calculate_ttl`] classified it into.
+pub fn observed_ttl(ttl: &Ttl) -> u8 {
+    match ttl {
+        Ttl::Value(v) | Ttl::Distance(v, _) | Ttl::Guess(v) | Ttl::Bad(v) => *v,
+    }
+}
+
+/// Hop guess when there is no usable signature TTL.
 pub fn guess_distance(ttl: u8) -> u8 {
     if ttl > 128 {
         255u8.saturating_sub(ttl)

--- a/huginn-net-tcp/tests/pcap_golden.rs
+++ b/huginn-net-tcp/tests/pcap_golden.rs
@@ -85,18 +85,8 @@ fn analyze_pcap_file(pcap_path: &str) -> Result<Vec<TcpAnalysisResult>, HuginnNe
     Ok(results)
 }
 
-/// Check if a TCP analysis result has meaningful data for golden tests.
+/// Handshake / MTU only. Uptime-only ACKs appear under slow instrumentation.
 fn has_meaningful_tcp_data(result: &TcpAnalysisResult) -> bool {
-    let has_uptime = {
-        #[cfg(feature = "uptime")]
-        {
-            result.client_uptime.is_some() || result.server_uptime.is_some()
-        }
-        #[cfg(not(feature = "uptime"))]
-        {
-            false
-        }
-    };
     let has_mtu = {
         #[cfg(feature = "mtu")]
         {
@@ -127,7 +117,7 @@ fn has_meaningful_tcp_data(result: &TcpAnalysisResult) -> bool {
             false
         }
     };
-    has_syn || has_syn_ack || has_mtu || has_uptime
+    has_syn || has_syn_ack || has_mtu
 }
 
 fn assert_connection_matches_snapshot(

--- a/huginn-net-tcp/tests/tcp_syn_options.rs
+++ b/huginn-net-tcp/tests/tcp_syn_options.rs
@@ -42,6 +42,7 @@ fn build_obs(
         quirks,
         pclass,
         peer_mss: None,
+        tos: 0,
     }
 }
 

--- a/huginn-net/src/analyzer/matchers.rs
+++ b/huginn-net/src/analyzer/matchers.rs
@@ -16,6 +16,8 @@ use huginn_net_http::output::BrowserQualityMatched;
 use huginn_net_http::output::MatchQuality as HttpMatchQuality;
 #[cfg(feature = "http-p0f-response")]
 use huginn_net_http::output::WebServerQualityMatched;
+#[cfg(all(feature = "db", any(feature = "tcp-syn", feature = "tcp-syn-ack")))]
+use huginn_net_tcp::matcher_api::TcpMatcher;
 #[cfg(any(feature = "tcp-syn", feature = "tcp-syn-ack"))]
 use huginn_net_tcp::observable::ObservableTcp;
 #[cfg(feature = "tcp-mtu")]
@@ -50,8 +52,6 @@ use crate::simple_quality_match;
 use huginn_net_http::output::Browser;
 #[cfg(all(feature = "db", feature = "http-p0f-response"))]
 use huginn_net_http::output::WebServer;
-#[cfg(all(feature = "db", any(feature = "tcp-syn", feature = "tcp-syn-ack")))]
-use huginn_net_tcp::output::OperativeSystem;
 
 use crate::AnalysisConfig;
 
@@ -121,31 +121,29 @@ impl<'a> HuginnNet<'a> {
     pub(super) fn match_tcp_request(&self, observable_tcp: &ObservableTcp) -> OSQualityMatched {
         #[cfg(feature = "db")]
         {
+            let obs = &observable_tcp.matching;
             simple_quality_match!(
                 enabled: self.config.matcher_enabled,
                 matcher: self.tcp_matcher,
-                method: matching_by_tcp_request(observable_tcp),
+                method: match_tcp_request(obs),
                 success: found => OSQualityMatched {
-                    os: Some(OperativeSystem::from(found.label)),
+                    os: Some(found.os),
                     quality: TcpMatchQuality::Matched {
                         quality: found.quality,
                         fuzzy: found.fuzzy,
                     },
+                    dist: found.dist,
+                    random_ttl: found.random_ttl,
+                    excess_dist: found.excess_dist,
+                    tos: obs.tos,
                 },
-                failure: OSQualityMatched {
-                    os: None,
-                    quality: TcpMatchQuality::NotMatched,
-                },
-                disabled: OSQualityMatched {
-                    os: None,
-                    quality: TcpMatchQuality::Disabled,
-                }
+                failure: OSQualityMatched::without_match(TcpMatchQuality::NotMatched, obs),
+                disabled: OSQualityMatched::without_match(TcpMatchQuality::Disabled, obs)
             )
         }
         #[cfg(not(feature = "db"))]
         {
-            let _ = observable_tcp;
-            OSQualityMatched { os: None, quality: TcpMatchQuality::Disabled }
+            OSQualityMatched::without_match(TcpMatchQuality::Disabled, &observable_tcp.matching)
         }
     }
 
@@ -153,31 +151,29 @@ impl<'a> HuginnNet<'a> {
     pub(super) fn match_tcp_response(&self, observable_tcp: &ObservableTcp) -> OSQualityMatched {
         #[cfg(feature = "db")]
         {
+            let obs = &observable_tcp.matching;
             simple_quality_match!(
                 enabled: self.config.matcher_enabled,
                 matcher: self.tcp_matcher,
-                method: matching_by_tcp_response(observable_tcp),
+                method: match_tcp_response(obs),
                 success: found => OSQualityMatched {
-                    os: Some(OperativeSystem::from(found.label)),
+                    os: Some(found.os),
                     quality: TcpMatchQuality::Matched {
                         quality: found.quality,
                         fuzzy: found.fuzzy,
                     },
+                    dist: found.dist,
+                    random_ttl: found.random_ttl,
+                    excess_dist: found.excess_dist,
+                    tos: obs.tos,
                 },
-                failure: OSQualityMatched {
-                    os: None,
-                    quality: TcpMatchQuality::NotMatched,
-                },
-                disabled: OSQualityMatched {
-                    os: None,
-                    quality: TcpMatchQuality::Disabled,
-                }
+                failure: OSQualityMatched::without_match(TcpMatchQuality::NotMatched, obs),
+                disabled: OSQualityMatched::without_match(TcpMatchQuality::Disabled, obs)
             )
         }
         #[cfg(not(feature = "db"))]
         {
-            let _ = observable_tcp;
-            OSQualityMatched { os: None, quality: TcpMatchQuality::Disabled }
+            OSQualityMatched::without_match(TcpMatchQuality::Disabled, &observable_tcp.matching)
         }
     }
 

--- a/huginn-net/src/matcher.rs
+++ b/huginn-net/src/matcher.rs
@@ -21,14 +21,26 @@
 ///     matched: (label, _signature, quality) => OSQualityMatched {
 ///         os: Some(OperativeSystem::from(&label)),
 ///         quality: MatchQuality::exact(quality),
+///         dist: 0,
+///         random_ttl: false,
+///         excess_dist: false,
+///         tos: 0,
 ///     },
 ///     not_matched: OSQualityMatched {
 ///         os: None,
 ///         quality: MatchQuality::NotMatched,
+///         dist: 0,
+///         random_ttl: false,
+///         excess_dist: false,
+///         tos: 0,
 ///     },
 ///     disabled: OSQualityMatched {
 ///         os: None,
 ///         quality: MatchQuality::Disabled,
+///         dist: 0,
+///         random_ttl: false,
+///         excess_dist: false,
+///         tos: 0,
 ///     }
 /// );
 /// ```


### PR DESCRIPTION
## Summary
- Early-exit on first specific exact; fuzzy userland first-wins → no match; DB coverage `warn!` + frozen ambiguous list; drop `deviation` tie-break.
- Observation `tos`; match fields `dist` / `random_ttl` / `excess_dist`; `params()` + `Dist:` aligned with p0f (`guess_dist` when needed).

## Why
Completes behavioral parity for *which* signature wins and *how* the match is reported, after gates and tiers exist.
