### PR TITLE
zero-alloc TCP index key, QuirkSet bitmask, and matcher docs

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -238,7 +238,10 @@ are gone. Each one is replaced by a check that answers the question directly.
 | `DatabaseSignature::calculate_distance` + `get_quality_score` | `DatabaseSignature::fit`, returning `Option<SignatureFit<Self::Fuzziness>>` |
 | `MatchQuality` trait, `TcpMatchQuality`, `HttpMatchQuality` (the database-side traits) | removed; use `MatchRank` |
 | `FingerprintDb::find_best_match` returning `(&Label, &DS, f32)` | returns `DatabaseMatch`, whose fields are named |
-| `matching_by_tcp_request`/`_response`, `matching_by_http_request`/`_response` returning tuples | the same `DatabaseMatch` |
+| `matching_by_tcp_request`/`_response`, `matching_by_http_request`/`_response`, `matching_by_mtu`, `matching_by_user_agent` | `TcpMatcher` / `HttpMatcher` trait methods (`match_tcp_request`, …); or `db.tcp_request.find_best_match` |
+| `huginn_net_db::db`, `db_parse`, `observable_tcp_signals_matching`, `observable_http_signals_matching` | `database`, `parse`, `tcp` / `http` matching impls (private) |
+| `TcpObservation.quirks: Vec<Quirk>` / `Signature.quirks: Vec<Quirk>` | `QuirkSet` bitmask |
+| `TcpIndexKey.olayout_key: String` | `olayout_hash: u32` (`hash_olayout`) |
 | `tcp::distance_ttl` | `tcp::ttl_fit` (returns the hop distance) |
 | `tcp::detect_win_multiplicator` returning a `WindowSize` | `tcp::detect_win_multi`, returning `Option<WindowMultiplier>` |
 | `tcp::distance_ip_version`, `distance_window_size`, `distance_payload_size` | `ip_version_matches`, `window_size_matches`, `payload_size_matches` (`bool`) |

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,250 +4,60 @@
 
 ## v2.0.0 → v2.1.0
 
-### What changed
+Matching follows p0f: a field that does not fit is a rejection (HTTP has no
+error budget). TCP still has a fuzzy tier for the documented TTL/quirk
+tolerances. Scores are **tiers**, not a penalty sum:
 
-The matcher now follows p0f's algorithm instead of summing soft penalties, so
-which signatures match changes: TCP gains coverage (p0f's fuzzy tolerances for
-quirks and TTL are honoured), HTTP loses it (no error budget — a header that
-does not fit is a rejection), and every field that p0f treats as a gate now
-rejects instead of costing points.
-
----
-
-### Quality scores mean something different
-
-A score is no longer a normalised sum of per-field penalties. It reports which
-tier the match landed in, following p0f's order of preference:
-
-| Score | Match |
-|-------|-------|
-| `1.0` | Exact fit against a signature naming a concrete product |
-| `0.8` | Exact fit against a catch-all (generic) signature |
-| `0.5` | Only holds because a documented tolerance was applied (TCP only) |
-
-Nothing else is produced. If you compared scores against thresholds, note that
-the ordering is the contract and the numbers are free to be recalibrated; if you
-branched on specific values, switch to comparisons.
-
-Selection follows p0f's first-match-wins rule within each tier: the first
-exact specific in `.fp` / bucket order wins immediately; otherwise the first
-exact generic; otherwise the first fuzzy. An exact generic still outranks a
-fuzzy specific. Application signatures (p0f's `s:!:…`, e.g. NMap) are never
-reported on a fuzzy match — and if the *first* fuzzy candidate is userland,
-nothing is reported even when a later fuzzy OS signature would also fit.
-
----
-
-### `TcpMatchQuality::Matched` says what was tolerated
-
-The variant carries a struct instead of a bare float, so a fuzzy match can name
-the tolerance it needed rather than only scoring lower for it:
-
-```rust
-// v2.0
-match os_matched.quality {
-    MatchQuality::Matched(quality) => …,
-    …
-}
-
-// v2.1.0
-match os_matched.quality {
-    MatchQuality::Matched { quality, fuzzy: None } => …,        // exact fit
-    MatchQuality::Matched { quality, fuzzy: Some(reason) } => { // held by a tolerance
-        println!("{reason}");                    // "missing id+, extra ecn"
-        reason.implausible_hop_distance;         // Option<u32>
-        reason.added_quirks;                     // Vec<Quirk>
-        reason.missing_quirks;                   // Vec<Quirk>
-    }
-    …
-}
-```
-
-`MatchQuality::exact(q)` builds the fuzzy-free case, which is what the MTU match
-reports: an MTU either equals a known link's value or it does not.
-
-Whether the match is specific or generic is *not* in here — `os.kind` already
-carries it. HTTP is unchanged, since p0f defines no tolerances for it.
-
-The `Params:` line of the TCP output follows p0f's vocabulary now (`generic`,
-`fuzzy (…)`, or `none`) instead of printing `Specified`/`Generic`, which matches
-what the HTTP output already did.
-
----
-
-### The observed window is no longer classified
-
-`TcpObservation.wsize` was a `WindowSize`, which meant the window got sorted into
-`Mss(n)`, `Mtu(n)`, `Mod(n)` or `Value(n)` as the packet was parsed. That
-classification is irreversible, and it made **52 of the 117 signatures with a
-literal window unreachable**: a window of 8192 was stored as `Mod(4096)` and
-could no longer be compared against the literal `8192` that Windows 7/8/8.1 and
-the `NT kernel 6.x` catch-all declare. All the Windows literals, both NMap
-signatures, OpenBSD 3.x-5.x, Linux 2.0, Tru64, HP-UX, OpenVMS 7.x and the two
-Nintendo consoles were affected. The one `mtu*n` signature could not match either.
-
-The window is now kept exactly as it came off the wire, and a multiple is derived
-only when a signature asks for one, which is what p0f does:
-
-```rust
-// v2.0
-TcpObservation { wsize: WindowSize::Mss(44), … }
-
-// v2.1
-TcpObservation {
-    wsize: 64240,   // raw, as on the wire
-    tot_hdr: 60,    // IP + TCP header bytes, one of the MTU divisors
-    …
-}
-
-observation.window_multiplier(); // Option<WindowMultiplier> { multiple, of_mtu }
-```
-
-`WindowSize` still describes what a *signature* declares, which is where the five
-forms belong. `detect_win_multiplicator`, which returned the classification, is
-replaced by `detect_win_multi`, which mirrors p0f's divisor list and answers with
-the family the multiple belongs to. The rendered signature is unchanged in shape:
-`mss*n`/`mtu*n` when the window is a multiple of one, the raw value otherwise,
-computed at render time like p0f's `dump_sig`.
-
-Two consequences for output you may be asserting on: a window that is *not* an
-exact multiple of the MSS is no longer reported as one (65535 with an MSS of 1460
-used to round down to `mss*44`, leaving 1295 bytes unaccounted for), and the
-divisors derived from a 1500-byte MTU now answer for the `mss*n` family rather
-than `mtu*n`, as they do in p0f.
-
----
-
-### Only the handshake produces a TCP signal
-
-A `SynAckTCPOutput` used to be emitted for **every packet that was not a plain
-SYN** — bare ACKs, data segments, `FIN+ACK`, `RST` — because the pipeline routed
-anything not coming from the client into the response slot. Now, as in p0f, only
-the two packets that open a connection are fingerprinted: the SYN and the
-SYN+ACK.
-
-Nothing is lost by it. A mid-stream packet has no MSS and no window scale option,
-and its window is already scaled, while all 101 `[tcp:response]` signatures
-require the MSS option — so those signals could only ever come back as
-`NotMatched`. What you get instead is one signal per handshake rather than one per
-packet: in the macOS pcap of the test corpus, 43 signals became 2.
-
-If you were counting signals, or treating `NotMatched` as evidence of an
-unrecognised stack, expect both numbers to drop sharply on live traffic, where
-most packets are data.
-
----
-
-### SYN+ACK windows can use the peer's MSS
-
-`TcpObservation` gained `peer_mss: Option<u16>`: the MSS from the client's SYN,
-filled in on a SYN+ACK when that SYN was seen on the same flow. It is always
-`None` on a SYN.
-
-p0f tries that value (and `peer_mss - 12`) as the last window divisors when
-classifying a response (`fp_tcp.c:92-99`). Without it, a SYN+ACK whose window is
-a multiple of the *client's* MSS but not of the server's own divisors rendered
-the raw window and could not match `mss*n` response signatures. Matching and
-`Display` / `raw_signature` both read it through `window_multiplier()`.
-
-```rust
-// v2.0: SYN+ACK observation had no peer context
-TcpObservation { mss: Some(1460), wsize: 14000, … }
-
-// v2.1
-TcpObservation {
-    mss: Some(1460),       // server's own MSS
-    wsize: 14000,
-    peer_mss: Some(1400),  // from the client's SYN; None if the SYN was not seen
-    …
-}
-```
-
-Consequences for feature builds:
-
-- The `syn-ack` feature now pulls in `ttl_cache` and keeps per-flow handshake
-  state (`syn_mss`, `acked`). A SYN+ACK is fingerprinted **once** per flow.
-- With only `syn-ack` enabled, SYN packets are still inspected far enough to
-  store the client's MSS. No `SynTCPOutput` is emitted unless `syn` is also on.
-- `ConnectionTracker` is no longer a no-op when `syn-ack` is on without `uptime`.
-
----
-
-### TCP `params` / `Dist:` align with p0f (`dump_flags`, `guess_dist`)
-
-`OSQualityMatched` and `TcpMatch` now carry the fields p0f prints beside the OS
-label:
-
-| Field | Meaning |
+| Score | Meaning |
 |-------|---------|
-| `dist` | Hop count for `Dist:` (signature hops when TTL is usable, else `guess_dist`) |
-| `random_ttl` | Winning signature used a randomised TTL (`nnn-`) |
-| `excess_dist` | Reported `dist` is above `MAX_DIST` (35) |
-| `tos` | IPv4 DSCP / IPv6 traffic-class bits 2–7 (`0` omits `tos:` from params) |
+| `1.0` | Exact, named product |
+| `0.8` | Exact, generic catch-all |
+| `0.5` | Fuzzy (TCP only) |
 
-`TcpObservation` gained `tos: u8` (not used for matching).  
-`params()` may also emit `random_ttl`, `excess_dist`, and `tos:0xNN`, still
-keeping the typed `fuzzy (…)` detail. Without a match, `tos` / `excess_dist`
-can still appear (same as p0f).
+First-match-wins within a tier. Userland (`s:!:…`) is never reported as fuzzy.
+
+### Call sites
 
 ```rust
-// v2.0
-OSQualityMatched { os, quality }
-println!("{}", os_matched.params()); // "generic" | "fuzzy (…)" | "none"
-// Dist: line used calculate_ttl's heuristic on the observation
+// quality
+MatchQuality::Matched(q)                          // v2.0
+MatchQuality::Matched { quality, fuzzy }          // v2.1; inspect FuzzyReason
 
-// v2.1
+// TCP result
+OSQualityMatched { os, quality }                  // v2.0
 OSQualityMatched { os, quality, dist, random_ttl, excess_dist, tos }
-println!("{}", os_matched.params()); // e.g. "fuzzy (…) random_ttl tos:0x2e"
-// Dist: uses os_matched.dist
+os_matched.params()                               // "generic" | "fuzzy (…)" | "random_ttl" | …
+
+// HTTP notes
+output.diagnosis                                  // v2.0 HttpDiagnosis
+output.params.dishonest                           // v2.1 HttpParams flags
+
+// observation
+wsize: WindowSize::Mss(44)                        // v2.0, classified at parse
+wsize: 64240, tot_hdr, peer_mss, tos, quirks: QuirkSet  // v2.1
+observation.window_multiplier()
 ```
 
-Call sites that construct `OSQualityMatched` or `TcpMatch` by hand must set the
-new fields (or use `OSQualityMatched::without_match` when there is no OS hit).
+Only SYN / SYN+ACK emit a TCP OS signal (not every ACK). `syn-ack` tracks
+handshake state (`peer_mss`, one fingerprint per flow).
 
----
+Matcher methods are the traits: `match_tcp_request` / `match_http_request` / …
+(or `db.tcp_request.find_best_match`). Protocol examples load `TcpDatabase` /
+`HttpDatabase`.
 
-### `HttpDiagnosis` → `HttpParams`
-
-`HttpRequestOutput`/`HttpResponseOutput` carry `params: HttpParams` instead of
-`diagnosis: HttpDiagnosis`, because p0f reports these as combinable flags
-(`dishonest generic`) rather than one verdict.
-
-```rust
-// v2.0
-match output.diagnosis { HttpDiagnosis::Dishonest => …, … }
-
-// v2.1
-if output.params.dishonest { … }
-println!("{}", output.params); // "dishonest generic", or "none"
-```
-
-`dishonest` now means what p0f means: the `User-Agent`/`Server` string does not
-contain the software the matched signature declares.
-
----
-
-### Removed
-
-There is no distance model anymore, so the helpers that produced or scored one
-are gone. Each one is replaced by a check that answers the question directly.
+### Renames
 
 | v2.0 | v2.1 |
 |------|------|
-| `http_common::get_diagnostic` | `http_common::build_params` |
-| `DatabaseSignature::calculate_distance` + `get_quality_score` | `DatabaseSignature::fit`, returning `Option<SignatureFit<Self::Fuzziness>>` |
-| `MatchQuality` trait, `TcpMatchQuality`, `HttpMatchQuality` (the database-side traits) | removed; use `MatchRank` |
-| `FingerprintDb::find_best_match` returning `(&Label, &DS, f32)` | returns `DatabaseMatch`, whose fields are named |
-| `matching_by_tcp_request`/`_response`, `matching_by_http_request`/`_response`, `matching_by_mtu`, `matching_by_user_agent` | `TcpMatcher` / `HttpMatcher` trait methods (`match_tcp_request`, …); or `db.tcp_request.find_best_match` |
-| `huginn_net_db::db`, `db_parse`, `observable_tcp_signals_matching`, `observable_http_signals_matching` | `database`, `parse`, `tcp` / `http` matching impls (private) |
-| `TcpObservation.quirks: Vec<Quirk>` / `Signature.quirks: Vec<Quirk>` | `QuirkSet` bitmask |
-| `TcpIndexKey.olayout_key: String` | `olayout_hash: u32` (`hash_olayout`) |
-| `tcp::distance_ttl` | `tcp::ttl_fit` (returns the hop distance) |
-| `tcp::detect_win_multiplicator` returning a `WindowSize` | `tcp::detect_win_multi`, returning `Option<WindowMultiplier>` |
-| `tcp::distance_ip_version`, `distance_window_size`, `distance_payload_size` | `ip_version_matches`, `window_size_matches`, `payload_size_matches` (`bool`) |
-| `http::distance_http_version`, `distance_header`, `distance_habsent` | `http_version_matches`, `headers_match`, `absent_headers_match` (`bool`) |
-| `huginn_net_db::http::distance_expsw` | `huginn_net_db::http::expsw_matches` (never part of the match) |
-| `HttpDistance::distance_*` methods | `version_matches`, `headers_match`, `horder_matches`, `absent_headers_match` |
+| `get_diagnostic` | `build_params` |
+| `calculate_distance` / `get_quality_score` | `fit` → `Option<SignatureFit<_>>` |
+| `find_best_match` → `(&Label, &DS, f32)` | `DatabaseMatch` |
+| `matching_by_*` | `TcpMatcher` / `HttpMatcher` |
+| `db` / `db_parse` / `observable_*_signals_matching` | `database` / `parse` (matching is private) |
+| `Vec<Quirk>` | `QuirkSet` |
+| `TcpIndexKey.olayout_key: String` | `olayout_hash: u32` |
+| `distance_ttl` / `detect_win_multiplicator` | `ttl_fit` / `detect_win_multi` |
+| `distance_*` (tcp/http) | `*_matches` (`bool`) |
 
 ---
 

--- a/examples/cli-http.rs
+++ b/examples/cli-http.rs
@@ -3,7 +3,7 @@ mod support;
 use support::{initialize_logging, Commands, FilterOptions, LiveMode, OutputFormat};
 
 use clap::Parser;
