### PR TITLE
p0f DB user aget parser fixed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,9 +135,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -380,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "equivalent"
@@ -641,14 +641,14 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.33",
+ "log 0.4.34",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "matchers"
@@ -1431,7 +1431,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "log 0.4.33",
+ "log 0.4.34",
  "once_cell",
  "tracing-core",
 ]

--- a/huginn-net-db/src/parse/http.rs
+++ b/huginn-net-db/src/parse/http.rs
@@ -1,9 +1,9 @@
 use super::common::{impl_from_str, str_parser};
 use crate::http::{Header as HttpHeader, Signature as HttpSignature, Version as HttpVersion};
 use nom::branch::alt;
-use nom::bytes::complete::{tag, take_until, take_while};
-use nom::character::complete::{alphanumeric1, char, space0};
-use nom::combinator::{map, opt, rest};
+use nom::bytes::complete::{tag, take_until, take_while, take_while1};
+use nom::character::complete::{char, space0};
+use nom::combinator::{eof, map, opt, rest};
 use nom::multi::{separated_list0, separated_list1};
 use nom::sequence::{pair, preceded, terminated};
 use nom::{IResult, Parser};
@@ -18,9 +18,11 @@ pub(super) fn parse_ua_os(input: &str) -> IResult<&str, Vec<(String, Option<Stri
         space0,
         tag("="),
         space0,
-        separated_list0(tag(","), parse_key_value),
+        separated_list0(char(','), parse_ua_os_entry),
     )
         .parse(input)?;
+    let (input, _) = space0.parse(input)?;
+    let (input, _) = eof.parse(input)?;
 
     let result = values
         .into_iter()
@@ -30,11 +32,22 @@ pub(super) fn parse_ua_os(input: &str) -> IResult<&str, Vec<(String, Option<Stri
     Ok((input, result))
 }
 
-fn parse_key_value(input: &str) -> IResult<&str, (&str, Option<&str>)> {
-    let (input, (name, _, value)) =
-        (alphanumeric1, space0, opt(preceded((space0, tag("="), space0), alphanumeric1)))
-            .parse(input)?;
-
+/// One `ua_os` entry: a possibly multi-word family (`Mac OS X`) and an optional
+/// `=[substr]` needle (`iOS=[iPad]`, `Solaris=[SunOS]`). Same bracket form as
+/// HTTP header values; names may contain spaces, so this cannot use `alphanumeric1`.
+fn parse_ua_os_entry(input: &str) -> IResult<&str, (&str, Option<&str>)> {
+    let (input, _) = space0.parse(input)?;
+    let (input, name) = take_while1(|c: char| c != ',' && c != '=').parse(input)?;
+    let name = name.trim_end();
+    if name.is_empty() {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::TakeWhile1,
+        )));
+    }
+    let (input, value) =
+        opt(preceded(tag("=["), terminated(take_until("]"), char(']')))).parse(input)?;
+    let (input, _) = space0.parse(input)?;
     Ok((input, (name, value)))
 }
 

--- a/huginn-net-db/src/parse/http.rs
+++ b/huginn-net-db/src/parse/http.rs
@@ -32,12 +32,19 @@ pub(super) fn parse_ua_os(input: &str) -> IResult<&str, Vec<(String, Option<Stri
     Ok((input, result))
 }
 
+/// p0f `config.h` `NAME_CHARS`: non-alnum allowed in OS names (`http_parse_ua`).
+const UA_OS_NAME_EXTRA: &str = " ./-_!?()";
+
+fn is_ua_os_name_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || UA_OS_NAME_EXTRA.contains(c)
+}
+
 /// One `ua_os` entry: a possibly multi-word family (`Mac OS X`) and an optional
 /// `=[substr]` needle (`iOS=[iPad]`, `Solaris=[SunOS]`). Same bracket form as
-/// HTTP header values; names may contain spaces, so this cannot use `alphanumeric1`.
+/// HTTP header values. Names follow p0f: `isalnum` plus `NAME_CHARS`.
 fn parse_ua_os_entry(input: &str) -> IResult<&str, (&str, Option<&str>)> {
     let (input, _) = space0.parse(input)?;
-    let (input, name) = take_while1(|c: char| c != ',' && c != '=').parse(input)?;
+    let (input, name) = take_while1(is_ua_os_name_char).parse(input)?;
     let name = name.trim_end();
     if name.is_empty() {
         return Err(nom::Err::Error(nom::error::Error::new(

--- a/huginn-net-db/tests/database/default_database.rs
+++ b/huginn-net-db/tests/database/default_database.rs
@@ -31,4 +31,19 @@ fn test_default_database() {
             ("loopback".to_owned(), vec![3924, 16384, 16436])
         ]
     );
+
+    assert_eq!(
+        db.http.ua_os,
+        vec![
+            ("Linux".to_owned(), None),
+            ("Windows".to_owned(), None),
+            ("iOS".to_owned(), Some("iPad".to_owned())),
+            ("iOS".to_owned(), Some("iPhone".to_owned())),
+            ("Mac OS X".to_owned(), None),
+            ("FreeBSD".to_owned(), None),
+            ("OpenBSD".to_owned(), None),
+            ("NetBSD".to_owned(), None),
+            ("Solaris".to_owned(), Some("SunOS".to_owned())),
+        ]
+    );
 }

--- a/huginn-net-db/tests/http/matcher.rs
+++ b/huginn-net-db/tests/http/matcher.rs
@@ -221,3 +221,27 @@ fn ua_lookup_returns_known_family() {
         .unwrap_or_else(|| panic!("Windows UA should map to an OS family"));
     assert_eq!(found.family, "Windows");
 }
+
+#[test]
+fn ua_lookup_maps_bracket_needles_and_multi_word_names() {
+    let db = match HttpDatabase::load_default() {
+        Ok(db) => db,
+        Err(e) => panic!("Failed to load default database: {e}"),
+    };
+    let matcher = huginn_net_db::HttpSignatureMatcher::new(&db);
+
+    let mac = matcher
+        .match_user_agent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)")
+        .unwrap_or_else(|| panic!("Mac OS X UA should map to an OS family"));
+    assert_eq!(mac.family, "Mac OS X");
+
+    let ios = matcher
+        .match_user_agent("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)")
+        .unwrap_or_else(|| panic!("iPhone UA should map via iOS=[iPhone]"));
+    assert_eq!(ios.family, "iOS");
+
+    let solaris = matcher
+        .match_user_agent("Mozilla/5.0 (X11; SunOS i86pc)")
+        .unwrap_or_else(|| panic!("SunOS UA should map via Solaris=[SunOS]"));
+    assert_eq!(solaris.family, "Solaris");
+}

--- a/huginn-net-db/tests/parse/parsers.rs
+++ b/huginn-net-db/tests/parse/parsers.rs
@@ -242,7 +242,49 @@ fn test_http_header() {
     }
 }
 
-/// Test helper function to create HTTP headers
+#[test]
+fn parse_ua_os_keeps_multi_word_names_and_bracket_needles() {
+    use huginn_net_db::HttpDatabase;
+    use std::str::FromStr;
+
+    let db = match HttpDatabase::from_str(
+        "ua_os = Linux,Windows,iOS=[iPad],iOS=[iPhone],Mac OS X,FreeBSD,OpenBSD,NetBSD,Solaris=[SunOS]",
+    ) {
+        Ok(db) => db,
+        Err(e) => panic!("ua_os line from p0f.fp must parse: {e}"),
+    };
+
+    assert_eq!(
+        db.ua_os,
+        vec![
+            ("Linux".to_owned(), None),
+            ("Windows".to_owned(), None),
+            ("iOS".to_owned(), Some("iPad".to_owned())),
+            ("iOS".to_owned(), Some("iPhone".to_owned())),
+            ("Mac OS X".to_owned(), None),
+            ("FreeBSD".to_owned(), None),
+            ("OpenBSD".to_owned(), None),
+            ("NetBSD".to_owned(), None),
+            ("Solaris".to_owned(), Some("SunOS".to_owned())),
+        ]
+    );
+}
+
+#[test]
+fn parse_ua_os_rejects_truncated_or_unclosed_entries() {
+    use huginn_net_db::HttpDatabase;
+    use std::str::FromStr;
+
+    assert!(
+        HttpDatabase::from_str("ua_os = Linux=[x]junk").is_err(),
+        "trailing junk after a completed entry must fail"
+    );
+    assert!(
+        HttpDatabase::from_str("ua_os = iOS=[iPad").is_err(),
+        "unclosed =[needle] must fail"
+    );
+}
+
 fn header<S: AsRef<str>>(name: S) -> HttpHeader {
     HttpHeader::new(name)
 }

--- a/huginn-net-db/tests/parse/parsers.rs
+++ b/huginn-net-db/tests/parse/parsers.rs
@@ -283,6 +283,14 @@ fn parse_ua_os_rejects_truncated_or_unclosed_entries() {
         HttpDatabase::from_str("ua_os = iOS=[iPad").is_err(),
         "unclosed =[needle] must fail"
     );
+    assert!(
+        HttpDatabase::from_str("ua_os = Windows:NT").is_err(),
+        "':' is not in p0f NAME_CHARS; leftover must fail"
+    );
+    assert!(
+        HttpDatabase::from_str("ua_os = Foo@Bar").is_err(),
+        "'@' is not in p0f NAME_CHARS; leftover must fail"
+    );
 }
 
 fn header<S: AsRef<str>>(name: S) -> HttpHeader {


### PR DESCRIPTION
`parse_ua_os` uses `alphanumeric1`, which stops at the first non-alphanumeric character. Multi-word names from `p0f.fp` (`Mac OS X`, `Windows NT`) end up truncated or discarded.