-use huginn_net_db::{Database, SharedHttpSignatureMatcher};
+use huginn_net_db::{HttpDatabase, SharedHttpSignatureMatcher};
 use huginn_net_http::matcher_api::HttpMatcher;
 use huginn_net_http::{FilterConfig, HttpAnalysisResult, HuginnNetHttp, IpFilter, PortFilter};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -76,6 +76,16 @@ fn main() {
 
     let (sender, receiver): (Sender<HttpAnalysisResult>, Receiver<HttpAnalysisResult>) = channel();
 
+    let db = match HttpDatabase::load_default() {
+        Ok(db) => Arc::new(db),
+        Err(e) => {
+            error!("Failed to load default HTTP database: {e}");
+            return;
+        }
+    };
+    debug!("Loaded p0f HTTP database successfully");
+    let matcher: Arc<dyn HttpMatcher + Send + Sync> = Arc::new(SharedHttpSignatureMatcher::new(db));
+
     let cancel_signal = Arc::new(AtomicBool::new(false));
     let ctrl_c_signal = cancel_signal.clone();
     let thread_cancel_signal = cancel_signal.clone();
@@ -89,17 +99,6 @@ fn main() {
     }
 
     thread::spawn(move || {
-        let db = match Database::load_default() {
-            Ok(db) => db,
-            Err(e) => {
-                error!("Failed to load default database: {e}");
-                return;
-            }
-        };
-        debug!("Loaded database: {:?}", db);
-
-        let matcher: Arc<dyn HttpMatcher + Send + Sync> =
-            Arc::new(SharedHttpSignatureMatcher::from_database(&db));
         let filter_config = build_filter(&args.filter);
 
         match args.command {

--- a/examples/cli-tcp.rs
+++ b/examples/cli-tcp.rs
@@ -3,7 +3,7 @@ mod support;
 use support::{initialize_logging, Commands, FilterOptions, LiveMode, OutputFormat};
 
 use clap::Parser;
-use huginn_net_db::{Database, SharedTcpSignatureMatcher};
+use huginn_net_db::{SharedTcpSignatureMatcher, TcpDatabase};
 use huginn_net_tcp::matcher_api::TcpMatcher;
 use huginn_net_tcp::{FilterConfig, HuginnNetTcp, IpFilter, PortFilter, TcpAnalysisResult};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -75,16 +75,15 @@ fn main() {
     let (sender, receiver): (Sender<TcpAnalysisResult>, Receiver<TcpAnalysisResult>) =
         mpsc::channel();
 
-    let db = match Database::load_default() {
+    let db = match TcpDatabase::load_default() {
         Ok(db) => Arc::new(db),
         Err(e) => {
-            error!("Failed to load default database: {e}");
+            error!("Failed to load default TCP database: {e}");
             return;
         }
     };
-    debug!("Loaded p0f database successfully");
-    let matcher: Arc<dyn TcpMatcher + Send + Sync> =
-        Arc::new(SharedTcpSignatureMatcher::from_database(&db));
+    debug!("Loaded p0f TCP database successfully");
+    let matcher: Arc<dyn TcpMatcher + Send + Sync> = Arc::new(SharedTcpSignatureMatcher::new(db));
 
     let filter_config = build_filter(&args.filter);
 

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -101,16 +101,16 @@ fn main() {
         return;
     }
 
-    thread::spawn(move || {
-        let db = match Database::load_default() {
-            Ok(db) => db,
-            Err(e) => {
-                error!("Failed to load default database: {e}");
-                return;
-            }
-        };
-        debug!("Loaded database: {:?}", db);
+    let db = match Database::load_default() {
+        Ok(db) => db,
+        Err(e) => {
+            error!("Failed to load default p0f database: {e}");
+            return;
+        }
+    };
+    debug!("Loaded p0f TCP+HTTP database successfully");
 
+    thread::spawn(move || {
         let filter_config = build_filter(&args.filter);
 
         let mut analyzer = match HuginnNet::new(Some(&db), 100, None) {

--- a/huginn-net-db/README.md
+++ b/huginn-net-db/README.md
@@ -71,12 +71,12 @@ Typical use is to build a `SharedTcpSignatureMatcher` /
 into a standalone analyzer via `.with_matcher(...)`:
 
 ```rust
-use huginn_net_db::{Database, SharedTcpSignatureMatcher};
+use huginn_net_db::{SharedTcpSignatureMatcher, TcpDatabase};
 use huginn_net_tcp::{HuginnNetTcp, SharedTcpMatcher};
 use std::sync::Arc;
 
-let db = Database::load_default()?;
-let matcher: SharedTcpMatcher = Arc::new(SharedTcpSignatureMatcher::from_database(&db));
+let db = TcpDatabase::load_default()?;
+let matcher: SharedTcpMatcher = Arc::new(SharedTcpSignatureMatcher::new(Arc::new(db)));
 let analyzer = HuginnNetTcp::new(1000).with_matcher(matcher);
 # Ok::<_, Box<dyn std::error::Error>>(())
 ```
@@ -97,6 +97,9 @@ is one of three fixed tiers:
 Prefer `1.0` without `fuzzy`. Treat `0.5` as a hint and inspect `FuzzyReason`
 plus TCP `params` (`dist`, `random_ttl`, `excess_dist`, `tos`). HTTP has no
 fuzzy tier: a hit is exact, and `HttpParams` flags annotate the claim.
+
+Match quality is also bounded by the bundled `p0f.fp` (last updated 2012):
+a correct algorithm cannot name a product the database does not list.
 
 ## Documentation
 

--- a/huginn-net-db/src/database/collection.rs
+++ b/huginn-net-db/src/database/collection.rs
@@ -73,6 +73,16 @@ where
     pub(crate) fn index_buckets(&self) -> impl Iterator<Item = (&K, &Vec<(usize, usize)>)> {
         self.index.iter()
     }
+
+    /// Number of labels (OS/browser rows) in this collection.
+    pub fn label_count(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Number of fingerprint signatures across all labels.
+    pub fn signature_count(&self) -> usize {
+        self.entries.iter().map(|(_, sigs)| sigs.len()).sum()
+    }
 }
 
 impl<OF, DS, K> FingerprintDb<OF, DS> for FingerprintCollection<OF, DS, K>

--- a/huginn-net-db/src/database/keys.rs
+++ b/huginn-net-db/src/database/keys.rs
@@ -8,11 +8,14 @@ use crate::tcp::{IpVersion, PayloadSize};
 use huginn_net_http::http::Version as HttpVersion;
 
 /// Index key for TCP signatures, used to optimize database lookups.
+///
+/// `olayout_hash` is [`huginn_net_tcp::tcp::hash_olayout`] of the option layout
+/// (p0f's `opt_hash` role). The key is `Copy` so lookups allocate nothing.
 #[cfg(feature = "tcp")]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TcpIndexKey {
     pub ip_version_key: IpVersion,
-    pub olayout_key: String,
+    pub olayout_hash: u32,
     pub pclass_key: PayloadSize,
 }
 

--- a/huginn-net-db/src/http/distances.rs
+++ b/huginn-net-db/src/http/distances.rs
@@ -1,42 +1,16 @@
-//! Pure gate helpers between an observed HTTP value and a signature value.
-//!
-//! These functions take **raw types** (versions, header slices, expected
-//! software strings), no observation structs, so they mirror the shape of
-//! [`crate::tcp`]'s helpers.
+//! HTTP field gates: version, `horder`, `habsent`, `expsw`.
 
 use super::{Header, Version};
 use huginn_net_http::http::UNKNOWN_SOFTWARE;
 use tracing::debug;
 
-/// Whether an observed [`Version`] satisfies a database [`Version`].
-///
-/// [`Version::Any`] in the signature matches everything; otherwise versions
-/// must be equal.
+/// [`Version::Any`] matches any observed version.
 pub fn http_version_matches(observed: Version, signature: Version) -> bool {
     signature == Version::Any || observed == signature
 }
 
-/// Whether the headers seen in the traffic satisfy the ones a database
-/// signature expects (`horder`).
-///
-/// Header matching has no error budget in p0f: every header the signature
-/// lists must be found in the observed list, in the same relative order, and
-/// any mismatch rejects the whole signature. Concretely:
-///
-/// - Observed headers the signature does not mention are skipped for free,
-///   however many of them appear and wherever they appear.
-/// - When the signature specifies a value, the observed value must *contain*
-///   it as a substring (so `Accept=[,*/*]` matches a longer real `Accept`),
-///   and an observed header carrying no value never satisfies one that
-///   expects a value.
-/// - A required header that is not found rejects the signature.
-/// - An optional header (`?` in the `.fp`) may be missing, but only if it is
-///   absent from the traffic altogether: appearing in a different position
-///   than the signature dictates is still a mismatch.
-///
-/// Only the signature's `optional` flag is consulted. Observations carry one
-/// too, but it describes how p0f would *print* the header, not how to match
-/// it.
+/// Signature `horder` vs observed headers: same relative order, value is a
+/// substring, extras skipped. `optional` only covers total absence.
 pub fn headers_match(observed: &[Header], signature: &[Header]) -> bool {
     let mut position = 0usize;
 
@@ -81,14 +55,7 @@ pub fn headers_match(observed: &[Header], signature: &[Header]) -> bool {
     true
 }
 
-/// Whether the traffic honours a signature's `habsent` list: the headers that
-/// must *not* show up in matching traffic.
-///
-/// Note that `observed` is the list of headers actually seen (the
-/// observation's `horder`), not the observation's own `habsent`. p0f checks
-/// its forbidden headers against the traffic's real headers; an observation's
-/// `habsent` is only the set of common headers it happened to be missing,
-/// which exists to print a candidate signature, not to match one.
+/// Signature `habsent` vs observed `horder`: none of the forbidden names may appear.
 pub fn absent_headers_match(observed: &[Header], signature_absent: &[Header]) -> bool {
     for forbidden in signature_absent {
         if observed.iter().any(|h| h.name == forbidden.name) {
@@ -100,20 +67,8 @@ pub fn absent_headers_match(observed: &[Header], signature_absent: &[Header]) ->
     true
 }
 
-/// Whether the software string seen in the traffic backs up the one the
-/// matched signature declares (`expsw`).
-///
-/// This is deliberately *not* a distance. In p0f the check runs only once a
-/// signature has already been chosen, and its outcome never rejects the
-/// signature nor makes it rank lower: it just flags the host as dishonest,
-/// because a host whose headers say Chrome while its `User-Agent` says
-/// something else is still a Chrome-shaped host.
-///
-/// The observed `User-Agent`/`Server` value must *contain* the signature's
-/// expected substring; note the database usually writes it with a leading
-/// space (`" Chrom"`), which is significant and keeps the match anchored at a
-/// token boundary. Either side having nothing to say means there is nothing
-/// to contradict, so it counts as honest.
+/// Observed User-Agent/Server contains the signature `expsw`. Empty on either
+/// side is honest. Not a gate: used after a signature has already won.
 pub fn expsw_matches(observed: &str, signature: &str) -> bool {
     if signature.is_empty() || observed.is_empty() || observed == UNKNOWN_SOFTWARE {
         return true;

--- a/huginn-net-db/src/http/distances.rs
+++ b/huginn-net-db/src/http/distances.rs
@@ -2,10 +2,7 @@
 //!
 //! These functions take **raw types** (versions, header slices, expected
 //! software strings), no observation structs, so they mirror the shape of
-//! [`crate::tcp`]'s helpers and can be reused from both the
-//! `DatabaseSignature` impl and the public [`HttpDistance`] trait.
-//!
-//! [`HttpDistance`]: crate::observable_http_signals_matching::HttpDistance
+//! [`crate::tcp`]'s helpers.
 
 use super::{Header, Version};
 use huginn_net_http::http::UNKNOWN_SOFTWARE;
@@ -19,8 +16,27 @@ pub fn http_version_matches(observed: Version, signature: Version) -> bool {
     signature == Version::Any || observed == signature
 }
 
-/// Signature `horder` vs traffic headers: required names in order, extras free.
-/// Signature values are substrings. `?` may be missing, not out of order.
+/// Whether the headers seen in the traffic satisfy the ones a database
+/// signature expects (`horder`).
+///
+/// Header matching has no error budget in p0f: every header the signature
+/// lists must be found in the observed list, in the same relative order, and
+/// any mismatch rejects the whole signature. Concretely:
+///
+/// - Observed headers the signature does not mention are skipped for free,
+///   however many of them appear and wherever they appear.
+/// - When the signature specifies a value, the observed value must *contain*
+///   it as a substring (so `Accept=[,*/*]` matches a longer real `Accept`),
+///   and an observed header carrying no value never satisfies one that
+///   expects a value.
+/// - A required header that is not found rejects the signature.
+/// - An optional header (`?` in the `.fp`) may be missing, but only if it is
+///   absent from the traffic altogether: appearing in a different position
+///   than the signature dictates is still a mismatch.
+///
+/// Only the signature's `optional` flag is consulted. Observations carry one
+/// too, but it describes how p0f would *print* the header, not how to match
+/// it.
 pub fn headers_match(observed: &[Header], signature: &[Header]) -> bool {
     let mut position = 0usize;
 
@@ -65,7 +81,14 @@ pub fn headers_match(observed: &[Header], signature: &[Header]) -> bool {
     true
 }
 
-/// Reject if any signature `habsent` name appears in the traffic headers.
+/// Whether the traffic honours a signature's `habsent` list: the headers that
+/// must *not* show up in matching traffic.
+///
+/// Note that `observed` is the list of headers actually seen (the
+/// observation's `horder`), not the observation's own `habsent`. p0f checks
+/// its forbidden headers against the traffic's real headers; an observation's
+/// `habsent` is only the set of common headers it happened to be missing,
+/// which exists to print a candidate signature, not to match one.
 pub fn absent_headers_match(observed: &[Header], signature_absent: &[Header]) -> bool {
     for forbidden in signature_absent {
         if observed.iter().any(|h| h.name == forbidden.name) {
@@ -77,8 +100,20 @@ pub fn absent_headers_match(observed: &[Header], signature_absent: &[Header]) ->
     true
 }
 
-/// True if `observed` contains the signature `expsw` substring.
-/// Empty on either side counts as a match.
+/// Whether the software string seen in the traffic backs up the one the
+/// matched signature declares (`expsw`).
+///
+/// This is deliberately *not* a distance. In p0f the check runs only once a
+/// signature has already been chosen, and its outcome never rejects the
+/// signature nor makes it rank lower: it just flags the host as dishonest,
+/// because a host whose headers say Chrome while its `User-Agent` says
+/// something else is still a Chrome-shaped host.
+///
+/// The observed `User-Agent`/`Server` value must *contain* the signature's
+/// expected substring; note the database usually writes it with a leading
+/// space (`" Chrom"`), which is significant and keeps the match anchored at a
+/// token boundary. Either side having nothing to say means there is nothing
+/// to contradict, so it counts as honest.
 pub fn expsw_matches(observed: &str, signature: &str) -> bool {
     if signature.is_empty() || observed.is_empty() || observed == UNKNOWN_SOFTWARE {
         return true;

--- a/huginn-net-db/src/http/matching.rs
+++ b/huginn-net-db/src/http/matching.rs
@@ -1,29 +1,12 @@
-//! Glue between [`huginn_net_http::observable`] and the database matcher
-//! infrastructure.
-//!
-//! Provides:
-//! - The [`HttpDistance`] bridge trait. Each method delegates to a pure free
-//!   function ([`crate::http::headers_match`], etc., re-exported from the
-//!   private `crate::http::distances` module); the trait exists to preserve
-//!   the public API (external callers use
-//!   `<X as HttpDistance>::headers_match`) and to give observation types a
-//!   uniform interface. New internal code should call the free functions
-//!   directly, mirroring TCP.
-//! - The [`crate::db_matching_trait::ObservedFingerprint`] impls for
-//!   [`HttpRequestObservation`] and [`HttpResponseObservation`].
-//! - The [`crate::db_matching_trait::DatabaseSignature`] impls comparing
-//!   `http::Signature` against either observation type.
-//!
-//! For backward compatibility this module is re-exposed at the crate root as
-//! `huginn_net_db::observable_http_signals_matching` via a `#[path]` shim in
-//! `lib.rs`.
+//! Glue between [`huginn_net_http::observable`] and the database matcher.
 
 use crate::database::HttpIndexKey;
 use crate::db_matching_trait::{DatabaseSignature, NoFuzziness, ObservedFingerprint, SignatureFit};
-use crate::http::{
-    self, absent_headers_match, expsw_matches, headers_match, http_version_matches, Header, Version,
-};
 use huginn_net_http::observable::{HttpRequestObservation, HttpResponseObservation};
+
+use super::{
+    absent_headers_match, headers_match, http_version_matches, Header, Signature, Version,
+};
 
 impl ObservedFingerprint for HttpRequestObservation {
     type Key = HttpIndexKey;
@@ -41,89 +24,19 @@ impl ObservedFingerprint for HttpResponseObservation {
     }
 }
 
-/// Bridge between an observation type and the pure gate helpers in
-/// [`crate::http`].
-///
-/// Each method is a thin wrapper around the corresponding free function in
-/// `crate::http::distances`. The trait exists to give observations
-/// (`HttpRequestObservation`, `HttpResponseObservation`) a uniform interface
-/// and to preserve the public API; new code should prefer the free functions
-/// directly, mirroring how [`crate::tcp::ttl_fit`] etc. are used.
-pub trait HttpDistance {
-    fn get_version(&self) -> Version;
-    fn get_horder(&self) -> &[Header];
-    fn get_habsent(&self) -> &[Header];
-    fn get_expsw(&self) -> &str;
-
-    fn version_matches(&self, other: &http::Signature) -> bool {
-        http_version_matches(self.get_version(), other.version)
-    }
-
-    /// Check that every header the signature expects appears in the observed
-    /// list, in order. Delegates to [`crate::http::headers_match`].
-    fn headers_match(observed: &[Header], signature: &[Header]) -> bool {
-        headers_match(observed, signature)
-    }
-
-    fn horder_matches(&self, other: &http::Signature) -> bool {
-        headers_match(self.get_horder(), &other.horder)
-    }
-
-    /// The signature's forbidden headers are checked against the headers
-    /// actually seen, so this reads `horder`, not the observation's own
-    /// `habsent`. See [`crate::http::absent_headers_match`].
-    fn absent_headers_match(&self, other: &http::Signature) -> bool {
-        absent_headers_match(self.get_horder(), &other.habsent)
-    }
-
-    /// Whether the traffic's software string backs up what the signature
-    /// declares. Not part of the fit; see [`crate::http::expsw_matches`].
-    fn expsw_matches(&self, other: &http::Signature) -> bool {
-        expsw_matches(self.get_expsw(), &other.expsw)
-    }
-}
-
-impl HttpDistance for HttpRequestObservation {
-    fn get_version(&self) -> Version {
-        self.version
-    }
-    fn get_horder(&self) -> &[Header] {
-        &self.horder
-    }
-    fn get_habsent(&self) -> &[Header] {
-        &self.habsent
-    }
-    fn get_expsw(&self) -> &str {
-        &self.expsw
-    }
-}
-
-impl HttpDistance for HttpResponseObservation {
-    fn get_version(&self) -> Version {
-        self.version
-    }
-    fn get_horder(&self) -> &[Header] {
-        &self.horder
-    }
-    fn get_habsent(&self) -> &[Header] {
-        &self.habsent
-    }
-    fn get_expsw(&self) -> &str {
-        &self.expsw
-    }
-}
-
-trait HttpSignatureHelper {
-    fn http_fit<T: HttpDistance>(&self, observed: &T) -> Option<SignatureFit<NoFuzziness>>;
-
-    fn generate_http_index_keys(&self) -> Vec<HttpIndexKey>;
-}
-
-impl HttpSignatureHelper for http::Signature {
-    fn http_fit<T: HttpDistance>(&self, observed: &T) -> Option<SignatureFit<NoFuzziness>> {
-        let gates = http_version_matches(observed.get_version(), self.version)
-            && headers_match(observed.get_horder(), &self.horder)
-            && absent_headers_match(observed.get_horder(), &self.habsent);
+impl Signature {
+    /// Every HTTP field is a gate. p0f has no fuzzy tier for HTTP — it keeps a
+    /// generic fallback and nothing else (`fp_http.c:162-282`) — so a fit is
+    /// always exact. Two signatures that both fit are separated by declaration
+    /// order.
+    ///
+    /// `expsw` is deliberately absent: p0f checks it only after a signature has
+    /// been chosen, and a mismatch flags the host as dishonest instead of
+    /// making the signature fit any worse.
+    fn http_fit(&self, version: Version, horder: &[Header]) -> Option<SignatureFit<NoFuzziness>> {
+        let gates = http_version_matches(version, self.version)
+            && headers_match(horder, &self.horder)
+            && absent_headers_match(horder, &self.habsent);
 
         gates.then(SignatureFit::exact)
     }
@@ -140,22 +53,22 @@ impl HttpSignatureHelper for http::Signature {
     }
 }
 
-impl DatabaseSignature<HttpRequestObservation> for http::Signature {
+impl DatabaseSignature<HttpRequestObservation> for Signature {
     type Fuzziness = NoFuzziness;
 
     fn fit(&self, observed: &HttpRequestObservation) -> Option<SignatureFit<NoFuzziness>> {
-        self.http_fit(observed)
+        self.http_fit(observed.version, &observed.horder)
     }
     fn generate_index_keys_for_db_entry(&self) -> Vec<HttpIndexKey> {
         self.generate_http_index_keys()
     }
 }
 
-impl DatabaseSignature<HttpResponseObservation> for http::Signature {
+impl DatabaseSignature<HttpResponseObservation> for Signature {
     type Fuzziness = NoFuzziness;
 
     fn fit(&self, observed: &HttpResponseObservation) -> Option<SignatureFit<NoFuzziness>> {
-        self.http_fit(observed)
+        self.http_fit(observed.version, &observed.horder)
     }
     fn generate_index_keys_for_db_entry(&self) -> Vec<HttpIndexKey> {
         self.generate_http_index_keys()

--- a/huginn-net-db/src/http/matching.rs
+++ b/huginn-net-db/src/http/matching.rs
@@ -25,14 +25,7 @@ impl ObservedFingerprint for HttpResponseObservation {
 }
 
 impl Signature {
-    /// Every HTTP field is a gate. p0f has no fuzzy tier for HTTP, it keeps a
-    /// generic fallback and nothing else, so a fit is
-    /// always exact. Two signatures that both fit are separated by declaration
-    /// order.
-    ///
-    /// `expsw` is deliberately absent: p0f checks it only after a signature has
-    /// been chosen, and a mismatch flags the host as dishonest instead of
-    /// making the signature fit any worse.
+    /// Version / `horder` / `habsent` only. `expsw` is checked after the match.
     fn http_fit(&self, version: Version, horder: &[Header]) -> Option<SignatureFit<NoFuzziness>> {
         let gates = http_version_matches(version, self.version)
             && headers_match(horder, &self.horder)

--- a/huginn-net-db/src/http/matching.rs
+++ b/huginn-net-db/src/http/matching.rs
@@ -25,8 +25,8 @@ impl ObservedFingerprint for HttpResponseObservation {
 }
 
 impl Signature {
-    /// Every HTTP field is a gate. p0f has no fuzzy tier for HTTP — it keeps a
-    /// generic fallback and nothing else (`fp_http.c:162-282`) — so a fit is
+    /// Every HTTP field is a gate. p0f has no fuzzy tier for HTTP, it keeps a
+    /// generic fallback and nothing else, so a fit is
     /// always exact. Two signatures that both fit are separated by declaration
     /// order.
     ///

--- a/huginn-net-db/src/http/mod.rs
+++ b/huginn-net-db/src/http/mod.rs
@@ -7,6 +7,7 @@ pub use huginn_net_http::http::{
 };
 
 mod distances;
+mod matching;
 mod signature;
 
 pub use distances::{absent_headers_match, expsw_matches, headers_match, http_version_matches};

--- a/huginn-net-db/src/lib.rs
+++ b/huginn-net-db/src/lib.rs
@@ -43,22 +43,10 @@ pub mod error;
 
 pub mod parse;
 
-pub mod db_parse {
-    #[allow(unused_imports)] // re-export is a no-op when both protocol features are off
-    pub use super::parse::*;
-}
-
 #[cfg(feature = "http")]
 pub mod http;
 #[cfg(feature = "tcp")]
 pub mod tcp;
-
-#[cfg(feature = "http")]
-#[path = "http/matching.rs"]
-pub mod observable_http_signals_matching;
-#[cfg(feature = "tcp")]
-#[path = "tcp/matching.rs"]
-pub mod observable_tcp_signals_matching;
 
 #[cfg(feature = "http")]
 #[path = "matcher/http_signature_matcher.rs"]
@@ -80,8 +68,3 @@ pub use error::DatabaseError;
 pub use http_signature_matcher::{HttpSignatureMatcher, SharedHttpSignatureMatcher};
 #[cfg(feature = "tcp")]
 pub use tcp_signature_matcher::{SharedTcpSignatureMatcher, TcpSignatureMatcher};
-
-/// Historical module path (`huginn_net_db::db::…`); re-exports [`database`].
-pub mod db {
-    pub use super::database::*;
-}

--- a/huginn-net-db/src/matcher/http_signature_matcher.rs
+++ b/huginn-net-db/src/matcher/http_signature_matcher.rs
@@ -1,5 +1,5 @@
 use crate::database::{HttpDatabase, Label, Type};
-use crate::db_matching_trait::{DatabaseMatch, FingerprintDb, NoFuzziness};
+use crate::db_matching_trait::FingerprintDb;
 use crate::http::expsw_matches;
 use huginn_net_http::matcher_api::{HttpMatcher, HttpRequestMatch, HttpResponseMatch, UaOsMatch};
 use huginn_net_http::observable::{HttpRequestObservation, HttpResponseObservation};
@@ -13,29 +13,6 @@ pub struct HttpSignatureMatcher<'a> {
 impl<'a> HttpSignatureMatcher<'a> {
     pub fn new(database: &'a HttpDatabase) -> Self {
         Self { database }
-    }
-
-    pub fn matching_by_http_request(
-        &self,
-        signature: &HttpRequestObservation,
-    ) -> Option<DatabaseMatch<'a, crate::http::Signature, NoFuzziness>> {
-        self.database.http_request.find_best_match(signature)
-    }
-
-    pub fn matching_by_http_response(
-        &self,
-        signature: &HttpResponseObservation,
-    ) -> Option<DatabaseMatch<'a, crate::http::Signature, NoFuzziness>> {
-        self.database.http_response.find_best_match(signature)
-    }
-
-    pub fn matching_by_user_agent(&self, user_agent: &str) -> Option<(&'a str, Option<&'a str>)> {
-        for (ua, ua_family) in &self.database.ua_os {
-            if user_agent.contains(ua.as_str()) {
-                return Some((ua.as_str(), ua_family.as_ref().map(|s| s.as_str())));
-            }
-        }
-        None
     }
 }
 
@@ -100,11 +77,15 @@ fn match_http_response_impl(
 }
 
 fn match_user_agent_impl(db: &HttpDatabase, ua: &str) -> Option<UaOsMatch> {
-    for (ua_substr, family) in &db.ua_os {
-        if ua.contains(ua_substr.as_str()) {
-            if let Some(family) = family {
-                return Some(UaOsMatch { family: family.clone(), flavor: None });
-            }
+    for (name, mapped) in &db.ua_os {
+        // `ua_os = Linux,Windows,iOS=[iPad]`: a bare name is both the needle
+        // and the family; `Family=[substr]` searches for `substr`.
+        let (needle, family) = match mapped.as_deref() {
+            Some(substr) => (substr, name.as_str()),
+            None => (name.as_str(), name.as_str()),
+        };
+        if ua.contains(needle) {
+            return Some(UaOsMatch { family: family.to_string(), flavor: None });
         }
     }
     None
@@ -141,6 +122,8 @@ impl SharedHttpSignatureMatcher {
         Self { database }
     }
 
+    /// Clone the HTTP sub-database out of a composed [`crate::Database`].
+    /// Requires both `tcp` and `http` features.
     #[cfg(all(feature = "tcp", feature = "http"))]
     pub fn from_database(database: &crate::Database) -> Self {
         Self { database: Arc::new(database.http.clone()) }

--- a/huginn-net-db/src/matcher/tcp_signature_matcher.rs
+++ b/huginn-net-db/src/matcher/tcp_signature_matcher.rs
@@ -2,7 +2,6 @@ use crate::database::{Label, TcpDatabase, Type};
 use crate::db_matching_trait::{DatabaseMatch, FingerprintDb};
 use crate::tcp::{report_hop_distance, Ttl, MAX_TTL_DISTANCE};
 use huginn_net_tcp::matcher_api::{MtuMatch, TcpMatch, TcpMatcher};
-use huginn_net_tcp::observable::ObservableTcp;
 use huginn_net_tcp::observable::TcpObservation;
 use huginn_net_tcp::output::{FuzzyReason, OperativeSystem, OsKind};
 use std::sync::Arc;
@@ -14,35 +13,6 @@ pub struct TcpSignatureMatcher<'a> {
 impl<'a> TcpSignatureMatcher<'a> {
     pub fn new(database: &'a TcpDatabase) -> Self {
         Self { database }
-    }
-
-    pub fn matching_by_tcp_request(
-        &self,
-        signature: &ObservableTcp,
-    ) -> Option<DatabaseMatch<'a, crate::tcp::Signature, FuzzyReason>> {
-        self.database
-            .tcp_request
-            .find_best_match(&signature.matching)
-    }
-
-    pub fn matching_by_tcp_response(
-        &self,
-        signature: &ObservableTcp,
-    ) -> Option<DatabaseMatch<'a, crate::tcp::Signature, FuzzyReason>> {
-        self.database
-            .tcp_response
-            .find_best_match(&signature.matching)
-    }
-
-    pub fn matching_by_mtu(&self, mtu: &u16) -> Option<(&'a String, &'a u16)> {
-        for (link, db_mtus) in &self.database.mtu {
-            for db_mtu in db_mtus {
-                if mtu == db_mtu {
-                    return Some((link, db_mtu));
-                }
-            }
-        }
-        None
     }
 }
 
@@ -135,7 +105,8 @@ impl SharedTcpSignatureMatcher {
         Self { database }
     }
 
-    /// TCP half of a composed [`crate::Database`] (`tcp` + `http` features).
+    /// Clone the TCP sub-database out of a composed [`crate::Database`].
+    /// Requires both `tcp` and `http` features.
     #[cfg(all(feature = "tcp", feature = "http"))]
     pub fn from_database(database: &crate::Database) -> Self {
         Self { database: Arc::new(database.tcp.clone()) }

--- a/huginn-net-db/src/parse/mod.rs
+++ b/huginn-net-db/src/parse/mod.rs
@@ -50,7 +50,7 @@ use crate::tcp::Signature as TcpSignature;
 #[cfg(any(feature = "tcp", feature = "http"))]
 use std::str::FromStr;
 #[cfg(any(feature = "tcp", feature = "http"))]
-use tracing::{trace, warn};
+use tracing::{info, trace, warn};
 
 /// Intermediate output of [`parse_sections`]: raw section content extracted
 /// from a `p0f.fp`-formatted input. Per-protocol fields are gated by their
@@ -251,12 +251,12 @@ impl FromStr for Database {
             tcp_request: FingerprintCollection::new(out.tcp_request),
             tcp_response: FingerprintCollection::new(out.tcp_response),
         });
-        let http = HttpDatabase {
+        let http = finish_http_database(HttpDatabase {
             classes: out.classes,
             ua_os: out.ua_os,
             http_request: FingerprintCollection::new(out.http_request),
             http_response: FingerprintCollection::new(out.http_response),
-        };
+        });
         Ok(Database { tcp, http })
     }
 }
@@ -281,8 +281,44 @@ impl FromStr for TcpDatabase {
 
 #[cfg(feature = "tcp")]
 fn finish_tcp_database(db: TcpDatabase) -> TcpDatabase {
+    let mtu_values: usize = db.mtu.iter().map(|(_, values)| values.len()).sum();
+    info!(
+        target: "huginn_net_db",
+        "[mtu] loaded {} values across {} labels",
+        mtu_values,
+        db.mtu.len()
+    );
+    info!(
+        target: "huginn_net_db",
+        "[tcp:request] loaded {} signatures across {} labels",
+        db.tcp_request.signature_count(),
+        db.tcp_request.label_count()
+    );
+    info!(
+        target: "huginn_net_db",
+        "[tcp:response] loaded {} signatures across {} labels",
+        db.tcp_response.signature_count(),
+        db.tcp_response.label_count()
+    );
     crate::tcp::warn_ambiguous_coverage("tcp:request", &db.tcp_request);
     crate::tcp::warn_ambiguous_coverage("tcp:response", &db.tcp_response);
+    db
+}
+
+#[cfg(feature = "http")]
+fn finish_http_database(db: HttpDatabase) -> HttpDatabase {
+    info!(
+        target: "huginn_net_db",
+        "[http:request] loaded {} signatures across {} labels",
+        db.http_request.signature_count(),
+        db.http_request.label_count()
+    );
+    info!(
+        target: "huginn_net_db",
+        "[http:response] loaded {} signatures across {} labels",
+        db.http_response.signature_count(),
+        db.http_response.label_count()
+    );
     db
 }
 
@@ -295,11 +331,11 @@ impl FromStr for HttpDatabase {
     /// TCP-related sections present in the input are silently ignored.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let out = parse_sections(s)?;
-        Ok(HttpDatabase {
+        Ok(finish_http_database(HttpDatabase {
             classes: out.classes,
             ua_os: out.ua_os,
             http_request: FingerprintCollection::new(out.http_request),
             http_response: FingerprintCollection::new(out.http_response),
-        })
+        }))
     }
 }

--- a/huginn-net-db/src/parse/tcp.rs
+++ b/huginn-net-db/src/parse/tcp.rs
@@ -37,7 +37,7 @@ pub(super) fn parse_tcp_signature(input: &str) -> IResult<&str, TcpSignature> {
         tag(":"),
         separated_list1(tag(","), parse_tcp_option),
         tag(":"),
-        separated_list0(tag(","), parse_quirk),
+        map(separated_list0(tag(","), parse_quirk), |q| q.into_iter().collect()),
         tag(":"),
         parse_payload_size,
     )

--- a/huginn-net-db/src/tcp/coverage.rs
+++ b/huginn-net-db/src/tcp/coverage.rs
@@ -72,7 +72,7 @@ fn synthetic_observation(sig: &Signature) -> Option<TcpObservation> {
         tot_hdr,
         wscale: sig.wscale,
         olayout: sig.olayout.clone(),
-        quirks: sig.quirks.clone(),
+        quirks: sig.quirks,
         pclass,
         peer_mss: None,
         tos: 0,

--- a/huginn-net-db/src/tcp/matching.rs
+++ b/huginn-net-db/src/tcp/matching.rs
@@ -1,30 +1,15 @@
 //! Glue between [`huginn_net_tcp::observable::TcpObservation`] and the
 //! database matcher infrastructure.
-//!
-//! Provides:
-//! - `pub(crate)` gate helpers that read fields off a `TcpObservation`
-//!   (`olen_matches`, `mss_matches`, `wscale_matches`, `olayout_matches`,
-//!   `quirks_fit`). The pure helpers that compare two raw signature types
-//!   ([`crate::tcp::ttl_fit`], [`crate::tcp::window_size_matches`], …) live in
-//!   `crate::tcp::distances` (private module; re-exported through
-//!   [`crate::tcp`]).
-//! - The [`crate::db_matching_trait::ObservedFingerprint`] impl that turns an
-//!   observation into a [`crate::database::TcpIndexKey`].
-//! - The [`crate::db_matching_trait::DatabaseSignature`] impl that compares a
-//!   `tcp::Signature` against a `TcpObservation`.
-//!
-//! For backward compatibility this module is re-exposed at the crate root as
-//! `huginn_net_db::observable_tcp_signals_matching` via a `#[path]` shim in
-//! `lib.rs`.
 
 use crate::database::TcpIndexKey;
 use crate::db_matching_trait::{DatabaseSignature, ObservedFingerprint, SignatureFit};
 use crate::tcp::{
     self, ip_version_matches, payload_size_matches, ttl_fit, window_size_matches, IpVersion,
-    PayloadSize, Quirk,
+    PayloadSize, QuirkSet,
 };
 use huginn_net_tcp::observable::TcpObservation;
 use huginn_net_tcp::output::FuzzyReason;
+use huginn_net_tcp::tcp::hash_olayout;
 
 /// `olen` is never wildcarded in p0f's format: a mismatch is a hard reject.
 pub(crate) fn olen_matches(observed: &TcpObservation, signature: &tcp::Signature) -> bool {
@@ -47,40 +32,14 @@ pub(crate) fn olayout_matches(observed: &TcpObservation, signature: &tcp::Signat
     observed.olayout == signature.olayout
 }
 
-/// Quirks a database signature may declare without the observation showing
-/// them (`df` and `id+` in p0f terms).
-const FUZZY_DELETABLE_QUIRKS: [Quirk; 2] = [Quirk::Df, Quirk::NonZeroID];
-
-/// Quirks an observation may show without the database signature declaring
-/// them (`id-` and `ecn` in p0f terms).
-const FUZZY_ADDABLE_QUIRKS: [Quirk; 2] = [Quirk::ZeroID, Quirk::Ecn];
-
-/// Whether a database quirk must be ignored because the signature is
-/// version-agnostic (`ver == *`) and the quirk only exists for the other IP
-/// version. Mirrors the `ref_quirks &= …` masking in
-/// `data/p0f/fp_tcp.c::tcp_find_match`.
-fn quirk_masked_by_ip_version(
-    quirk: &Quirk,
-    signature_version: IpVersion,
-    observed_version: IpVersion,
-) -> bool {
-    if signature_version != IpVersion::Any {
-        return false;
-    }
-    match observed_version {
-        IpVersion::V6 => matches!(quirk, Quirk::Df | Quirk::NonZeroID | Quirk::ZeroID),
-        _ => matches!(quirk, Quirk::FlowID),
-    }
-}
-
 /// The quirks that had to be tolerated for a signature to hold. Empty on both
 /// sides when the sets agreed exactly.
 #[derive(Debug, Default)]
 pub(crate) struct QuirksFit {
     /// Shown by the traffic, not declared by the signature.
-    pub added: Vec<Quirk>,
+    pub added: QuirkSet,
     /// Declared by the signature, not shown by the traffic.
-    pub missing: Vec<Quirk>,
+    pub missing: QuirkSet,
 }
 
 impl QuirksFit {
@@ -89,56 +48,55 @@ impl QuirksFit {
     }
 }
 
-/// Quirks are compared as sets, not as ordered lists, and a narrow set of
-/// differences is tolerated as a fuzzy match: `df`/`id+` may be absent from
-/// the traffic, and `id-`/`ecn` may appear in it. Any other difference
-/// rejects the signature outright.
+/// Apply p0f's version-agnostic quirk mask (`fp_tcp.c:140-141`): when the
+/// signature is `ver == *`, drop quirks that only exist on the other IP family.
+fn mask_signature_quirks(
+    sig_quirks: QuirkSet,
+    sig_version: IpVersion,
+    obs_version: IpVersion,
+) -> QuirkSet {
+    if sig_version != IpVersion::Any {
+        return sig_quirks;
+    }
+    match obs_version {
+        IpVersion::V4 => sig_quirks & !QuirkSet::MASK_WHEN_OBS_V4,
+        IpVersion::V6 => sig_quirks & !QuirkSet::MASK_WHEN_OBS_V6,
+        IpVersion::Any => sig_quirks,
+    }
+}
+
+/// Quirks are compared as bitmasks, and a narrow set of differences is
+/// tolerated as a fuzzy match: `df`/`id+` may be absent from the traffic, and
+/// `id-`/`ecn` may appear in it. Any other difference rejects the signature.
 ///
 /// Returns which quirks the tolerance had to cover; `None` rejects.
 pub(crate) fn quirks_fit(
     observed: &TcpObservation,
     signature: &tcp::Signature,
 ) -> Option<QuirksFit> {
-    let declared_by_signature = |quirk: &Quirk| {
-        signature.quirks.contains(quirk)
-            && !quirk_masked_by_ip_version(quirk, signature.version, observed.version)
-    };
+    let sig = mask_signature_quirks(signature.quirks, signature.version, observed.version);
+    let obs = observed.quirks;
 
-    let mut fit = QuirksFit::default();
+    let missing = sig.difference(obs);
+    let added = obs.difference(sig);
 
-    for quirk in &signature.quirks {
-        if quirk_masked_by_ip_version(quirk, signature.version, observed.version)
-            || observed.quirks.contains(quirk)
-        {
-            continue;
-        }
-        if !FUZZY_DELETABLE_QUIRKS.contains(quirk) {
-            return None;
-        }
-        fit.missing.push(quirk.clone());
+    if !missing.difference(QuirkSet::FUZZY_DELETABLE).is_empty() {
+        return None;
+    }
+    if !added.difference(QuirkSet::FUZZY_ADDABLE).is_empty() {
+        return None;
     }
 
-    for quirk in &observed.quirks {
-        if declared_by_signature(quirk) {
-            continue;
-        }
-        if !FUZZY_ADDABLE_QUIRKS.contains(quirk) {
-            return None;
-        }
-        fit.added.push(quirk.clone());
-    }
-
-    Some(fit)
+    Some(QuirksFit { added, missing })
 }
 
 impl ObservedFingerprint for TcpObservation {
     type Key = TcpIndexKey;
 
     fn generate_index_key(&self) -> Self::Key {
-        let olayout_parts: Vec<String> = self.olayout.iter().map(|opt| format!("{opt}")).collect();
         TcpIndexKey {
             ip_version_key: self.version,
-            olayout_key: olayout_parts.join(","),
+            olayout_hash: hash_olayout(&self.olayout),
             pclass_key: self.pclass,
         }
     }
@@ -179,32 +137,26 @@ impl DatabaseSignature<TcpObservation> for tcp::Signature {
 
     fn generate_index_keys_for_db_entry(&self) -> Vec<TcpIndexKey> {
         let mut keys = Vec::new();
+        let olayout_hash = hash_olayout(&self.olayout);
 
-        let olayout_key_str = self
-            .olayout
-            .iter()
-            .map(|opt| format!("{opt}"))
-            .collect::<Vec<String>>()
-            .join(",");
-
-        let versions_for_keys = if self.version == IpVersion::Any {
-            vec![IpVersion::V4, IpVersion::V6]
+        let versions_for_keys: &[IpVersion] = if self.version == IpVersion::Any {
+            &[IpVersion::V4, IpVersion::V6]
         } else {
-            vec![self.version]
+            std::slice::from_ref(&self.version)
         };
 
-        let pclasses_for_keys = if self.pclass == PayloadSize::Any {
-            vec![PayloadSize::Zero, PayloadSize::NonZero]
+        let pclasses_for_keys: &[PayloadSize] = if self.pclass == PayloadSize::Any {
+            &[PayloadSize::Zero, PayloadSize::NonZero]
         } else {
-            vec![self.pclass]
+            std::slice::from_ref(&self.pclass)
         };
 
-        for v_key_part in &versions_for_keys {
-            for pc_key_part in &pclasses_for_keys {
+        for &v_key_part in versions_for_keys {
+            for &pc_key_part in pclasses_for_keys {
                 keys.push(TcpIndexKey {
-                    ip_version_key: *v_key_part,
-                    olayout_key: olayout_key_str.clone(),
-                    pclass_key: *pc_key_part,
+                    ip_version_key: v_key_part,
+                    olayout_hash,
+                    pclass_key: pc_key_part,
                 });
             }
         }

--- a/huginn-net-db/src/tcp/mod.rs
+++ b/huginn-net-db/src/tcp/mod.rs
@@ -4,10 +4,13 @@
 //! [`Quirk`], [`PayloadSize`]) are re-exported from `huginn-net-tcp`. This
 //! module owns the **database-specific** pieces.
 
-pub use huginn_net_tcp::tcp::{IpVersion, PayloadSize, Quirk, TcpOption, Ttl, WindowSize};
+pub use huginn_net_tcp::tcp::{
+    IpVersion, PayloadSize, Quirk, QuirkSet, TcpOption, Ttl, WindowSize,
+};
 
 mod coverage;
 mod distances;
+mod matching;
 mod signature;
 
 pub use coverage::{ambiguous_exact_pairs, warn_ambiguous_coverage, AmbiguousExactPair};

--- a/huginn-net-db/src/tcp/signature.rs
+++ b/huginn-net-db/src/tcp/signature.rs
@@ -17,7 +17,7 @@ pub struct Signature {
     /// layout and ordering of TCP options, if any.
     pub olayout: Vec<super::TcpOption>,
     /// properties and quirks observed in IP or TCP headers.
-    pub quirks: Vec<super::Quirk>,
+    pub quirks: super::QuirkSet,
     /// payload size classification
     pub pclass: super::PayloadSize,
 }
@@ -31,7 +31,7 @@ trait TcpDisplayFormat {
     fn get_wsize(&self) -> super::WindowSize;
     fn get_wscale(&self) -> Option<u8>;
     fn get_olayout(&self) -> &[super::TcpOption];
-    fn get_quirks(&self) -> &[super::Quirk];
+    fn get_quirks(&self) -> super::QuirkSet;
     fn get_pclass(&self) -> super::PayloadSize;
 
     fn format_tcp_display(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -60,16 +60,7 @@ trait TcpDisplayFormat {
             write!(f, "{o}")?;
         }
 
-        f.write_str(":")?;
-
-        for (i, q) in self.get_quirks().iter().enumerate() {
-            if i > 0 {
-                f.write_str(",")?;
-            }
-            write!(f, "{q}")?;
-        }
-
-        write!(f, ":{}", self.get_pclass())
+        write!(f, ":{}:{}", self.get_quirks(), self.get_pclass())
     }
 }
 
@@ -95,8 +86,8 @@ impl TcpDisplayFormat for Signature {
     fn get_olayout(&self) -> &[super::TcpOption] {
         &self.olayout
     }
-    fn get_quirks(&self) -> &[super::Quirk] {
-        &self.quirks
+    fn get_quirks(&self) -> super::QuirkSet {
+        self.quirks
     }
     fn get_pclass(&self) -> super::PayloadSize {
         self.pclass

--- a/huginn-net-db/tests/http_distance_header.rs
+++ b/huginn-net-db/tests/http_distance_header.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "http")]
+use huginn_net_db::http::headers_match;
 use huginn_net_db::http::Header;
-use huginn_net_db::observable_http_signals_matching::HttpDistance;
-use huginn_net_http::observable::{HttpRequestObservation, HttpResponseObservation};
 
 #[test]
 fn test_headers_with_one_optional_header_mismatch() {
@@ -39,7 +38,7 @@ fn test_headers_with_one_optional_header_mismatch() {
     assert!(!b[6].optional);
     assert_ne!(a[6], b[6]);
 
-    let result = <HttpResponseObservation as HttpDistance>::headers_match(&a, &b);
+    let result = headers_match(&a, &b);
     assert!(
         result,
         "only the signature's optional flag is consulted, so the observation's differing flag is irrelevant"
@@ -63,7 +62,7 @@ fn test_headers_optional_skip_in_middle() {
         Header::new("Connection").with_value("keep-alive"),
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    let result = headers_match(&observed, &signature);
     assert!(result, "Optional header in middle should be skipped for perfect alignment");
 }
 
@@ -80,7 +79,7 @@ fn test_headers_multiple_optional_skips() {
         Header::new("Connection").with_value("keep-alive"),
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    let result = headers_match(&observed, &signature);
     assert!(result, "Multiple optional headers should be skipped");
 }
 
@@ -94,7 +93,7 @@ fn test_headers_missing_required_header_in_middle_rejects() {
         Header::new("Connection").with_value("keep-alive"),
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    let result = headers_match(&observed, &signature);
     assert!(!result, "a required header missing rejects the signature outright");
 }
 
@@ -119,7 +118,7 @@ fn test_headers_realistic_browser_with_optional_skips() {
         Header::new("Connection").with_value("keep-alive"),
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    let result = headers_match(&observed, &signature);
     assert!(result, "Browser should match signature even with optional headers missing");
 }
 
@@ -135,7 +134,7 @@ fn test_headers_missing_optional_header() {
             .with_value("en-US"), // Missing but optional
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    let result = headers_match(&observed, &signature);
     assert!(result, "Missing optional headers should not cause errors");
 }
 
@@ -148,7 +147,7 @@ fn test_headers_missing_required_header_at_end_rejects() {
         Header::new("User-Agent").with_value("Mozilla/5.0"), // Missing and NOT optional
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    let result = headers_match(&observed, &signature);
     assert!(!result, "a required header missing rejects the signature outright");
 }
 
@@ -163,7 +162,7 @@ fn test_headers_extra_headers_in_observed_are_free() {
 
     let signature = vec![Header::new("Host"), Header::new("User-Agent").with_value("Mozilla/5.0")];
 
-    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    let result = headers_match(&observed, &signature);
     assert!(
         result,
         "headers the signature does not mention never penalise, wherever they appear"
@@ -179,17 +178,19 @@ fn test_headers_expected_value_matches_as_substring() {
 
     let signature = vec![Header::new("Host"), Header::new("Accept").with_value("*/*")];
 
-    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    let result = headers_match(&observed, &signature);
     assert!(result, "the expected value only has to be contained in the observed one");
 }
 
 #[test]
 fn test_headers_expects_value_but_observed_has_none_rejects() {
+    // Observations drop the value of headers p0f prints without one, so a
+    // signature demanding a value can never be satisfied by them.
     let observed = vec![Header::new("Host"), Header::new("User-Agent")];
 
     let signature = vec![Header::new("Host"), Header::new("User-Agent").with_value("Mozilla/5.0")];
 
-    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    let result = headers_match(&observed, &signature);
     assert!(!result, "a valueless observed header cannot satisfy an expected value");
 }
 
@@ -210,7 +211,7 @@ fn test_headers_optional_header_out_of_order_rejects() {
         Header::new("User-Agent").with_value("Mozilla/5.0"),
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    let result = headers_match(&observed, &signature);
     assert!(!result, "an optional header present out of order rejects the signature");
 }
 
@@ -220,7 +221,7 @@ fn test_headers_required_header_out_of_order_rejects() {
 
     let signature = vec![Header::new("Host"), Header::new("Connection").with_value("keep-alive")];
 
-    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    let result = headers_match(&observed, &signature);
     assert!(!result, "header order is part of the signature");
 }
 
@@ -236,7 +237,7 @@ fn test_headers_optional_header_at_end() {
             .with_value("en-US"), // Optional, missing
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    let result = headers_match(&observed, &signature);
     assert!(result, "Missing optional headers at end should not cause errors");
 }
 
@@ -258,7 +259,7 @@ fn test_headers_observed_vs_signature_with_optional() {
             .with_value("en-US"), // Optional but value must match
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    let result = headers_match(&observed, &signature);
     assert!(
         result,
         "Should match perfectly: all headers match including values for optional headers"
@@ -274,12 +275,14 @@ fn test_headers_value_mismatch_rejects() {
         Header::new("Connection").with_value("close"), // Different value
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    let result = headers_match(&observed, &signature);
     assert!(!result, "a value that is not a substring of the observed one rejects");
 }
 
 #[test]
 fn test_headers_value_mismatch_rejects_even_when_optional() {
+    // `optional` only covers absence: a header that is present must still
+    // match the expected value.
     let observed = vec![Header::new("Host"), Header::new("Referer").with_value("http://other")];
 
     let signature = vec![
@@ -289,7 +292,7 @@ fn test_headers_value_mismatch_rejects_even_when_optional() {
             .with_value("http://example.com"),
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    let result = headers_match(&observed, &signature);
     assert!(!result, "optional headers that are present must still match their value");
 }
 
@@ -318,7 +321,7 @@ fn test_headers_realistic_browser_scenario() {
         Header::new("Connection").with_value("keep-alive"),
     ];
 
-    let result = <HttpRequestObservation as HttpDistance>::headers_match(&observed, &signature);
+    let result = headers_match(&observed, &signature);
     assert!(
         result,
         "Should match perfectly for realistic Chrome signature with value matching"

--- a/huginn-net-db/tests/http_expsw.rs
+++ b/huginn-net-db/tests/http_expsw.rs
@@ -1,15 +1,21 @@
 #![cfg(feature = "http")]
+//! `expsw` is p0f's "expected software" field: what the matched signature
+//! claims the software is. It is checked *after* a signature wins, and its
+//! only effect is to flag the host as dishonest — never to reject or demote
+//! the signature.
 
-use huginn_net_db::db_matching_trait::DatabaseSignature;
-use huginn_net_db::http::UNKNOWN_SOFTWARE;
-use huginn_net_db::{http, HttpDatabase, HttpSignatureMatcher, SharedHttpSignatureMatcher};
+use huginn_net_db::db_matching_trait::{DatabaseSignature, FingerprintDb};
+use huginn_net_db::{http, HttpDatabase, SharedHttpSignatureMatcher};
 use huginn_net_http::matcher_api::HttpMatcher;
 use huginn_net_http::observable::HttpRequestObservation;
 use std::sync::Arc;
 
+/// A full `User-Agent` as seen on the wire.
 const CHROME_UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
                          (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36";
 
+/// How the database writes the claim: a short substring, kept anchored at a
+/// token boundary by a leading space.
 const CHROME_EXPSW: &str = " Chrom";
 
 #[test]
@@ -40,7 +46,7 @@ fn nothing_to_compare_counts_as_honest() {
         "traffic that says nothing makes no claim to check"
     );
     assert!(
-        http::expsw_matches(UNKNOWN_SOFTWARE, CHROME_EXPSW),
+        http::expsw_matches(http::UNKNOWN_SOFTWARE, CHROME_EXPSW),
         "the absent-header placeholder is not a literal claim"
     );
 }
@@ -50,6 +56,8 @@ fn a_contradicting_software_string_is_dishonest() {
     assert!(!http::expsw_matches("Mozilla/5.0 Firefox/128.0", CHROME_EXPSW));
 }
 
+/// The point of keeping `expsw` out of the comparison: two observations that
+/// differ *only* in their software string must be equally good matches.
 #[test]
 fn software_string_does_not_change_the_fit() {
     let db = HttpDatabase::load_default()
@@ -71,9 +79,9 @@ fn software_string_does_not_change_the_fit() {
         expsw: expsw.to_string(),
     };
 
-    let matcher = HttpSignatureMatcher::new(&db);
-    let honest_match = matcher
-        .matching_by_http_request(&observation("Firefox/"))
+    let honest_match = db
+        .http_request
+        .find_best_match(&observation("Firefox/"))
         .unwrap_or_else(|| panic!("no match found for the Firefox 2.x signature"));
 
     let honest = honest_match.signature.fit(&observation("Firefox/"));
@@ -82,12 +90,15 @@ fn software_string_does_not_change_the_fit() {
         .fit(&observation("definitely-not-firefox"));
     assert_eq!(honest, lying, "expsw must not affect how well the signature fits");
 
-    let lying_match = matcher
-        .matching_by_http_request(&observation("definitely-not-firefox"))
+    let lying_match = db
+        .http_request
+        .find_best_match(&observation("definitely-not-firefox"))
         .unwrap_or_else(|| panic!("a dishonest software string must not reject the signature"));
     assert_eq!(honest_match.quality, lying_match.quality);
 }
 
+/// The flag rides along with the match, because it takes the winning
+/// signature to know what was claimed.
 #[test]
 fn the_match_reports_whether_the_host_is_dishonest() {
     let db = HttpDatabase::load_default()

--- a/huginn-net-db/tests/http_expsw.rs
+++ b/huginn-net-db/tests/http_expsw.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "http")]
 //! `expsw` is p0f's "expected software" field: what the matched signature
 //! claims the software is. It is checked *after* a signature wins, and its
-//! only effect is to flag the host as dishonest — never to reject or demote
+//! only effect is to flag the host as dishonest, never to reject or demote
 //! the signature.
 
 use huginn_net_db::db_matching_trait::{DatabaseSignature, FingerprintDb};

--- a/huginn-net-db/tests/http_matcher.rs
+++ b/huginn-net-db/tests/http_matcher.rs
@@ -78,6 +78,42 @@ fn matching_apache_by_http_response() {
     }
 }
 
+#[test]
+fn matching_chrome11_by_http_request() {
+    let db = match HttpDatabase::load_default() {
+        Ok(db) => db,
+        Err(e) => panic!("Failed to create default database: {e}"),
+    };
+
+    // Layout from p0f.fp `Chrome:11 or newer` (2012): sdch + Accept-Charset.
+    let chrome_signature = HttpRequestObservation {
+        version: http::Version::V11,
+        horder: vec![
+            http::Header::new("Host"),
+            http::Header::new("Connection").with_value("keep-alive"),
+            http::Header::new("User-Agent"),
+            http::Header::new("Accept").with_value("*/*"),
+            http::Header::new("Accept-Encoding").with_value("gzip,deflate,sdch"),
+            http::Header::new("Accept-Language"),
+            http::Header::new("Accept-Charset").with_value("utf-8;q=0.7,*;q=0.3"),
+        ],
+        habsent: vec![],
+        expsw: "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.7 \
+                (KHTML, like Gecko) Chrome/16.0.912.75 Safari/535.7"
+            .to_string(),
+    };
+
+    if let Some(found) = db.http_request.find_best_match(&chrome_signature) {
+        assert_eq!(found.label.name, "Chrome");
+        assert_eq!(found.label.class, None);
+        assert_eq!(found.label.flavor, Some("11 or newer".to_string()));
+        assert_eq!(found.label.ty, Type::Specified);
+        assert_eq!(found.quality, 1.0);
+    } else {
+        panic!("No match found for Chrome 11 HTTP signature");
+    }
+}
+
 /// p0f.fp's Chrome signatures date from ~2012 and require
 /// `Accept-Encoding=[gzip,deflate,sdch]` plus an `Accept-Charset`; a current
 /// Chrome sends neither (`sdch` was dropped around 2016). Header matching is

--- a/huginn-net-db/tests/http_matcher.rs
+++ b/huginn-net-db/tests/http_matcher.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "http")]
-use huginn_net_db::{http, HttpDatabase, HttpSignatureMatcher, Type};
+use huginn_net_db::db_matching_trait::FingerprintDb;
+use huginn_net_db::{http, HttpDatabase, Type};
+use huginn_net_http::matcher_api::HttpMatcher;
 use huginn_net_http::observable::{HttpRequestObservation, HttpResponseObservation};
 
 #[test]
@@ -25,9 +27,7 @@ fn matching_firefox2_by_http_request() {
         expsw: "Firefox/".to_string(),
     };
 
-    let matcher = HttpSignatureMatcher::new(&db);
-
-    if let Some(found) = matcher.matching_by_http_request(&firefox_signature) {
+    if let Some(found) = db.http_request.find_best_match(&firefox_signature) {
         assert_eq!(found.label.name, "Firefox");
         assert_eq!(found.label.class, None);
         assert_eq!(found.label.flavor, Some("2.x".to_string()));
@@ -67,9 +67,7 @@ fn matching_apache_by_http_response() {
         expsw: "Apache".to_string(),
     };
 
-    let matcher = HttpSignatureMatcher::new(&db);
-
-    if let Some(found) = matcher.matching_by_http_response(&apache_signature) {
+    if let Some(found) = db.http_response.find_best_match(&apache_signature) {
         assert_eq!(found.label.name, "Apache");
         assert_eq!(found.label.class, None);
         assert_eq!(found.label.flavor, Some("2.x".to_string()));
@@ -77,44 +75,6 @@ fn matching_apache_by_http_response() {
         assert_eq!(found.quality, 1.0);
     } else {
         panic!("No match found for Apache 2.x HTTP response signature");
-    }
-}
-
-#[test]
-fn matching_chrome11_by_http_request() {
-    let db = match HttpDatabase::load_default() {
-        Ok(db) => db,
-        Err(e) => panic!("Failed to create default database: {e}"),
-    };
-
-    // Layout from p0f.fp `Chrome:11 or newer` (2012): sdch + Accept-Charset.
-    let chrome_signature = HttpRequestObservation {
-        version: http::Version::V11,
-        horder: vec![
-            http::Header::new("Host"),
-            http::Header::new("Connection").with_value("keep-alive"),
-            http::Header::new("User-Agent"),
-            http::Header::new("Accept").with_value("*/*"),
-            http::Header::new("Accept-Encoding").with_value("gzip,deflate,sdch"),
-            http::Header::new("Accept-Language"),
-            http::Header::new("Accept-Charset").with_value("utf-8;q=0.7,*;q=0.3"),
-        ],
-        habsent: vec![],
-        expsw: "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.7 \
-                (KHTML, like Gecko) Chrome/16.0.912.75 Safari/535.7"
-            .to_string(),
-    };
-
-    let matcher = HttpSignatureMatcher::new(&db);
-
-    if let Some(found) = matcher.matching_by_http_request(&chrome_signature) {
-        assert_eq!(found.label.name, "Chrome");
-        assert_eq!(found.label.class, None);
-        assert_eq!(found.label.flavor, Some("11 or newer".to_string()));
-        assert_eq!(found.label.ty, Type::Specified);
-        assert_eq!(found.quality, 1.0);
-    } else {
-        panic!("No match found for Chrome 11 HTTP signature");
     }
 }
 
@@ -153,11 +113,9 @@ fn modern_chrome_request_is_not_covered_by_bundled_signatures() {
         expsw: "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Mobile Safari/537.36".to_string(),
     };
 
-    let matcher = HttpSignatureMatcher::new(&db);
-
     assert!(
-        matcher
-            .matching_by_http_request(&android_chrome_signature)
+        db.http_request
+            .find_best_match(&android_chrome_signature)
             .is_none(),
         "no bundled signature describes this request, so it must not be labelled"
     );
@@ -169,7 +127,6 @@ fn unknown_request_signature_does_not_match() {
         Ok(db) => db,
         Err(e) => panic!("Failed to load default database: {e}"),
     };
-    let matcher = HttpSignatureMatcher::new(&db);
 
     let unknown = HttpRequestObservation {
         version: http::Version::V30,
@@ -177,8 +134,7 @@ fn unknown_request_signature_does_not_match() {
         habsent: vec![],
         expsw: "DefinitelyNotARealBrowser/0.0".to_string(),
     };
-
-    let result = matcher.matching_by_http_request(&unknown);
+    let result = db.http_request.find_best_match(&unknown);
     assert!(
         result.is_none(),
         "expected no match for synthetic signature, got {:?}",
@@ -192,11 +148,12 @@ fn ua_lookup_returns_known_family() {
         Ok(db) => db,
         Err(e) => panic!("Failed to load default database: {e}"),
     };
-    let matcher = HttpSignatureMatcher::new(&db);
+    let matcher = huginn_net_db::HttpSignatureMatcher::new(&db);
 
     let ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
               (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
-    if let Some((substr, _family)) = matcher.matching_by_user_agent(ua) {
-        assert!(ua.contains(substr), "matched substring should appear in UA");
-    }
+    let found = matcher
+        .match_user_agent(ua)
+        .unwrap_or_else(|| panic!("Windows UA should map to an OS family"));
+    assert_eq!(found.family, "Windows");
 }

--- a/huginn-net-db/tests/parse.rs
+++ b/huginn-net-db/tests/parse.rs
@@ -1,11 +1,13 @@
 #![cfg(all(feature = "tcp", feature = "http"))]
-use huginn_net_db::db_parse::parse_ttl_str;
 use huginn_net_db::http::{
     Header as HttpHeader, Signature as HttpSignature, Version as HttpVersion,
 };
+use huginn_net_db::parse::parse_ttl_str;
 use huginn_net_db::tcp::Quirk::{AckNumNonZero, Df, NonZeroID};
 use huginn_net_db::tcp::TcpOption::{Mss, Nop, Sok, Ws, TS};
-use huginn_net_db::tcp::{IpVersion, PayloadSize, Signature as TcpSignature, Ttl, WindowSize};
+use huginn_net_db::tcp::{
+    IpVersion, PayloadSize, QuirkSet, Signature as TcpSignature, Ttl, WindowSize,
+};
 use huginn_net_db::{Label, Type};
 use lazy_static::lazy_static;
 
@@ -59,7 +61,7 @@ lazy_static! {
                     wsize: WindowSize::Mss(20),
                     wscale: Some(10),
                     olayout: vec![Mss, Sok, TS, Nop, Ws],
-                    quirks: vec![Df, NonZeroID],
+                    quirks: QuirkSet::from([Df, NonZeroID]),
                     pclass: PayloadSize::Zero,
                 }
             ),
@@ -73,7 +75,7 @@ lazy_static! {
                     wsize: WindowSize::Value(16384),
                     wscale: Some(0),
                     olayout: vec![Mss],
-                    quirks: vec![],
+                    quirks: QuirkSet::EMPTY,
                     pclass: PayloadSize::Zero,
                 }
             ),
@@ -87,7 +89,7 @@ lazy_static! {
                     wsize: WindowSize::Mtu(2),
                     wscale: Some(0),
                     olayout: vec![Mss, Nop, Ws],
-                    quirks: vec![],
+                    quirks: QuirkSet::EMPTY,
                     pclass: PayloadSize::Zero,
                 }
             ),
@@ -101,7 +103,7 @@ lazy_static! {
                     wsize: WindowSize::Mod(512),
                     wscale: Some(0),
                     olayout: vec![Mss, Sok, TS],
-                    quirks: vec![AckNumNonZero],
+                    quirks: QuirkSet::from([AckNumNonZero]),
                     pclass: PayloadSize::Zero,
                 }
             ),
@@ -115,7 +117,7 @@ lazy_static! {
                     wsize: WindowSize::Mss(44),
                     wscale: Some(1),
                     olayout: vec![Mss, Sok, TS, Nop, Ws],
-                    quirks: vec![Df, NonZeroID],
+                    quirks: QuirkSet::from([Df, NonZeroID]),
                     pclass: PayloadSize::Zero,
                 }
             ),
@@ -129,7 +131,7 @@ lazy_static! {
                     wsize: WindowSize::Any,
                     wscale: None,
                     olayout: vec![Mss, Sok, TS, Nop, Ws],
-                    quirks: vec![Df, NonZeroID],
+                    quirks: QuirkSet::from([Df, NonZeroID]),
                     pclass: PayloadSize::Zero,
                 }
 
@@ -230,7 +232,7 @@ fn test_http_signature() {
 
 #[test]
 fn test_http_header() {
-    use huginn_net_db::db_parse::parse_http_header_str;
+    use huginn_net_db::parse::parse_http_header_str;
     for (s, h) in HTTP_HEADERS.iter() {
         let result = parse_http_header_str(s);
         assert!(result.is_ok(), "Failed to parse HTTP header: {s}");

--- a/huginn-net-db/tests/tcp_db_reachable.rs
+++ b/huginn-net-db/tests/tcp_db_reachable.rs
@@ -1,16 +1,4 @@
 #![cfg(feature = "tcp")]
-//! Every signature in the database has to be reachable.
-//!
-//! Each signature is replayed as the packet that declared it, the observation a
-//! host matching it would produce, and has to come back with a match. A
-//! signature that no packet can reach is dead weight in the database, and the
-//! way to end up with one is to compare a field in a form the observation no
-//! longer carries.
-//!
-//! The match is not required to be the signature's *own* label: `p0f.fp` ships
-//! signatures that are indistinguishable from each other, so a specific one can
-//! legitimately answer for another. That ambiguity is a property of the data, not
-//! of the matcher, and it belongs to the coverage check.
 
 use huginn_net_db::database::Label;
 use huginn_net_db::tcp::{IpVersion, PayloadSize, Signature, Ttl, WindowSize};

--- a/huginn-net-db/tests/tcp_db_reachable.rs
+++ b/huginn-net-db/tests/tcp_db_reachable.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "tcp")]
 //! Every signature in the database has to be reachable.
 //!
-//! Each signature is replayed as the packet that declared it —the observation a
-//! host matching it would produce— and has to come back with a match. A
+//! Each signature is replayed as the packet that declared it, the observation a
+//! host matching it would produce, and has to come back with a match. A
 //! signature that no packet can reach is dead weight in the database, and the
 //! way to end up with one is to compare a field in a form the observation no
 //! longer carries.

--- a/huginn-net-db/tests/tcp_db_reachable.rs
+++ b/huginn-net-db/tests/tcp_db_reachable.rs
@@ -1,9 +1,21 @@
 #![cfg(feature = "tcp")]
-//! Every database signature, replayed as the observation it describes, must match.
+//! Every signature in the database has to be reachable.
+//!
+//! Each signature is replayed as the packet that declared it —the observation a
+//! host matching it would produce— and has to come back with a match. A
+//! signature that no packet can reach is dead weight in the database, and the
+//! way to end up with one is to compare a field in a form the observation no
+//! longer carries.
+//!
+//! The match is not required to be the signature's *own* label: `p0f.fp` ships
+//! signatures that are indistinguishable from each other, so a specific one can
+//! legitimately answer for another. That ambiguity is a property of the data, not
+//! of the matcher, and it belongs to the coverage check.
 
 use huginn_net_db::database::Label;
 use huginn_net_db::tcp::{IpVersion, PayloadSize, Signature, Ttl, WindowSize};
 use huginn_net_db::{TcpDatabase, TcpSignatureMatcher};
+use huginn_net_tcp::matcher_api::TcpMatcher;
 use huginn_net_tcp::observable::TcpObservation;
 use huginn_net_tcp::ObservableTcp;
 
@@ -40,7 +52,7 @@ fn replay(sig: &Signature) -> ObservableTcp {
             tot_hdr: TYPICAL_TOT_HDR,
             wscale: Some(sig.wscale.unwrap_or(0)),
             olayout: sig.olayout.clone(),
-            quirks: sig.quirks.clone(),
+            quirks: sig.quirks,
             pclass: if sig.pclass == PayloadSize::Any {
                 PayloadSize::Zero
             } else {
@@ -85,7 +97,7 @@ fn every_request_signature_is_reachable() {
     let matcher = TcpSignatureMatcher::new(&db);
 
     let unreachable = unreachable_signatures(&db.tcp_request.entries, |obs| {
-        matcher.matching_by_tcp_request(obs).is_some()
+        matcher.match_tcp_request(&obs.matching).is_some()
     });
 
     assert!(
@@ -105,7 +117,7 @@ fn every_response_signature_is_reachable() {
     let matcher = TcpSignatureMatcher::new(&db);
 
     let unreachable = unreachable_signatures(&db.tcp_response.entries, |obs| {
-        matcher.matching_by_tcp_response(obs).is_some()
+        matcher.match_tcp_response(&obs.matching).is_some()
     });
 
     assert!(

--- a/huginn-net-db/tests/tcp_match_selection.rs
+++ b/huginn-net-db/tests/tcp_match_selection.rs
@@ -2,7 +2,7 @@
 
 use huginn_net_db::database::{FingerprintCollection, Label, TcpIndexKey, Type};
 use huginn_net_db::db_matching_trait::FingerprintDb;
-use huginn_net_db::tcp::{IpVersion, PayloadSize, Quirk, Signature, Ttl, WindowSize};
+use huginn_net_db::tcp::{IpVersion, PayloadSize, Quirk, QuirkSet, Signature, Ttl, WindowSize};
 use huginn_net_tcp::observable::TcpObservation;
 
 type TcpCollection = FingerprintCollection<TcpObservation, Signature, TcpIndexKey>;
@@ -17,7 +17,7 @@ fn observation() -> TcpObservation {
         tot_hdr: 40,
         wscale: Some(6),
         olayout: Vec::new(),
-        quirks: Vec::new(),
+        quirks: QuirkSet::EMPTY,
         pclass: PayloadSize::Zero,
         peer_mss: None,
         tos: 0,
@@ -34,7 +34,7 @@ fn signature() -> Signature {
         wsize: WindowSize::Value(65535),
         wscale: Some(6),
         olayout: Vec::new(),
-        quirks: Vec::new(),
+        quirks: QuirkSet::EMPTY,
         pclass: PayloadSize::Zero,
     }
 }
@@ -42,7 +42,7 @@ fn signature() -> Signature {
 /// Only fits [`observation`] through the quirks whitelist: p0f lets `df`
 /// disappear from the traffic, but the match is fuzzy.
 fn fuzzy_signature() -> Signature {
-    Signature { quirks: vec![Quirk::Df], ..signature() }
+    Signature { quirks: QuirkSet::from([Quirk::Df]), ..signature() }
 }
 
 fn label(name: &str, ty: Type) -> Label {

--- a/huginn-net-db/tests/tcp_matcher.rs
+++ b/huginn-net-db/tests/tcp_matcher.rs
@@ -1,8 +1,10 @@
 #![cfg(feature = "tcp")]
-use huginn_net_db::tcp::{IpVersion, PayloadSize, Quirk, Signature, TcpOption, Ttl, WindowSize};
-use huginn_net_db::{TcpDatabase, TcpSignatureMatcher, Type};
+use huginn_net_db::db_matching_trait::FingerprintDb;
+use huginn_net_db::tcp::{
+    IpVersion, PayloadSize, Quirk, QuirkSet, Signature, TcpOption, Ttl, WindowSize,
+};
+use huginn_net_db::{TcpDatabase, Type};
 use huginn_net_tcp::observable::TcpObservation;
-use huginn_net_tcp::ObservableTcp;
 
 /// Resolves the window a signature declares into a concrete value a packet
 /// could have carried, so the signature can be replayed as an observation.
@@ -27,24 +29,24 @@ fn observation_from_signature(sig: &Signature) -> TcpObservation {
         tot_hdr: 60,
         wscale: sig.wscale,
         olayout: sig.olayout.clone(),
-        quirks: sig.quirks.clone(),
+        quirks: sig.quirks,
         pclass: sig.pclass,
         peer_mss: None,
         tos: 0,
     }
 }
 
-/// Parses `raw` as a TCP signature and runs it through `matching_by_tcp_request`.
+/// Parses `raw` as a TCP signature and matches it against the request collection.
 fn match_request(
-    matcher: &TcpSignatureMatcher,
+    db: &TcpDatabase,
     raw: &str,
 ) -> Option<(String, Option<String>, Option<String>, f32)> {
     let sig: Signature = match raw.parse() {
         Ok(sig) => sig,
         Err(e) => panic!("Failed to parse signature {raw}: {e}"),
     };
-    let obs = ObservableTcp { matching: observation_from_signature(&sig) };
-    let found = matcher.matching_by_tcp_request(&obs)?;
+    let obs = observation_from_signature(&sig);
+    let found = db.tcp_request.find_best_match(&obs)?;
     Some((
         found.label.name.clone(),
         found.label.class.clone(),
@@ -63,32 +65,22 @@ fn matching_linux_by_tcp_request() {
     };
 
     //sig: 4:58+6:0:1452:mss*44,7:mss,sok,ts,nop,ws:df,id+:0
-    let linux_signature = ObservableTcp {
-        matching: TcpObservation {
-            version: IpVersion::V4,
-            ittl: Ttl::Distance(58, 6),
-            olen: 0,
-            mss: Some(1452),
-            wsize: 1452 * 44,
-            tot_hdr: 60,
-            wscale: Some(7),
-            olayout: vec![
-                TcpOption::Mss,
-                TcpOption::Sok,
-                TcpOption::TS,
-                TcpOption::Nop,
-                TcpOption::Ws,
-            ],
-            quirks: vec![Quirk::Df, Quirk::NonZeroID],
-            pclass: PayloadSize::Zero,
-            peer_mss: None,
-            tos: 0,
-        },
+    let linux_signature = TcpObservation {
+        version: IpVersion::V4,
+        ittl: Ttl::Distance(58, 6),
+        olen: 0,
+        mss: Some(1452),
+        wsize: 1452 * 44,
+        tot_hdr: 60,
+        wscale: Some(7),
+        olayout: vec![TcpOption::Mss, TcpOption::Sok, TcpOption::TS, TcpOption::Nop, TcpOption::Ws],
+        quirks: QuirkSet::from([Quirk::Df, Quirk::NonZeroID]),
+        pclass: PayloadSize::Zero,
+        peer_mss: None,
+        tos: 0,
     };
 
-    let matcher = TcpSignatureMatcher::new(&db);
-
-    if let Some(found) = matcher.matching_by_tcp_request(&linux_signature) {
+    if let Some(found) = db.tcp_request.find_best_match(&linux_signature) {
         assert_eq!(found.label.name, "Linux");
         assert_eq!(found.label.class, Some("unix".to_string()));
         assert_eq!(found.label.flavor, Some("2.2.x-3.x".to_string()));
@@ -112,56 +104,38 @@ fn matching_android_by_tcp_request() {
     };
 
     //sig: "4:64+0:0:1460:65535,8:mss,sok,ts,nop,ws:df,id+:0"
-    let android_signature = ObservableTcp {
-        matching: TcpObservation {
-            version: IpVersion::V4,
-            ittl: Ttl::Value(64),
-            olen: 0,
-            mss: Some(1460),
-            wsize: 65535,
-            tot_hdr: 60,
-            wscale: Some(8),
-            olayout: vec![
-                TcpOption::Mss,
-                TcpOption::Sok,
-                TcpOption::TS,
-                TcpOption::Nop,
-                TcpOption::Ws,
-            ],
-            quirks: vec![Quirk::Df, Quirk::NonZeroID],
-            pclass: PayloadSize::Zero,
-            peer_mss: None,
-            tos: 0,
-        },
+    let android_signature = TcpObservation {
+        version: IpVersion::V4,
+        ittl: Ttl::Value(64),
+        olen: 0,
+        mss: Some(1460),
+        wsize: 65535,
+        tot_hdr: 60,
+        wscale: Some(8),
+        olayout: vec![TcpOption::Mss, TcpOption::Sok, TcpOption::TS, TcpOption::Nop, TcpOption::Ws],
+        quirks: QuirkSet::from([Quirk::Df, Quirk::NonZeroID]),
+        pclass: PayloadSize::Zero,
+        peer_mss: None,
+        tos: 0,
     };
 
     //sig: "4:57+7:0:1460:65535,8:mss,sok,ts,nop,ws:df,id+:0"
-    let android_signature_with_distance = ObservableTcp {
-        matching: TcpObservation {
-            version: IpVersion::V4,
-            ittl: Ttl::Distance(57, 7),
-            olen: 0,
-            mss: Some(1460),
-            wsize: 65535,
-            tot_hdr: 60,
-            wscale: Some(8),
-            olayout: vec![
-                TcpOption::Mss,
-                TcpOption::Sok,
-                TcpOption::TS,
-                TcpOption::Nop,
-                TcpOption::Ws,
-            ],
-            quirks: vec![Quirk::Df, Quirk::NonZeroID],
-            pclass: PayloadSize::Zero,
-            peer_mss: None,
-            tos: 0,
-        },
+    let android_signature_with_distance = TcpObservation {
+        version: IpVersion::V4,
+        ittl: Ttl::Distance(57, 7),
+        olen: 0,
+        mss: Some(1460),
+        wsize: 65535,
+        tot_hdr: 60,
+        wscale: Some(8),
+        olayout: vec![TcpOption::Mss, TcpOption::Sok, TcpOption::TS, TcpOption::Nop, TcpOption::Ws],
+        quirks: QuirkSet::from([Quirk::Df, Quirk::NonZeroID]),
+        pclass: PayloadSize::Zero,
+        peer_mss: None,
+        tos: 0,
     };
 
-    let matcher = TcpSignatureMatcher::new(&db);
-
-    if let Some(found) = matcher.matching_by_tcp_request(&android_signature) {
+    if let Some(found) = db.tcp_request.find_best_match(&android_signature) {
         assert_eq!(found.label.name, "Linux");
         assert_eq!(found.label.class, Some("unix".to_string()));
         assert_eq!(found.label.flavor, Some("Android".to_string()));
@@ -172,7 +146,10 @@ fn matching_android_by_tcp_request() {
         panic!("No match found");
     }
 
-    if let Some(found) = matcher.matching_by_tcp_request(&android_signature_with_distance) {
+    if let Some(found) = db
+        .tcp_request
+        .find_best_match(&android_signature_with_distance)
+    {
         assert_eq!(found.label.name, "Linux");
         assert_eq!(found.label.class, Some("unix".to_string()));
         assert_eq!(found.label.flavor, Some("Android".to_string()));
@@ -192,10 +169,8 @@ fn unknown_request_signature_does_not_match() {
         Ok(db) => db,
         Err(e) => panic!("Failed to load default database: {e}"),
     };
-    let matcher = TcpSignatureMatcher::new(&db);
-
     let raw = "4:64+0:0:1460:65535,6:mss,nop,ws,nop,nop,ts,sok,eol+1,eol+0:df,ecn:0";
-    let result = match_request(&matcher, raw);
+    let result = match_request(&db, raw);
     assert!(
         result.is_none(),
         "expected no match for synthetic signature: {raw}, got {result:?}"

--- a/huginn-net-db/tests/tcp_matching.rs
+++ b/huginn-net-db/tests/tcp_matching.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "tcp")]
 use huginn_net_db::db_matching_trait::{DatabaseSignature, SignatureFit};
-use huginn_net_db::tcp::{IpVersion, PayloadSize, Quirk, Signature, Ttl, WindowSize};
+use huginn_net_db::tcp::{IpVersion, PayloadSize, Quirk, QuirkSet, Signature, Ttl, WindowSize};
 use huginn_net_tcp::observable::TcpObservation;
 use huginn_net_tcp::output::FuzzyReason;
 
@@ -14,7 +14,7 @@ fn base_observation() -> TcpObservation {
         tot_hdr: 40,
         wscale: Some(6),
         olayout: Vec::new(),
-        quirks: Vec::new(),
+        quirks: QuirkSet::EMPTY,
         pclass: PayloadSize::Zero,
         peer_mss: None,
         tos: 0,
@@ -30,7 +30,7 @@ fn base_signature() -> Signature {
         wsize: WindowSize::Value(65535),
         wscale: Some(6),
         olayout: Vec::new(),
-        quirks: Vec::new(),
+        quirks: QuirkSet::EMPTY,
         pclass: PayloadSize::Zero,
     }
 }
@@ -43,7 +43,7 @@ fn exact() -> Option<SignatureFit<FuzzyReason>> {
 
 /// The match only holds because these quirks were tolerated, the TTL being
 /// plausible.
-fn tolerating_quirks(missing: Vec<Quirk>, added: Vec<Quirk>) -> Option<SignatureFit<FuzzyReason>> {
+fn tolerating_quirks(missing: QuirkSet, added: QuirkSet) -> Option<SignatureFit<FuzzyReason>> {
     Some(SignatureFit::fuzzy(FuzzyReason {
         implausible_hop_distance: None,
         added_quirks: added,
@@ -124,9 +124,9 @@ fn wildcard_window_size_matches_any_observed_value() {
 #[test]
 fn quirks_are_compared_as_sets_not_ordered_lists() {
     let mut signature = base_signature();
-    signature.quirks = vec![Quirk::Df, Quirk::NonZeroID];
+    signature.quirks = QuirkSet::from([Quirk::Df, Quirk::NonZeroID]);
     let mut observed = base_observation();
-    observed.quirks = vec![Quirk::NonZeroID, Quirk::Df];
+    observed.quirks = QuirkSet::from([Quirk::NonZeroID, Quirk::Df]);
     assert_eq!(signature.fit(&observed), exact());
 }
 
@@ -134,10 +134,10 @@ fn quirks_are_compared_as_sets_not_ordered_lists() {
 fn missing_df_or_non_zero_id_is_a_fuzzy_match() {
     for quirk in [Quirk::Df, Quirk::NonZeroID] {
         let mut signature = base_signature();
-        signature.quirks = vec![quirk.clone()];
+        signature.quirks = QuirkSet::from([quirk]);
         assert_eq!(
             signature.fit(&base_observation()),
-            tolerating_quirks(vec![quirk.clone()], vec![]),
+            tolerating_quirks(QuirkSet::from([quirk]), QuirkSet::EMPTY),
             "p0f tolerates {quirk:?} disappearing from the traffic"
         );
     }
@@ -147,10 +147,10 @@ fn missing_df_or_non_zero_id_is_a_fuzzy_match() {
 fn extra_zero_id_or_ecn_is_a_fuzzy_match() {
     for quirk in [Quirk::ZeroID, Quirk::Ecn] {
         let mut observed = base_observation();
-        observed.quirks = vec![quirk.clone()];
+        observed.quirks = QuirkSet::from([quirk]);
         assert_eq!(
             base_signature().fit(&observed),
-            tolerating_quirks(vec![], vec![quirk.clone()]),
+            tolerating_quirks(QuirkSet::EMPTY, QuirkSet::from([quirk])),
             "p0f tolerates {quirk:?} appearing in the traffic"
         );
     }
@@ -159,14 +159,14 @@ fn extra_zero_id_or_ecn_is_a_fuzzy_match() {
 #[test]
 fn other_missing_quirk_rejects_signature() {
     let mut signature = base_signature();
-    signature.quirks = vec![Quirk::MustBeZero];
+    signature.quirks = QuirkSet::from([Quirk::MustBeZero]);
     assert_eq!(signature.fit(&base_observation()), None, "only df and id+ may disappear");
 }
 
 #[test]
 fn other_extra_quirk_rejects_signature() {
     let mut observed = base_observation();
-    observed.quirks = vec![Quirk::SeqNumZero];
+    observed.quirks = QuirkSet::from([Quirk::SeqNumZero]);
     assert_eq!(base_signature().fit(&observed), None, "only id- and ecn may appear");
 }
 
@@ -174,7 +174,7 @@ fn other_extra_quirk_rejects_signature() {
 fn version_agnostic_signature_ignores_ipv6_only_quirks_on_ipv4() {
     let mut signature = base_signature();
     signature.version = IpVersion::Any;
-    signature.quirks = vec![Quirk::FlowID];
+    signature.quirks = QuirkSet::from([Quirk::FlowID]);
     assert_eq!(
         signature.fit(&base_observation()),
         exact(),
@@ -186,7 +186,7 @@ fn version_agnostic_signature_ignores_ipv6_only_quirks_on_ipv4() {
 fn version_agnostic_signature_ignores_ipv4_only_quirks_on_ipv6() {
     let mut signature = base_signature();
     signature.version = IpVersion::Any;
-    signature.quirks = vec![Quirk::Df, Quirk::NonZeroID, Quirk::ZeroID];
+    signature.quirks = QuirkSet::from([Quirk::Df, Quirk::NonZeroID, Quirk::ZeroID]);
     let mut observed = base_observation();
     observed.version = IpVersion::V6;
     assert_eq!(
@@ -200,7 +200,7 @@ fn version_agnostic_signature_ignores_ipv4_only_quirks_on_ipv6() {
 fn version_specific_signature_does_not_mask_quirks() {
     let mut signature = base_signature();
     signature.version = IpVersion::V4;
-    signature.quirks = vec![Quirk::FlowID];
+    signature.quirks = QuirkSet::from([Quirk::FlowID]);
     assert_eq!(
         signature.fit(&base_observation()),
         None,
@@ -227,8 +227,8 @@ fn an_implausible_hop_count_is_a_fuzzy_match() {
         base_signature().fit(&observed),
         Some(SignatureFit::fuzzy(FuzzyReason {
             implausible_hop_distance: Some(54),
-            added_quirks: vec![],
-            missing_quirks: vec![],
+            added_quirks: QuirkSet::EMPTY,
+            missing_quirks: QuirkSet::EMPTY,
         })),
         "54 hops is beyond p0f's MAX_DIST, so the signature only holds as fuzzy"
     );
@@ -237,16 +237,16 @@ fn an_implausible_hop_count_is_a_fuzzy_match() {
 #[test]
 fn the_reason_reports_both_tolerances_when_both_apply() {
     let mut signature = base_signature();
-    signature.quirks = vec![Quirk::Df];
+    signature.quirks = QuirkSet::from([Quirk::Df]);
     let mut observed = base_observation();
     observed.ittl = Ttl::Value(10);
-    observed.quirks = vec![Quirk::Ecn];
+    observed.quirks = QuirkSet::from([Quirk::Ecn]);
     assert_eq!(
         signature.fit(&observed),
         Some(SignatureFit::fuzzy(FuzzyReason {
             implausible_hop_distance: Some(54),
-            added_quirks: vec![Quirk::Ecn],
-            missing_quirks: vec![Quirk::Df],
+            added_quirks: QuirkSet::from([Quirk::Ecn]),
+            missing_quirks: QuirkSet::from([Quirk::Df]),
         })),
         "the TTL and the quirks are independent tolerances, so neither hides the other"
     );

--- a/huginn-net-db/tests/tcp_params.rs
+++ b/huginn-net-db/tests/tcp_params.rs
@@ -3,7 +3,8 @@
 
 use huginn_net_db::database::{FingerprintCollection, Label, Type};
 use huginn_net_db::tcp::{
-    report_hop_distance, IpVersion, PayloadSize, Signature, Ttl, WindowSize, MAX_TTL_DISTANCE,
+    report_hop_distance, IpVersion, PayloadSize, QuirkSet, Signature, Ttl, WindowSize,
+    MAX_TTL_DISTANCE,
 };
 use huginn_net_db::{TcpDatabase, TcpSignatureMatcher};
 use huginn_net_tcp::matcher_api::TcpMatcher;
@@ -21,7 +22,7 @@ fn observation(ittl: Ttl, tos: u8) -> TcpObservation {
         tot_hdr: 40,
         wscale: Some(6),
         olayout: Vec::new(),
-        quirks: Vec::new(),
+        quirks: QuirkSet::EMPTY,
         pclass: PayloadSize::Zero,
         peer_mss: None,
         tos,
@@ -37,7 +38,7 @@ fn signature(ittl: Ttl) -> Signature {
         wsize: WindowSize::Value(65535),
         wscale: Some(6),
         olayout: Vec::new(),
-        quirks: Vec::new(),
+        quirks: QuirkSet::EMPTY,
         pclass: PayloadSize::Zero,
     }
 }

--- a/huginn-net-db/tests/tcp_window_size.rs
+++ b/huginn-net-db/tests/tcp_window_size.rs
@@ -1,8 +1,13 @@
 #![cfg(feature = "tcp")]
-//! Window match: raw `wsize` vs the signature form (`mss*n`, literal, peer MSS).
+//! A database signature that declares a literal window must stay reachable.
+//!
+//! p0f keeps the observed window exactly as it came off the wire and only
+//! resolves a multiplier when the *signature* asks for one, so a literal window
+//! is compared for equality and always works (`fp_tcp.c:189-217`).
 
-use huginn_net_db::tcp::{IpVersion, PayloadSize, Quirk, TcpOption};
+use huginn_net_db::tcp::{IpVersion, PayloadSize, Quirk, QuirkSet, TcpOption};
 use huginn_net_db::{TcpDatabase, TcpSignatureMatcher};
+use huginn_net_tcp::matcher_api::TcpMatcher;
 use huginn_net_tcp::observable::TcpObservation;
 use huginn_net_tcp::ObservableTcp;
 
@@ -14,9 +19,17 @@ fn observed(
     window: u16,
     wscale: Option<u8>,
     olayout: Vec<TcpOption>,
-    quirks: Vec<Quirk>,
+    quirks: QuirkSet,
     peer_mss: Option<u16>,
 ) -> ObservableTcp {
+    // Twenty bytes of IP header plus a TCP header of five words and one more per
+    // option, which is close enough for a test that only reads the window.
+    let option_words = u16::try_from(olayout.len()).unwrap_or(0);
+    let tot_hdr = option_words
+        .saturating_add(5)
+        .saturating_mul(4)
+        .saturating_add(20);
+
     ObservableTcp {
         matching: TcpObservation {
             version: IpVersion::V4,
@@ -24,11 +37,7 @@ fn observed(
             olen: 0,
             mss,
             wsize: window,
-            tot_hdr: u16::try_from(olayout.len())
-                .unwrap_or(0)
-                .saturating_add(5)
-                .saturating_mul(4)
-                .saturating_add(20),
+            tot_hdr,
             wscale,
             olayout,
             quirks,
@@ -45,7 +54,7 @@ fn observed_syn(
     window: u16,
     wscale: Option<u8>,
     olayout: Vec<TcpOption>,
-    quirks: Vec<Quirk>,
+    quirks: QuirkSet,
 ) -> ObservableTcp {
     observed(raw_ttl, mss, window, wscale, olayout, quirks, None)
 }
@@ -55,8 +64,8 @@ fn matched_request_flavor(syn: &ObservableTcp) -> Option<(String, Option<String>
         Ok(db) => db,
         Err(e) => panic!("failed to load default database: {e}"),
     };
-    let found = TcpSignatureMatcher::new(&db).matching_by_tcp_request(syn)?;
-    Some((found.label.name.clone(), found.label.flavor.clone()))
+    let found = TcpSignatureMatcher::new(&db).match_tcp_request(&syn.matching)?;
+    Some((found.os.name, found.os.variant))
 }
 
 fn matched_response_flavor(syn_ack: &ObservableTcp) -> Option<(String, Option<String>)> {
@@ -64,8 +73,8 @@ fn matched_response_flavor(syn_ack: &ObservableTcp) -> Option<(String, Option<St
         Ok(db) => db,
         Err(e) => panic!("failed to load default database: {e}"),
     };
-    let found = TcpSignatureMatcher::new(&db).matching_by_tcp_response(syn_ack)?;
-    Some((found.label.name.clone(), found.label.flavor.clone()))
+    let found = TcpSignatureMatcher::new(&db).match_tcp_response(&syn_ack.matching)?;
+    Some((found.os.name, found.os.variant))
 }
 
 #[test]
@@ -77,7 +86,7 @@ fn a_windows_syn_matches_its_literal_window() {
         8192,
         Some(0),
         vec![TcpOption::Mss, TcpOption::Nop, TcpOption::Nop, TcpOption::Sok],
-        vec![Quirk::Df, Quirk::NonZeroID],
+        QuirkSet::from([Quirk::Df, Quirk::NonZeroID]),
     );
 
     assert_eq!(
@@ -90,7 +99,7 @@ fn a_windows_syn_matches_its_literal_window() {
 #[test]
 fn an_nmap_scan_matches_its_literal_window() {
     // s:!:NMap:SYN scan -> *:64-:0:1460:1024,0:mss::0
-    let syn = observed_syn(64, Some(1460), 1024, Some(0), vec![TcpOption::Mss], vec![]);
+    let syn = observed_syn(64, Some(1460), 1024, Some(0), vec![TcpOption::Mss], QuirkSet::EMPTY);
 
     assert_eq!(
         matched_request_flavor(&syn),
@@ -109,7 +118,7 @@ fn a_window_that_is_a_multiple_of_the_mss_matches_an_mss_signature() {
         1460 * 20,
         Some(10),
         vec![TcpOption::Mss, TcpOption::Sok, TcpOption::TS, TcpOption::Nop, TcpOption::Ws],
-        vec![Quirk::Df, Quirk::NonZeroID],
+        QuirkSet::from([Quirk::Df, Quirk::NonZeroID]),
     );
 
     assert_eq!(
@@ -129,7 +138,7 @@ fn a_window_that_is_not_a_multiple_of_the_mss_does_not_match_an_mss_signature() 
         65535,
         Some(10),
         vec![TcpOption::Mss, TcpOption::Sok, TcpOption::TS, TcpOption::Nop, TcpOption::Ws],
-        vec![Quirk::Df, Quirk::NonZeroID],
+        QuirkSet::from([Quirk::Df, Quirk::NonZeroID]),
     );
 
     assert_ne!(
@@ -149,7 +158,7 @@ fn a_syn_ack_window_sized_off_the_peer_mss_matches_and_renders() {
         1400 * 10,
         Some(7),
         vec![TcpOption::Mss, TcpOption::Sok, TcpOption::TS, TcpOption::Nop, TcpOption::Ws],
-        vec![Quirk::Df],
+        QuirkSet::from([Quirk::Df]),
         Some(1400),
     );
 
@@ -173,7 +182,7 @@ fn without_the_peer_mss_that_same_window_does_not_match() {
         1400 * 10,
         Some(7),
         vec![TcpOption::Mss, TcpOption::Sok, TcpOption::TS, TcpOption::Nop, TcpOption::Ws],
-        vec![Quirk::Df],
+        QuirkSet::from([Quirk::Df]),
         None,
     );
 

--- a/huginn-net-db/tests/tcp_window_size.rs
+++ b/huginn-net-db/tests/tcp_window_size.rs
@@ -1,9 +1,4 @@
 #![cfg(feature = "tcp")]
-//! A database signature that declares a literal window must stay reachable.
-//!
-//! p0f keeps the observed window exactly as it came off the wire and only
-//! resolves a multiplier when the *signature* asks for one, so a literal window
-//! is compared for equality and always works (`fp_tcp.c:189-217`).
 
 use huginn_net_db::tcp::{IpVersion, PayloadSize, Quirk, QuirkSet, TcpOption};
 use huginn_net_db::{TcpDatabase, TcpSignatureMatcher};
@@ -11,8 +6,6 @@ use huginn_net_tcp::matcher_api::TcpMatcher;
 use huginn_net_tcp::observable::TcpObservation;
 use huginn_net_tcp::ObservableTcp;
 
-/// Builds an observation the way the packet pipeline does: from wire values,
-/// not from a database signature.
 fn observed(
     raw_ttl: u8,
     mss: Option<u16>,
@@ -22,8 +15,6 @@ fn observed(
     quirks: QuirkSet,
     peer_mss: Option<u16>,
 ) -> ObservableTcp {
-    // Twenty bytes of IP header plus a TCP header of five words and one more per
-    // option, which is close enough for a test that only reads the window.
     let option_words = u16::try_from(olayout.len()).unwrap_or(0);
     let tot_hdr = option_words
         .saturating_add(5)

--- a/huginn-net-tcp/src/output/common.rs
+++ b/huginn-net-tcp/src/output/common.rs
@@ -1,6 +1,6 @@
 use crate::observable::TcpObservation;
 use crate::tcp::ttl::{guess_distance, observed_ttl, MAX_DIST};
-use crate::tcp::Quirk;
+use crate::tcp::QuirkSet;
 use std::fmt;
 use std::fmt::Formatter;
 
@@ -51,10 +51,10 @@ pub struct FuzzyReason {
     pub implausible_hop_distance: Option<u32>,
     /// Quirks the traffic showed that the signature does not declare. Only
     /// `id-` and `ecn` ever appear here; anything else rejects the signature.
-    pub added_quirks: Vec<Quirk>,
+    pub added_quirks: QuirkSet,
     /// Quirks the signature declares that the traffic did not show. Only `df`
     /// and `id+` ever appear here.
-    pub missing_quirks: Vec<Quirk>,
+    pub missing_quirks: QuirkSet,
 }
 
 impl fmt::Display for FuzzyReason {
@@ -74,23 +74,15 @@ impl fmt::Display for FuzzyReason {
         }
         if !self.missing_quirks.is_empty() {
             separate(f)?;
-            write!(f, "missing {}", join_quirks(&self.missing_quirks))?;
+            write!(f, "missing {}", self.missing_quirks)?;
         }
         if !self.added_quirks.is_empty() {
             separate(f)?;
-            write!(f, "extra {}", join_quirks(&self.added_quirks))?;
+            write!(f, "extra {}", self.added_quirks)?;
         }
 
         Ok(())
     }
-}
-
-fn join_quirks(quirks: &[Quirk]) -> String {
-    quirks
-        .iter()
-        .map(|quirk| quirk.to_string())
-        .collect::<Vec<_>>()
-        .join(",")
 }
 
 /// Outcome of matching an observation against a fingerprint database.

--- a/huginn-net-tcp/src/process/flow.rs
+++ b/huginn-net-tcp/src/process/flow.rs
@@ -9,7 +9,7 @@ use crate::tcp;
 use crate::tcp::observable::{ObservableTcp, TcpObservation};
 #[cfg(any(feature = "syn", feature = "syn-ack"))]
 use crate::tcp::PayloadSize;
-use crate::tcp::{IpOptions, IpVersion, Quirk, TcpOption, Ttl};
+use crate::tcp::{IpOptions, IpVersion, Quirk, QuirkSet, TcpOption, Ttl};
 #[cfg(feature = "uptime")]
 use crate::uptime::{check_ts_tcp, Connection, ObservableUptime};
 use pnet::packet::ip::IpNextHeaderProtocols;
@@ -131,24 +131,24 @@ pub fn process_tcp_ipv4(
     let ttl: Ttl = tcp::ttl::calculate_ttl(ttl_observed);
     let tos: u8 = packet.get_dscp();
     let olen: u8 = IpOptions::calculate_ipv4_length(packet);
-    let mut quirks: Vec<Quirk> = Vec::with_capacity(8);
+    let mut quirks = QuirkSet::EMPTY;
 
     if (packet.get_ecn() & (IP_TOS_CE | IP_TOS_ECT)) != 0 {
-        quirks.push(Quirk::Ecn);
+        quirks.insert(Quirk::Ecn);
     }
 
     if (packet.get_flags() & IP4_MBZ) != 0 {
-        quirks.push(Quirk::MustBeZero);
+        quirks.insert(Quirk::MustBeZero);
     }
 
     if (packet.get_flags() & Ipv4Flags::DontFragment) != 0 {
-        quirks.push(Quirk::Df);
+        quirks.insert(Quirk::Df);
 
         if packet.get_identification() != 0 {
-            quirks.push(Quirk::NonZeroID);
+            quirks.insert(Quirk::NonZeroID);
         }
     } else if packet.get_identification() == 0 {
-        quirks.push(Quirk::ZeroID);
+        quirks.insert(Quirk::ZeroID);
     }
 
     let source_ip: IpAddr = IpAddr::V4(packet.get_source());
@@ -191,13 +191,13 @@ pub fn process_tcp_ipv6(
     let ttl: Ttl = tcp::ttl::calculate_ttl(ttl_observed);
     let tos: u8 = packet.get_traffic_class() >> 2;
     let olen: u8 = IpOptions::calculate_ipv6_length(packet);
-    let mut quirks: Vec<Quirk> = Vec::with_capacity(8);
+    let mut quirks = QuirkSet::EMPTY;
 
     if packet.get_flow_label() != 0 {
-        quirks.push(Quirk::FlowID);
+        quirks.insert(Quirk::FlowID);
     }
     if (packet.get_traffic_class() & (IP_TOS_CE | IP_TOS_ECT)) != 0 {
-        quirks.push(Quirk::Ecn);
+        quirks.insert(Quirk::Ecn);
     }
 
     let source_ip: IpAddr = IpAddr::V6(packet.get_source());
@@ -238,7 +238,7 @@ fn tcp_observation(
     tcp: &TcpPacket,
     wscale: Option<u8>,
     olayout: Vec<TcpOption>,
-    quirks: Vec<Quirk>,
+    quirks: QuirkSet,
     peer_mss: Option<u16>,
 ) -> TcpObservation {
     let tot_hdr =
@@ -286,7 +286,7 @@ fn visit_tcp(
     ip_package_header_length: u8,
     ip_header_bytes: u16,
     olen: u8,
-    mut quirks: Vec<Quirk>,
+    mut quirks: QuirkSet,
     source_ip: IpAddr,
     destination_ip: IpAddr,
 ) -> Result<ObservableTCPPackage, HuginnNetTcpError> {
@@ -319,27 +319,27 @@ fn visit_tcp(
     }
 
     if (flags & (ECE | CWR)) != 0 {
-        quirks.push(Quirk::Ecn);
+        quirks.insert(Quirk::Ecn);
     }
     if tcp.get_sequence() == 0 {
-        quirks.push(Quirk::SeqNumZero);
+        quirks.insert(Quirk::SeqNumZero);
     }
     if flags & ACK == ACK {
         if tcp.get_acknowledgement() == 0 {
-            quirks.push(Quirk::AckNumZero);
+            quirks.insert(Quirk::AckNumZero);
         }
     } else if tcp.get_acknowledgement() != 0 && flags & RST == 0 {
-        quirks.push(Quirk::AckNumNonZero);
+        quirks.insert(Quirk::AckNumNonZero);
     }
 
     if flags & URG == URG {
-        quirks.push(Quirk::Urg);
+        quirks.insert(Quirk::Urg);
     } else if tcp.get_urgent_ptr() != 0 {
-        quirks.push(Quirk::NonZeroURG);
+        quirks.insert(Quirk::NonZeroURG);
     }
 
     if flags & PSH == PSH {
-        quirks.push(Quirk::Push);
+        quirks.insert(Quirk::Push);
     }
 
     let mut buf = tcp.get_options_raw();
@@ -361,7 +361,7 @@ fn visit_tcp(
                 olayout.push(TcpOption::Eol(buf.len() as u8));
 
                 if buf.iter().any(|&b| b != 0) {
-                    quirks.push(Quirk::TrailinigNonZero);
+                    quirks.insert(Quirk::TrailinigNonZero);
                 }
 
                 break;
@@ -383,7 +383,7 @@ fn visit_tcp(
                     wscale = Some(data[0]);
 
                     if data[0] > 14 {
-                        quirks.push(Quirk::ExcessiveWindowScaling);
+                        quirks.insert(Quirk::ExcessiveWindowScaling);
                     }
                 }
             }
@@ -403,7 +403,7 @@ fn visit_tcp(
                         )
                     })?;
                     if u32::from_be_bytes(ts_val_bytes) == 0 {
-                        quirks.push(Quirk::OwnTimestampZero);
+                        quirks.insert(Quirk::OwnTimestampZero);
                     }
                 }
 
@@ -414,7 +414,7 @@ fn visit_tcp(
                         )
                     })?;
                     if u32::from_be_bytes(ts_peer_bytes) != 0 {
-                        quirks.push(Quirk::PeerTimestampNonZero);
+                        quirks.insert(Quirk::PeerTimestampNonZero);
                     }
                 }
 

--- a/huginn-net-tcp/src/tcp/mod.rs
+++ b/huginn-net-tcp/src/tcp/mod.rs
@@ -1,11 +1,13 @@
 pub mod ip_options;
 pub mod observable;
+pub mod quirks;
 pub mod syn_options;
 pub mod ttl;
 pub mod window_size;
 
 pub use ip_options::IpOptions;
 pub use observable::{ObservableTcp, TcpObservation};
+pub use quirks::QuirkSet;
 pub use syn_options::{parse_options_raw, ParsedTcpOptions};
 pub use ttl::{calculate_ttl, guess_distance, observed_ttl, MAX_DIST};
 pub use window_size::{detect_win_multi, WindowMultiplier};
@@ -57,7 +59,7 @@ pub enum WindowSize {
 }
 
 /// One TCP option, in the order it appeared on the wire.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum TcpOption {
     /// `eol+n`  - explicit end of options, followed by `n` bytes of padding.
     Eol(u8),
@@ -77,8 +79,39 @@ pub enum TcpOption {
     Unknown(u8),
 }
 
+/// Deterministic FNV-1a hash of a TCP option layout, for index keys.
+///
+/// Stable across process runs (fixed seed). Used like p0f's `opt_hash`: bucket
+/// by layout without allocating Display strings on the lookup path. Collisions
+/// only widen a bucket; exact `olayout` equality in matching still filters.
+pub fn hash_olayout(olayout: &[TcpOption]) -> u32 {
+    const FNV_OFFSET: u32 = 0x811c_9dc5;
+    const FNV_PRIME: u32 = 0x0100_0193;
+
+    let mut hash = FNV_OFFSET;
+    for opt in olayout {
+        let (tag, extra) = match *opt {
+            TcpOption::Eol(n) => (0u8, Some(n)),
+            TcpOption::Nop => (1, None),
+            TcpOption::Mss => (2, None),
+            TcpOption::Ws => (3, None),
+            TcpOption::Sok => (4, None),
+            TcpOption::Sack => (5, None),
+            TcpOption::TS => (6, None),
+            TcpOption::Unknown(n) => (7, Some(n)),
+        };
+        hash ^= u32::from(tag);
+        hash = hash.wrapping_mul(FNV_PRIME);
+        if let Some(byte) = extra {
+            hash ^= u32::from(byte);
+            hash = hash.wrapping_mul(FNV_PRIME);
+        }
+    }
+    hash
+}
+
 /// A protocol-level quirk observed in IP or TCP headers.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Quirk {
     /// `df`     - "don't fragment" set (probably PMTUD); ignored for IPv6.
     Df,

--- a/huginn-net-tcp/src/tcp/observable.rs
+++ b/huginn-net-tcp/src/tcp/observable.rs
@@ -1,5 +1,5 @@
 use super::window_size::{detect_win_multi, WindowMultiplier};
-use super::{IpVersion, PayloadSize, Quirk, TcpOption, Ttl};
+use super::{IpVersion, PayloadSize, Quirk, QuirkSet, TcpOption, Ttl};
 use core::fmt;
 use std::fmt::Formatter;
 
@@ -26,7 +26,7 @@ pub struct TcpObservation {
     /// Layout and ordering of TCP options, if any.
     pub olayout: Vec<TcpOption>,
     /// Properties and quirks observed in IP or TCP headers.
-    pub quirks: Vec<Quirk>,
+    pub quirks: QuirkSet,
     /// Payload size classification.
     pub pclass: PayloadSize,
     /// Peer SYN MSS on a SYN+ACK, when the SYN was seen. Always `None` on a SYN.
@@ -50,7 +50,7 @@ impl TcpObservation {
 
     /// Timestamp option present and non-zero.
     fn own_timestamp_is_nonzero(&self) -> bool {
-        self.olayout.contains(&TcpOption::TS) && !self.quirks.contains(&Quirk::OwnTimestampZero)
+        self.olayout.contains(&TcpOption::TS) && !self.quirks.contains(Quirk::OwnTimestampZero)
     }
 }
 
@@ -97,16 +97,7 @@ impl fmt::Display for TcpObservation {
             write!(f, "{o}")?;
         }
 
-        f.write_str(":")?;
-
-        for (i, q) in self.quirks.iter().enumerate() {
-            if i > 0 {
-                f.write_str(",")?;
-            }
-            write!(f, "{q}")?;
-        }
-
-        write!(f, ":{}", self.pclass)
+        write!(f, ":{}:{}", self.quirks, self.pclass)
     }
 }
 

--- a/huginn-net-tcp/src/tcp/quirks.rs
+++ b/huginn-net-tcp/src/tcp/quirks.rs
@@ -1,0 +1,188 @@
+//! Quirk bitmask (`QuirkSet`) aligned with p0f's `QUIRK_*` in `process.h`.
+
+use super::Quirk;
+use core::fmt;
+use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, Not};
+
+/// Set of TCP/IP quirks as a `u32` bitmask (p0f `pk.quirks` / `sig->quirks`).
+///
+/// Individual quirks stay as [`Quirk`] for parsing and naming; matching uses
+/// bitwise ops on this type.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct QuirkSet(u32);
+
+impl QuirkSet {
+    pub const EMPTY: Self = Self(0);
+
+    /// Bits that may disappear from traffic vs the signature (`df`, `id+`).
+    pub const FUZZY_DELETABLE: Self = Self(Quirk::Df.bit() | Quirk::NonZeroID.bit());
+
+    /// Bits that may appear in traffic beyond the signature (`id-`, `ecn`).
+    pub const FUZZY_ADDABLE: Self = Self(Quirk::ZeroID.bit() | Quirk::Ecn.bit());
+
+    /// Cleared from a version-agnostic signature when the observation is IPv4.
+    pub const MASK_WHEN_OBS_V4: Self = Self(Quirk::FlowID.bit());
+
+    /// Cleared from a version-agnostic signature when the observation is IPv6.
+    pub const MASK_WHEN_OBS_V6: Self =
+        Self(Quirk::Df.bit() | Quirk::NonZeroID.bit() | Quirk::ZeroID.bit());
+
+    #[inline]
+    pub const fn from_bits(bits: u32) -> Self {
+        Self(bits)
+    }
+
+    #[inline]
+    pub const fn bits(self) -> u32 {
+        self.0
+    }
+
+    #[inline]
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    #[inline]
+    pub const fn contains(self, quirk: Quirk) -> bool {
+        self.0 & quirk.bit() != 0
+    }
+
+    #[inline]
+    pub fn insert(&mut self, quirk: Quirk) {
+        self.0 |= quirk.bit();
+    }
+
+    #[inline]
+    pub const fn with(self, quirk: Quirk) -> Self {
+        Self(self.0 | quirk.bit())
+    }
+
+    /// Quirks present in `self` but not in `other`.
+    #[inline]
+    pub const fn difference(self, other: Self) -> Self {
+        Self(self.0 & !other.0)
+    }
+
+    /// Iterate quirks in p0f `.fp` declaration order (for Display / FuzzyReason).
+    pub fn iter(self) -> impl Iterator<Item = Quirk> {
+        DISPLAY_ORDER
+            .iter()
+            .copied()
+            .filter(move |q| self.contains(*q))
+    }
+}
+
+impl FromIterator<Quirk> for QuirkSet {
+    fn from_iter<T: IntoIterator<Item = Quirk>>(iter: T) -> Self {
+        let mut set = Self::EMPTY;
+        for q in iter {
+            set.insert(q);
+        }
+        set
+    }
+}
+
+impl From<&[Quirk]> for QuirkSet {
+    fn from(quirks: &[Quirk]) -> Self {
+        quirks.iter().copied().collect()
+    }
+}
+
+impl<const N: usize> From<[Quirk; N]> for QuirkSet {
+    fn from(quirks: [Quirk; N]) -> Self {
+        quirks.into_iter().collect()
+    }
+}
+
+impl BitOr for QuirkSet {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl BitOrAssign for QuirkSet {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+impl BitAnd for QuirkSet {
+    type Output = Self;
+    fn bitand(self, rhs: Self) -> Self {
+        Self(self.0 & rhs.0)
+    }
+}
+
+impl BitAndAssign for QuirkSet {
+    fn bitand_assign(&mut self, rhs: Self) {
+        self.0 &= rhs.0;
+    }
+}
+
+impl Not for QuirkSet {
+    type Output = Self;
+    fn not(self) -> Self {
+        Self(!self.0)
+    }
+}
+
+impl fmt::Display for QuirkSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut first = true;
+        for quirk in self.iter() {
+            if !first {
+                f.write_str(",")?;
+            }
+            write!(f, "{quirk}")?;
+            first = false;
+        }
+        Ok(())
+    }
+}
+
+/// Order used when rendering quirks (matches p0f `.fp` / `fp_tcp.c` parse order).
+const DISPLAY_ORDER: &[Quirk] = &[
+    Quirk::Df,
+    Quirk::NonZeroID,
+    Quirk::ZeroID,
+    Quirk::Ecn,
+    Quirk::MustBeZero,
+    Quirk::FlowID,
+    Quirk::SeqNumZero,
+    Quirk::AckNumNonZero,
+    Quirk::AckNumZero,
+    Quirk::NonZeroURG,
+    Quirk::Urg,
+    Quirk::Push,
+    Quirk::OwnTimestampZero,
+    Quirk::PeerTimestampNonZero,
+    Quirk::TrailinigNonZero,
+    Quirk::ExcessiveWindowScaling,
+    Quirk::OptBad,
+];
+
+impl Quirk {
+    /// Bit in [`QuirkSet`] / p0f `QUIRK_*`.
+    pub const fn bit(self) -> u32 {
+        match self {
+            Quirk::Ecn => 0x0000_0001,
+            Quirk::Df => 0x0000_0002,
+            Quirk::NonZeroID => 0x0000_0004,
+            Quirk::ZeroID => 0x0000_0008,
+            Quirk::MustBeZero => 0x0000_0010,
+            Quirk::FlowID => 0x0000_0020,
+            Quirk::SeqNumZero => 0x0000_1000,
+            Quirk::AckNumNonZero => 0x0000_2000,
+            Quirk::AckNumZero => 0x0000_4000,
+            Quirk::NonZeroURG => 0x0000_8000,
+            Quirk::Urg => 0x0001_0000,
+            Quirk::Push => 0x0002_0000,
+            Quirk::OwnTimestampZero => 0x0100_0000,
+            Quirk::PeerTimestampNonZero => 0x0200_0000,
+            Quirk::TrailinigNonZero => 0x0400_0000,
+            Quirk::ExcessiveWindowScaling => 0x0800_0000,
+            Quirk::OptBad => 0x1000_0000,
+        }
+    }
+}

--- a/huginn-net-tcp/tests/tcp_olayout_hash.rs
+++ b/huginn-net-tcp/tests/tcp_olayout_hash.rs
@@ -1,0 +1,26 @@
+use huginn_net_tcp::tcp::{hash_olayout, TcpOption};
+
+#[test]
+fn same_layout_hashes_equal() {
+    let a = [TcpOption::Mss, TcpOption::Sok, TcpOption::TS, TcpOption::Nop, TcpOption::Ws];
+    let b = a;
+    assert_eq!(hash_olayout(&a), hash_olayout(&b));
+}
+
+#[test]
+fn empty_layout_is_stable() {
+    assert_eq!(hash_olayout(&[]), hash_olayout(&[]));
+}
+
+#[test]
+fn different_layouts_usually_differ() {
+    let linux = [TcpOption::Mss, TcpOption::Sok, TcpOption::TS, TcpOption::Nop, TcpOption::Ws];
+    let windows = [TcpOption::Mss, TcpOption::Nop, TcpOption::Ws];
+    assert_ne!(hash_olayout(&linux), hash_olayout(&windows));
+}
+
+#[test]
+fn eol_padding_and_unknown_id_affect_the_hash() {
+    assert_ne!(hash_olayout(&[TcpOption::Eol(0)]), hash_olayout(&[TcpOption::Eol(1)]));
+    assert_ne!(hash_olayout(&[TcpOption::Unknown(10)]), hash_olayout(&[TcpOption::Unknown(11)]));
+}

--- a/huginn-net-tcp/tests/tcp_quirk_set.rs
+++ b/huginn-net-tcp/tests/tcp_quirk_set.rs
@@ -1,0 +1,26 @@
+use huginn_net_tcp::tcp::{Quirk, QuirkSet};
+
+#[test]
+fn bits_match_p0f_process_h() {
+    assert_eq!(Quirk::Ecn.bit(), 0x0000_0001);
+    assert_eq!(Quirk::Df.bit(), 0x0000_0002);
+    assert_eq!(Quirk::NonZeroID.bit(), 0x0000_0004);
+    assert_eq!(Quirk::OptBad.bit(), 0x1000_0000);
+}
+
+#[test]
+fn display_follows_fp_declaration_order() {
+    let set = QuirkSet::from([Quirk::Ecn, Quirk::Df, Quirk::NonZeroID]);
+    assert_eq!(set.to_string(), "df,id+,ecn");
+}
+
+#[test]
+fn difference_and_fuzzy_masks() {
+    let sig = QuirkSet::from([Quirk::Df, Quirk::NonZeroID]);
+    let obs = QuirkSet::from([Quirk::Ecn]);
+    let missing = sig.difference(obs);
+    let added = obs.difference(sig);
+    assert_eq!(missing, QuirkSet::FUZZY_DELETABLE);
+    assert!(added.difference(QuirkSet::FUZZY_ADDABLE).is_empty());
+    assert!(added.contains(Quirk::Ecn));
+}

--- a/huginn-net-tcp/tests/tcp_syn_options.rs
+++ b/huginn-net-tcp/tests/tcp_syn_options.rs
@@ -1,6 +1,6 @@
 use huginn_net_tcp::observable::TcpObservation;
 use huginn_net_tcp::syn_options::parse_options_raw;
-use huginn_net_tcp::tcp::{IpVersion, PayloadSize, Quirk, TcpOption};
+use huginn_net_tcp::tcp::{IpVersion, PayloadSize, QuirkSet, TcpOption};
 
 /// Common Linux SYN options: MSS(1460), NOP, WS(6), NOP, NOP, TS, SACK-permitted
 fn linux_syn_options() -> Vec<u8> {
@@ -22,7 +22,7 @@ fn build_obs(
     window: u16,
     olen: u8,
     options: &[u8],
-    quirks: Vec<Quirk>,
+    quirks: QuirkSet,
     pclass: PayloadSize,
 ) -> TcpObservation {
     let parsed = parse_options_raw(options);
@@ -47,7 +47,16 @@ fn build_obs(
 }
 
 fn ipv4_obs(raw_ttl: u8, window: u16, options: &[u8]) -> TcpObservation {
-    build_obs(IpVersion::V4, 20, raw_ttl, window, 0, options, vec![], PayloadSize::Zero)
+    build_obs(
+        IpVersion::V4,
+        20,
+        raw_ttl,
+        window,
+        0,
+        options,
+        QuirkSet::EMPTY,
+        PayloadSize::Zero,
+    )
 }
 
 #[test]
@@ -180,7 +189,7 @@ fn test_ipv4_fields_set_correctly() {
 fn test_ipv6_observation() {
     // IPv6: ip_hdr_len=40, hop_limit=128
     let buf: &[u8] = &[2, 4, 0x05, 0xb4, 1, 3, 3, 6]; // MSS=1460, NOP, WS=6
-    let obs = build_obs(IpVersion::V6, 40, 128, 65535, 0, buf, vec![], PayloadSize::Zero);
+    let obs = build_obs(IpVersion::V6, 40, 128, 65535, 0, buf, QuirkSet::EMPTY, PayloadSize::Zero);
     assert_eq!(obs.version, IpVersion::V6);
     assert_eq!(obs.mss, Some(1460));
     assert_eq!(obs.wscale, Some(6));

--- a/huginn-net/src/analyzer/matchers.rs
+++ b/huginn-net/src/analyzer/matchers.rs
@@ -97,8 +97,6 @@ impl<'a> HuginnNet<'a> {
                 enabled: self.config.matcher_enabled,
                 matcher: self.tcp_matcher,
                 method: match_mtu(*mtu),
-                // An MTU either equals a known link's value or it does not;
-                // there is no signature to fit approximately.
                 success: found => MTUQualityMatched {
                     link: Some(found.link),
                     quality: TcpMatchQuality::exact(1.0),

--- a/huginn-net/src/analyzer/matchers.rs
+++ b/huginn-net/src/analyzer/matchers.rs
@@ -1,11 +1,13 @@
 use super::HuginnNet;
+#[cfg(any(feature = "http-p0f-request", feature = "http-p0f-response"))]
+use huginn_net_http::http::{build_params, HttpParams};
+// Notes about a matched signature only exist when there is a database to match
+// against.
 #[cfg(all(
     feature = "db",
     any(feature = "http-p0f-request", feature = "http-p0f-response")
 ))]
 use huginn_net_http::http::MatchedSignatureNotes;
-#[cfg(any(feature = "http-p0f-request", feature = "http-p0f-response"))]
-use huginn_net_http::http::{build_params, HttpParams};
 #[cfg(feature = "http-p0f-request")]
 use huginn_net_http::observable::ObservableHttpRequest;
 #[cfg(feature = "http-p0f-response")]
@@ -16,7 +18,10 @@ use huginn_net_http::output::BrowserQualityMatched;
 use huginn_net_http::output::MatchQuality as HttpMatchQuality;
 #[cfg(feature = "http-p0f-response")]
 use huginn_net_http::output::WebServerQualityMatched;
-#[cfg(all(feature = "db", any(feature = "tcp-syn", feature = "tcp-syn-ack")))]
+#[cfg(all(
+    feature = "db",
+    any(feature = "tcp-syn", feature = "tcp-syn-ack", feature = "tcp-mtu")
+))]
 use huginn_net_tcp::matcher_api::TcpMatcher;
 #[cfg(any(feature = "tcp-syn", feature = "tcp-syn-ack"))]
 use huginn_net_tcp::observable::ObservableTcp;
@@ -37,21 +42,17 @@ use huginn_net_tcp::output::OSQualityMatched;
         feature = "http-p0f-response"
     )
 ))]
-use crate::quality_match;
+use crate::{quality_match, simple_quality_match};
 #[cfg(all(
     feature = "db",
-    any(
-        feature = "tcp-syn",
-        feature = "tcp-syn-ack",
-        feature = "tcp-mtu",
-        feature = "http-p0f-response"
-    )
+    any(feature = "http-p0f-request", feature = "http-p0f-response")
 ))]
-use crate::simple_quality_match;
-#[cfg(all(feature = "db", feature = "http-p0f-request"))]
-use huginn_net_http::output::Browser;
-#[cfg(all(feature = "db", feature = "http-p0f-response"))]
-use huginn_net_http::output::WebServer;
+use huginn_net_http::matcher_api::HttpMatcher;
+#[cfg(all(
+    feature = "db",
+    any(feature = "http-p0f-request", feature = "http-p0f-response")
+))]
+use huginn_net_http::output::OsKind;
 
 use crate::AnalysisConfig;
 
@@ -95,9 +96,11 @@ impl<'a> HuginnNet<'a> {
             simple_quality_match!(
                 enabled: self.config.matcher_enabled,
                 matcher: self.tcp_matcher,
-                method: matching_by_mtu(mtu),
-                success: (link, _) => MTUQualityMatched {
-                    link: Some(link.clone()),
+                method: match_mtu(*mtu),
+                // An MTU either equals a known link's value or it does not;
+                // there is no signature to fit approximately.
+                success: found => MTUQualityMatched {
+                    link: Some(found.link),
                     quality: TcpMatchQuality::exact(1.0),
                 },
                 failure: MTUQualityMatched {
@@ -185,37 +188,24 @@ impl<'a> HuginnNet<'a> {
         #[cfg(feature = "db")]
         {
             let observed = &observable_http_request.matching;
-            let (browser_quality, notes) = quality_match!(
+            let (browser_quality, notes) = simple_quality_match!(
                 enabled: self.config.matcher_enabled,
                 matcher: self.http_matcher,
-                call: matcher => Some(matcher.matching_by_http_request(observed)),
-                matched: signature_matcher => {
-                    signature_matcher
-                        .map(|found| {
-                            let notes = MatchedSignatureNotes {
-                                dishonest: !huginn_net_db::http::expsw_matches(
-                                    &observed.expsw,
-                                    &found.signature.expsw,
-                                ),
-                                generic: found.label.ty == huginn_net_db::database::Type::Generic,
-                            };
-                            (
-                                BrowserQualityMatched {
-                                    browser: Some(Browser::from(found.label)),
-                                    quality: HttpMatchQuality::Matched(found.quality),
-                                },
-                                Some(notes),
-                            )
-                        })
-                        .unwrap_or((
-                            BrowserQualityMatched {
-                                browser: None,
-                                quality: HttpMatchQuality::NotMatched,
-                            },
-                            None,
-                        ))
+                method: match_http_request(observed),
+                success: found => {
+                    let notes = MatchedSignatureNotes {
+                        dishonest: found.dishonest,
+                        generic: found.browser.kind == OsKind::Generic,
+                    };
+                    (
+                        BrowserQualityMatched {
+                            browser: Some(found.browser),
+                            quality: HttpMatchQuality::Matched(found.quality),
+                        },
+                        Some(notes),
+                    )
                 },
-                not_matched: (
+                failure: (
                     BrowserQualityMatched {
                         browser: None,
                         quality: HttpMatchQuality::NotMatched,
@@ -255,37 +245,24 @@ impl<'a> HuginnNet<'a> {
         #[cfg(feature = "db")]
         {
             let observed = &observable_http_response.matching;
-            let (web_server_quality, notes) = quality_match!(
+            let (web_server_quality, notes) = simple_quality_match!(
                 enabled: self.config.matcher_enabled,
                 matcher: self.http_matcher,
-                call: matcher => Some(matcher.matching_by_http_response(observed)),
-                matched: signature_matcher => {
-                    signature_matcher
-                        .map(|found| {
-                            let notes = MatchedSignatureNotes {
-                                dishonest: !huginn_net_db::http::expsw_matches(
-                                    &observed.expsw,
-                                    &found.signature.expsw,
-                                ),
-                                generic: found.label.ty == huginn_net_db::database::Type::Generic,
-                            };
-                            (
-                                WebServerQualityMatched {
-                                    web_server: Some(WebServer::from(found.label)),
-                                    quality: HttpMatchQuality::Matched(found.quality),
-                                },
-                                Some(notes),
-                            )
-                        })
-                        .unwrap_or((
-                            WebServerQualityMatched {
-                                web_server: None,
-                                quality: HttpMatchQuality::NotMatched,
-                            },
-                            None,
-                        ))
+                method: match_http_response(observed),
+                success: found => {
+                    let notes = MatchedSignatureNotes {
+                        dishonest: found.dishonest,
+                        generic: found.web_server.kind == OsKind::Generic,
+                    };
+                    (
+                        WebServerQualityMatched {
+                            web_server: Some(found.web_server),
+                            quality: HttpMatchQuality::Matched(found.quality),
+                        },
+                        Some(notes),
+                    )
                 },
-                not_matched: (
+                failure: (
                     WebServerQualityMatched {
                         web_server: None,
                         quality: HttpMatchQuality::NotMatched,

--- a/huginn-net/src/matcher.rs
+++ b/huginn-net/src/matcher.rs
@@ -6,20 +6,17 @@
 ///
 /// ```rust
 /// use huginn_net::quality_match;
-/// # use huginn_net_tcp::output::{MatchQuality, OSQualityMatched, OperativeSystem};
-/// # use huginn_net_db::Label;
+/// # use huginn_net_tcp::output::{MatchQuality, OSQualityMatched};
 /// # struct Config { matcher_enabled: bool }
 /// # struct Matcher;
-/// # struct ObservableTcp;
 /// # let config = Config { matcher_enabled: true };
 /// # let matcher: Option<Matcher> = None;
-/// # let observable_tcp = ObservableTcp;
 /// let quality = quality_match!(
 ///     enabled: config.matcher_enabled,
 ///     matcher: matcher,
-///     call: matcher => None::<(Label, String, f32)>,
-///     matched: (label, _signature, quality) => OSQualityMatched {
-///         os: Some(OperativeSystem::from(&label)),
+///     call: matcher => None::<(String, f32)>,
+///     matched: (name, quality) => OSQualityMatched {
+///         os: None, // real code: Some(OperativeSystem::from(label))
 ///         quality: MatchQuality::exact(quality),
 ///         dist: 0,
 ///         random_ttl: false,
@@ -43,6 +40,7 @@
 ///         tos: 0,
 ///     }
 /// );
+/// # let _ = quality;
 /// ```
 #[macro_export]
 macro_rules! quality_match {
@@ -79,7 +77,7 @@ macro_rules! quality_match {
 /// # struct Config { matcher_enabled: bool }
 /// # struct Matcher;
 /// # impl Matcher {
-/// #     fn matching_by_mtu(&self, _value: &u16) -> Option<(String, String)> { None }
+/// #     fn match_mtu(&self, _value: u16) -> Option<huginn_net_tcp::matcher_api::MtuMatch> { None }
 /// # }
 /// # struct ObservableMtu { value: u16 }
 /// # let config = Config { matcher_enabled: true };
@@ -88,9 +86,9 @@ macro_rules! quality_match {
 /// let quality = simple_quality_match!(
 ///     enabled: config.matcher_enabled,
 ///     matcher: matcher,
-///     method: matching_by_mtu(&observable_mtu.value),
-///     success: (link, _) => MTUQualityMatched {
-///         link: Some(link.clone()),
+///     method: match_mtu(observable_mtu.value),
+///     success: found => MTUQualityMatched {
+///         link: Some(found.link),
 ///         quality: MatchQuality::exact(1.0),
 ///     },
 ///     failure: MTUQualityMatched {

--- a/huginn-net/tests/smoke.rs
+++ b/huginn-net/tests/smoke.rs
@@ -16,7 +16,7 @@
 
 use huginn_net::{Database, HuginnNet, TcpMatchQuality};
 use huginn_net_http::output::MatchQuality as HttpMatchQuality;
-use huginn_net_tcp::tcp::Quirk;
+use huginn_net_tcp::tcp::{Quirk, QuirkSet};
 use std::path::Path;
 use std::sync::mpsc;
 
@@ -56,8 +56,8 @@ fn e2e_tcp_syn_and_mtu_are_identified() {
     assert_eq!(os.name, "Mac OS X", "first SYN OS name");
     match &first_syn.os_matched.quality {
         TcpMatchQuality::Matched { fuzzy: Some(reason), .. } => {
-            assert_eq!(reason.missing_quirks, vec![Quirk::NonZeroID]);
-            assert_eq!(reason.added_quirks, vec![Quirk::Ecn]);
+            assert_eq!(reason.missing_quirks, QuirkSet::from([Quirk::NonZeroID]));
+            assert_eq!(reason.added_quirks, QuirkSet::from([Quirk::Ecn]));
             assert_eq!(
                 reason.implausible_hop_distance, None,
                 "the TTL is plausible; only the quirks were tolerated"


### PR DESCRIPTION
## Summary
- `olayout_hash` / `TcpIndexKey: Copy` (no `format!`/`join` on the hot path).
- `QuirkSet(u32)` + bitwise `quirks_fit` (p0f-style XOR/AND).
- Load-time signature/label `info!` stats; protocol-scoped examples (`TcpDatabase` / `HttpDatabase` where appropriate).
- README: fixed quality tiers + note that `.fp` data quality bounds match quality.

## Why
Parity micro-cost last; docs/examples catch up so consumers don’t read the old continuous-score story.