### PR TITLE
Introduce match rank typed

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,22 +6,26 @@
 
 Matching follows p0f: a field that does not fit is a rejection (HTTP has no
 error budget). TCP still has a fuzzy tier for the documented TTL/quirk
-tolerances. Scores are **tiers**, not a penalty sum:
+tolerances. The outcome is a **tier**, not a penalty sum, and it is now a type
+(`MatchRank`) rather than an `f32`:
 
-| Score | Meaning |
-|-------|---------|
-| `1.0` | Exact, named product |
-| `0.8` | Exact, generic catch-all |
-| `0.5` | Fuzzy (TCP only) |
+| Tier | Score | Meaning |
+|------|-------|---------|
+| `Specific` | `1.0` | Exact, named product |
+| `Generic` | `0.8` | Exact, generic catch-all |
+| `Fuzzy(FuzzyReason)` | `0.5` | Fuzzy (TCP only), carrying what was tolerated |
 
+The tolerance lives inside `Fuzzy`, so a match cannot be exact and fuzzy at
+once. Scores are derived with `rank.as_quality()`; the JSON is unchanged.
 First-match-wins within a tier. Userland (`s:!:…`) is never reported as fuzzy.
 
 ### Call sites
 
 ```rust
 // quality
-MatchQuality::Matched(q)                          // v2.0
-MatchQuality::Matched { quality, fuzzy }          // v2.1; inspect FuzzyReason
+MatchQuality::Matched(q)                          // v2.0, f32
+MatchQuality::Matched(rank)                       // v2.1, MatchRank
+quality.fuzzy()                                   // Option<&FuzzyReason>
 
 // TCP result
 OSQualityMatched { os, quality }                  // v2.0
@@ -67,7 +71,8 @@ Matcher methods are the traits: `match_tcp_request` / `match_http_request` / …
 |------|------|
 | `get_diagnostic` | `build_params` |
 | `calculate_distance` / `get_quality_score` | `fit` → `Option<SignatureFit<_>>` |
-| `find_best_match` → `(&Label, &DS, f32)` | `DatabaseMatch` |
+| `find_best_match` → `(&Label, &DS, f32)` | `DatabaseMatch { label, signature, rank }` |
+| `TcpMatch` / `HttpRequestMatch` / `HttpResponseMatch` `.quality: f32` (+ `.fuzzy`) | `.rank: MatchRank` |
 | `matching_by_*` | `TcpMatcher` / `HttpMatcher` |
 | `db` / `db_parse` / `observable_*_signals_matching` | `database` / `parse` (matching is private) |
 | `Vec<Quirk>` | `QuirkSet` |

--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ Optional packet filtering by port and/or IP address for improved performance. Fi
 
 Database matching follows p0f-style **tier selection**, not a continuous distance score. Each signature field is a pass/fail gate; a candidate that fails any gate is rejected, not ranked lower.
 
-The reported `quality` is a **tier label** (ordering matters; values may be recalibrated):
+A match reports its tier as `MatchQuality::Matched(MatchRank)` (ordering matters; the scores from `as_quality()` may be recalibrated):
 
-- **1.0** — exact fit on a **specified** signature (concrete product/OS)
-- **0.8** — exact fit on a **generic** catch-all signature
-- **0.5** — **fuzzy** fit (TCP only): the signature holds only after documented tolerances (e.g. missing `df`/`id+`, extra `id-`/`ecn`, implausible TTL hop distance)
+- **`Specific`** (1.0) — exact fit on a **specified** signature (concrete product/OS)
+- **`Generic`** (0.8) — exact fit on a **generic** catch-all signature
+- **`Fuzzy(FuzzyReason)`** (0.5) — **fuzzy** fit (TCP only): the signature holds only after documented tolerances (e.g. missing `df`/`id+`, extra `id-`/`ecn`, implausible TTL hop distance), and the variant carries which ones
 
 Other outcomes: **NotMatched** (matcher active, nothing fit) and **Disabled** (no matcher attached). On TCP, fuzzy matches also surface in `Params:` (`fuzzy (…)`, `generic`, `random_ttl`, `excess_dist`, `tos:0xNN`). HTTP signatures must fit exactly — there is no fuzzy tier.
 

--- a/huginn-net-db/README.md
+++ b/huginn-net-db/README.md
@@ -83,20 +83,25 @@ let analyzer = HuginnNetTcp::new(1000).with_matcher(matcher);
 
 ## Reading match results
 
-The matcher either returns a label or nothing. When it returns one, `quality`
-is one of three fixed tiers:
+The matcher either returns a label or nothing. When it returns one,
+`DatabaseMatch.rank` names one of three fixed tiers:
 
-| Outcome | `quality` | Meaning |
-|---------|-----------|---------|
-| Specific exact | `1.0` | Named product, every field fit |
-| Generic exact | `0.8` | Family catch-all, still exact |
-| Fuzzy | `0.5` | Held only with a documented tolerance (`FuzzyReason`) |
+| `MatchRank` | Score | Meaning |
+|-------------|-------|---------|
+| `Specific` | `1.0` | Named product, every field fit |
+| `Generic` | `0.8` | Family catch-all, still exact |
+| `Fuzzy(FuzzyReason)` | `0.5` | Held only with a documented tolerance |
 | No match | - | No signature passed the gates |
 | Disabled | - | No matcher was attached |
 
-Prefer `1.0` without `fuzzy`. Treat `0.5` as a hint and inspect `FuzzyReason`
-plus TCP `params` (`dist`, `random_ttl`, `excess_dist`, `tos`). HTTP has no
-fuzzy tier: a hit is exact, and `HttpParams` flags annotate the claim.
+The tolerance is carried by the `Fuzzy` variant, so there is no such thing as
+an exact match with a tolerance attached. `as_quality()` renders the score for
+display and JSON.
+
+Prefer `Specific`. Treat `Fuzzy` as a hint and inspect its `FuzzyReason` plus
+TCP `params` (`dist`, `random_ttl`, `excess_dist`, `tos`). HTTP has no fuzzy
+tier: its `Fuzziness` type is uninhabited, so a hit is always exact, and
+`HttpParams` flags annotate the claim.
 
 Match quality is also bounded by the bundled `p0f.fp` (last updated 2012):
 a correct algorithm cannot name a product the database does not list.

--- a/huginn-net-db/src/database/collection.rs
+++ b/huginn-net-db/src/database/collection.rs
@@ -118,8 +118,7 @@ where
                         return Some(DatabaseMatch {
                             label,
                             signature: db_sig,
-                            quality: MatchRank::Specific.as_quality(),
-                            fuzzy: None,
+                            rank: MatchRank::Specific,
                         });
                     }
                     Type::Generic => {
@@ -142,22 +141,12 @@ where
         }
 
         if let Some((label, signature)) = gmatch {
-            return Some(DatabaseMatch {
-                label,
-                signature,
-                quality: MatchRank::Generic.as_quality(),
-                fuzzy: None,
-            });
+            return Some(DatabaseMatch { label, signature, rank: MatchRank::Generic });
         }
 
         if let Some((label, signature, fuzzy)) = fmatch {
             label.class.as_ref()?;
-            return Some(DatabaseMatch {
-                label,
-                signature,
-                quality: MatchRank::Fuzzy.as_quality(),
-                fuzzy: Some(fuzzy),
-            });
+            return Some(DatabaseMatch { label, signature, rank: MatchRank::Fuzzy(fuzzy) });
         }
 
         None

--- a/huginn-net-db/src/matcher/http_signature_matcher.rs
+++ b/huginn-net-db/src/matcher/http_signature_matcher.rs
@@ -1,9 +1,9 @@
 use crate::database::{HttpDatabase, Label, Type};
-use crate::db_matching_trait::FingerprintDb;
+use crate::db_matching_trait::{FingerprintDb, MatchRank, NoFuzziness};
 use crate::http::expsw_matches;
 use huginn_net_http::matcher_api::{HttpMatcher, HttpRequestMatch, HttpResponseMatch, UaOsMatch};
 use huginn_net_http::observable::{HttpRequestObservation, HttpResponseObservation};
-use huginn_net_http::output::{Browser, OsKind, WebServer};
+use huginn_net_http::output::{Browser, MatchRank as HttpMatchRank, OsKind, WebServer};
 use std::sync::Arc;
 
 pub struct HttpSignatureMatcher<'a> {
@@ -48,6 +48,17 @@ impl From<&Label> for WebServer {
     }
 }
 
+impl From<MatchRank<NoFuzziness>> for HttpMatchRank {
+    fn from(rank: MatchRank<NoFuzziness>) -> Self {
+        match rank {
+            MatchRank::Specific => HttpMatchRank::Specific,
+            MatchRank::Generic => HttpMatchRank::Generic,
+            // `NoFuzziness` is uninhabited: HTTP signatures have no tolerances.
+            MatchRank::Fuzzy(never) => match never {},
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Shared matching helpers
 // ---------------------------------------------------------------------------
@@ -59,7 +70,7 @@ fn match_http_request_impl(
     let found = db.http_request.find_best_match(obs)?;
     Some(HttpRequestMatch {
         browser: Browser::from(found.label),
-        quality: found.quality,
+        rank: found.rank.into(),
         dishonest: !expsw_matches(&obs.expsw, &found.signature.expsw),
     })
 }
@@ -71,7 +82,7 @@ fn match_http_response_impl(
     let found = db.http_response.find_best_match(obs)?;
     Some(HttpResponseMatch {
         web_server: WebServer::from(found.label),
-        quality: found.quality,
+        rank: found.rank.into(),
         dishonest: !expsw_matches(&obs.expsw, &found.signature.expsw),
     })
 }

--- a/huginn-net-db/src/matcher/tcp_signature_matcher.rs
+++ b/huginn-net-db/src/matcher/tcp_signature_matcher.rs
@@ -1,9 +1,9 @@
 use crate::database::{Label, TcpDatabase, Type};
-use crate::db_matching_trait::{DatabaseMatch, FingerprintDb};
+use crate::db_matching_trait::{DatabaseMatch, FingerprintDb, MatchRank};
 use crate::tcp::{report_hop_distance, Ttl, MAX_TTL_DISTANCE};
 use huginn_net_tcp::matcher_api::{MtuMatch, TcpMatch, TcpMatcher};
 use huginn_net_tcp::observable::TcpObservation;
-use huginn_net_tcp::output::{FuzzyReason, OperativeSystem, OsKind};
+use huginn_net_tcp::output::{FuzzyReason, MatchRank as TcpMatchRank, OperativeSystem, OsKind};
 use std::sync::Arc;
 
 pub struct TcpSignatureMatcher<'a> {
@@ -38,6 +38,16 @@ impl From<&Label> for OperativeSystem {
 // Shared matching helpers
 // ---------------------------------------------------------------------------
 
+impl From<MatchRank<FuzzyReason>> for TcpMatchRank {
+    fn from(rank: MatchRank<FuzzyReason>) -> Self {
+        match rank {
+            MatchRank::Specific => TcpMatchRank::Specific,
+            MatchRank::Generic => TcpMatchRank::Generic,
+            MatchRank::Fuzzy(reason) => TcpMatchRank::Fuzzy(reason),
+        }
+    }
+}
+
 fn tcp_match_from_db(
     found: DatabaseMatch<'_, crate::tcp::Signature, FuzzyReason>,
     obs: &TcpObservation,
@@ -45,8 +55,7 @@ fn tcp_match_from_db(
     let dist = report_hop_distance(&obs.ittl, &found.signature.ittl);
     TcpMatch {
         os: OperativeSystem::from(found.label),
-        quality: found.quality,
-        fuzzy: found.fuzzy,
+        rank: found.rank.into(),
         dist,
         random_ttl: matches!(found.signature.ittl, Ttl::Bad(_)),
         excess_dist: dist > MAX_TTL_DISTANCE,

--- a/huginn-net-db/src/matcher/traits.rs
+++ b/huginn-net-db/src/matcher/traits.rs
@@ -64,28 +64,42 @@ pub trait DatabaseSignature<OF: ObservedFingerprint> {
 /// Base trait for keys used in fingerprint indexes.
 pub trait IndexKey: Debug + Clone + Eq + Hash {}
 
-/// Preference order: Specific > Generic > Fuzzy (`Ord` is best-first).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum MatchRank {
+/// Which tier a match landed in, in preference order: `Specific` beats
+/// `Generic`, and both beat `Fuzzy`.
+///
+/// The tier and the tolerance are the same fact, so they are one value: a match
+/// is fuzzy exactly when there is a tolerance to report. `F` is the
+/// protocol-specific tolerance, [`NoFuzziness`] for protocols with none, which
+/// makes `Fuzzy` unconstructible for them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MatchRank<F> {
     /// Exact fit against a signature naming a concrete product.
     Specific,
     /// Exact fit against a catch-all signature.
     Generic,
-    /// Only holds because a documented tolerance was applied.
-    Fuzzy,
+    /// Only holds because the carried tolerance was applied.
+    Fuzzy(F),
 }
 
-impl MatchRank {
+impl<F> MatchRank<F> {
     /// Quality score reported to consumers.
     ///
     /// The contract is the ordering, not the numbers: a specific match always
     /// scores above a generic one, which always scores above a fuzzy one. The
     /// values themselves are free to be recalibrated.
-    pub fn as_quality(self) -> f32 {
+    pub fn as_quality(&self) -> f32 {
         match self {
             MatchRank::Specific => 1.0,
             MatchRank::Generic => 0.8,
-            MatchRank::Fuzzy => 0.5,
+            MatchRank::Fuzzy(_) => 0.5,
+        }
+    }
+
+    /// The tolerance that was applied, or `None` for an exact fit.
+    pub fn fuzzy(&self) -> Option<&F> {
+        match self {
+            MatchRank::Specific | MatchRank::Generic => None,
+            MatchRank::Fuzzy(reason) => Some(reason),
         }
     }
 }
@@ -97,10 +111,9 @@ pub struct DatabaseMatch<'a, DS, F> {
     pub label: &'a Label,
     /// The signature that matched, as written in the database.
     pub signature: &'a DS,
-    /// Quality score derived from the tier the match landed in.
-    pub quality: f32,
-    /// The tolerance that was applied, when the match is not exact.
-    pub fuzzy: Option<F>,
+    /// The tier this match landed in, carrying the applied tolerance when the
+    /// fit is not exact.
+    pub rank: MatchRank<F>,
 }
 
 /// Represents a collection of database signatures of a specific type.

--- a/huginn-net-db/tests/http/expsw.rs
+++ b/huginn-net-db/tests/http/expsw.rs
@@ -93,7 +93,7 @@ fn software_string_does_not_change_the_fit() {
         .http_request
         .find_best_match(&observation("definitely-not-firefox"))
         .unwrap_or_else(|| panic!("a dishonest software string must not reject the signature"));
-    assert_eq!(honest_match.quality, lying_match.quality);
+    assert_eq!(honest_match.rank, lying_match.rank);
 }
 
 /// The flag rides along with the match, because it takes the winning

--- a/huginn-net-db/tests/http/matcher.rs
+++ b/huginn-net-db/tests/http/matcher.rs
@@ -1,4 +1,4 @@
-use huginn_net_db::db_matching_trait::FingerprintDb;
+use huginn_net_db::db_matching_trait::{FingerprintDb, MatchRank};
 use huginn_net_db::{http, HttpDatabase, Type};
 use huginn_net_http::matcher_api::HttpMatcher;
 use huginn_net_http::observable::{HttpRequestObservation, HttpResponseObservation};
@@ -31,7 +31,7 @@ fn matching_firefox2_by_http_request() {
         assert_eq!(found.label.class, None);
         assert_eq!(found.label.flavor, Some("2.x".to_string()));
         assert_eq!(found.label.ty, Type::Specified);
-        assert_eq!(found.quality, 1.0);
+        assert_eq!(found.rank, MatchRank::Specific);
     } else {
         panic!("No match found for Firefox 2.x HTTP signature");
     }
@@ -71,7 +71,7 @@ fn matching_apache_by_http_response() {
         assert_eq!(found.label.class, None);
         assert_eq!(found.label.flavor, Some("2.x".to_string()));
         assert_eq!(found.label.ty, Type::Specified);
-        assert_eq!(found.quality, 1.0);
+        assert_eq!(found.rank, MatchRank::Specific);
     } else {
         panic!("No match found for Apache 2.x HTTP response signature");
     }
@@ -107,7 +107,7 @@ fn matching_chrome11_by_http_request() {
         assert_eq!(found.label.class, None);
         assert_eq!(found.label.flavor, Some("11 or newer".to_string()));
         assert_eq!(found.label.ty, Type::Specified);
-        assert_eq!(found.quality, 1.0);
+        assert_eq!(found.rank, MatchRank::Specific);
     } else {
         panic!("No match found for Chrome 11 HTTP signature");
     }
@@ -136,7 +136,7 @@ fn matching_modern_curl_by_http_request() {
         assert_eq!(found.label.class, None);
         assert_eq!(found.label.flavor, None);
         assert_eq!(found.label.ty, Type::Specified);
-        assert_eq!(found.quality, 1.0);
+        assert_eq!(found.rank, MatchRank::Specific);
     } else {
         panic!("No match found for modern curl HTTP signature");
     }
@@ -202,7 +202,7 @@ fn unknown_request_signature_does_not_match() {
     assert!(
         result.is_none(),
         "expected no match for synthetic signature, got {:?}",
-        result.map(|found| (found.label.name.clone(), found.quality))
+        result.map(|found| (found.label.name.clone(), found.rank))
     );
 }
 

--- a/huginn-net-db/tests/http/pcap_golden.rs
+++ b/huginn-net-db/tests/http/pcap_golden.rs
@@ -82,13 +82,14 @@ fn run_pcap_with_matcher(pcap_path: &str) -> Vec<HttpAnalysisResult> {
 
 fn assert_quality(actual: &MatchQuality, expected: &str, ctx: &str) {
     match actual {
-        MatchQuality::Matched(q) => {
+        MatchQuality::Matched(rank) => {
             let expected_q: f32 = expected
                 .strip_prefix("Matched(")
                 .and_then(|s| s.strip_suffix(")"))
                 .unwrap_or_else(|| panic!("{ctx}: unexpected quality format: {expected}"))
                 .parse()
                 .unwrap_or_else(|_| panic!("{ctx}: cannot parse quality float from: {expected}"));
+            let q = rank.as_quality();
             assert!(
                 (q - expected_q).abs() < 0.01,
                 "{ctx}: quality mismatch, expected {expected_q}, got {q}"

--- a/huginn-net-db/tests/tcp/match_selection.rs
+++ b/huginn-net-db/tests/tcp/match_selection.rs
@@ -1,7 +1,8 @@
 use huginn_net_db::database::{FingerprintCollection, Label, TcpIndexKey, Type};
-use huginn_net_db::db_matching_trait::FingerprintDb;
+use huginn_net_db::db_matching_trait::{FingerprintDb, MatchRank};
 use huginn_net_db::tcp::{IpVersion, PayloadSize, Quirk, QuirkSet, Signature, Ttl, WindowSize};
 use huginn_net_tcp::observable::TcpObservation;
+use huginn_net_tcp::output::FuzzyReason;
 
 type TcpCollection = FingerprintCollection<TcpObservation, Signature, TcpIndexKey>;
 
@@ -53,11 +54,11 @@ fn application_label(name: &str) -> Label {
     Label { ty: Type::Specified, class: None, name: name.to_string(), flavor: None }
 }
 
-fn best_match(entries: Vec<(Label, Vec<Signature>)>) -> Option<(String, f32)> {
+fn best_match(entries: Vec<(Label, Vec<Signature>)>) -> Option<(String, MatchRank<FuzzyReason>)> {
     let collection = TcpCollection::new(entries);
     collection
         .find_best_match(&observation())
-        .map(|found| (found.label.name.clone(), found.quality))
+        .map(|found| (found.label.name.clone(), found.rank))
 }
 
 #[test]
@@ -71,9 +72,9 @@ fn a_specific_signature_wins_over_a_generic_one_whatever_the_database_order() {
             entries.reverse();
         }
 
-        let (name, quality) = best_match(entries).unwrap_or_else(|| panic!("expected a match"));
+        let (name, rank) = best_match(entries).unwrap_or_else(|| panic!("expected a match"));
         assert_eq!(name, "Specific OS");
-        assert_eq!(quality, 1.0);
+        assert_eq!(rank, MatchRank::Specific);
     }
 }
 
@@ -81,24 +82,31 @@ fn a_specific_signature_wins_over_a_generic_one_whatever_the_database_order() {
 fn an_exact_generic_match_wins_over_a_fuzzy_specific_one() {
     // p0f keeps its fuzzy candidate aside and only reaches for it once no
     // generic signature fit either, so a tolerance never outranks an exact fit.
-    let (name, quality) = best_match(vec![
+    let (name, rank) = best_match(vec![
         (label("Fuzzy Specific OS", Type::Specified), vec![fuzzy_signature()]),
         (label("Generic OS", Type::Generic), vec![signature()]),
     ])
     .unwrap_or_else(|| panic!("expected a match"));
 
     assert_eq!(name, "Generic OS");
-    assert_eq!(quality, 0.8);
+    assert_eq!(rank, MatchRank::Generic);
 }
 
 #[test]
 fn a_fuzzy_match_is_reported_when_nothing_fits_exactly() {
-    let (name, quality) =
+    let (name, rank) =
         best_match(vec![(label("Fuzzy OS", Type::Specified), vec![fuzzy_signature()])])
             .unwrap_or_else(|| panic!("expected a fuzzy match"));
 
     assert_eq!(name, "Fuzzy OS");
-    assert_eq!(quality, 0.5);
+    let reason = rank
+        .fuzzy()
+        .unwrap_or_else(|| panic!("expected the fuzzy tier, got {rank:?}"));
+    assert_eq!(
+        reason.missing_quirks,
+        QuirkSet::from([Quirk::Df]),
+        "the signature declares df, the traffic did not show it"
+    );
 }
 
 #[test]
@@ -110,7 +118,7 @@ fn an_application_is_never_reported_on_a_fuzzy_match() {
 
 #[test]
 fn an_application_is_still_reported_on_an_exact_match() {
-    let (name, _quality) = best_match(vec![(application_label("NMap"), vec![signature()])])
+    let (name, _rank) = best_match(vec![(application_label("NMap"), vec![signature()])])
         .unwrap_or_else(|| panic!("an exact fit against an application signature is a match"));
 
     assert_eq!(name, "NMap");

--- a/huginn-net-db/tests/tcp/matcher.rs
+++ b/huginn-net-db/tests/tcp/matcher.rs
@@ -1,9 +1,10 @@
-use huginn_net_db::db_matching_trait::FingerprintDb;
+use huginn_net_db::db_matching_trait::{FingerprintDb, MatchRank};
 use huginn_net_db::tcp::{
     IpVersion, PayloadSize, Quirk, QuirkSet, Signature, TcpOption, Ttl, WindowSize,
 };
 use huginn_net_db::{TcpDatabase, Type};
 use huginn_net_tcp::observable::TcpObservation;
+use huginn_net_tcp::output::FuzzyReason;
 
 /// Resolves the window a signature declares into a concrete value a packet
 /// could have carried, so the signature can be replayed as an observation.
@@ -35,11 +36,11 @@ fn observation_from_signature(sig: &Signature) -> TcpObservation {
     }
 }
 
+/// `(name, class, flavor)` of the winning label plus the tier it won in.
+type MatchedLabel = (String, Option<String>, Option<String>, MatchRank<FuzzyReason>);
+
 /// Parses `raw` as a TCP signature and matches it against the request collection.
-fn match_request(
-    db: &TcpDatabase,
-    raw: &str,
-) -> Option<(String, Option<String>, Option<String>, f32)> {
+fn match_request(db: &TcpDatabase, raw: &str) -> Option<MatchedLabel> {
     let sig: Signature = match raw.parse() {
         Ok(sig) => sig,
         Err(e) => panic!("Failed to parse signature {raw}: {e}"),
@@ -50,7 +51,7 @@ fn match_request(
         found.label.name.clone(),
         found.label.class.clone(),
         found.label.flavor.clone(),
-        found.quality,
+        found.rank,
     ))
 }
 
@@ -84,10 +85,9 @@ fn matching_linux_by_tcp_request() {
         assert_eq!(found.label.class, Some("unix".to_string()));
         assert_eq!(found.label.flavor, Some("2.2.x-3.x".to_string()));
         assert_eq!(found.label.ty, Type::Generic);
-        // A catch-all signature fits, so the match is real but ranks below what
-        // a signature naming a concrete release would have scored.
-        assert_eq!(found.quality, 0.8);
-        assert_eq!(found.fuzzy, None, "every field fit, nothing was tolerated");
+        // A catch-all signature fits every field, so the match is real but
+        // ranks below what a signature naming a concrete release would have.
+        assert_eq!(found.rank, MatchRank::Generic);
     } else {
         panic!("No match found");
     }
@@ -139,8 +139,7 @@ fn matching_android_by_tcp_request() {
         assert_eq!(found.label.class, Some("unix".to_string()));
         assert_eq!(found.label.flavor, Some("Android".to_string()));
         assert_eq!(found.label.ty, Type::Specified);
-        assert_eq!(found.quality, 1.0);
-        assert_eq!(found.fuzzy, None);
+        assert_eq!(found.rank, MatchRank::Specific);
     } else {
         panic!("No match found");
     }
@@ -153,10 +152,9 @@ fn matching_android_by_tcp_request() {
         assert_eq!(found.label.class, Some("unix".to_string()));
         assert_eq!(found.label.flavor, Some("Android".to_string()));
         assert_eq!(found.label.ty, Type::Specified);
-        assert_eq!(found.quality, 1.0);
         // The packet crossed routers, which is ordinary: a plausible hop count
-        // is not a tolerance.
-        assert_eq!(found.fuzzy, None);
+        // is not a tolerance, so this stays out of the fuzzy tier.
+        assert_eq!(found.rank, MatchRank::Specific);
     } else {
         panic!("No match found");
     }

--- a/huginn-net-db/tests/tcp/params.rs
+++ b/huginn-net-db/tests/tcp/params.rs
@@ -84,7 +84,7 @@ fn tcp_matcher_fills_random_ttl_dist_and_params_tos() {
 
     let matched = OSQualityMatched {
         os: Some(found.os),
-        quality: MatchQuality::Matched { quality: found.quality, fuzzy: found.fuzzy },
+        quality: MatchQuality::Matched(found.rank),
         dist: found.dist,
         random_ttl: found.random_ttl,
         excess_dist: found.excess_dist,

--- a/huginn-net-db/tests/tcp/pcap_golden.rs
+++ b/huginn-net-db/tests/tcp/pcap_golden.rs
@@ -88,13 +88,14 @@ fn run_pcap_with_matcher(pcap_path: &str) -> Vec<TcpAnalysisResult> {
 
 fn assert_quality(actual: &MatchQuality, expected: &str, ctx: &str) {
     match actual {
-        MatchQuality::Matched { quality, .. } => {
+        MatchQuality::Matched(rank) => {
             let expected_q: f32 = expected
                 .strip_prefix("Matched(")
                 .and_then(|s| s.strip_suffix(")"))
                 .unwrap_or_else(|| panic!("{ctx}: unexpected quality format: {expected}"))
                 .parse()
                 .unwrap_or_else(|_| panic!("{ctx}: cannot parse quality float: {expected}"));
+            let quality = rank.as_quality();
             assert!(
                 (quality - expected_q).abs() < 0.01,
                 "{ctx}: quality mismatch, expected {expected_q}, got {quality}"
@@ -106,10 +107,9 @@ fn assert_quality(actual: &MatchQuality, expected: &str, ctx: &str) {
 }
 
 fn assert_fuzzy(actual: &MatchQuality, expected: &str, ctx: &str) {
-    let rendered = match actual {
-        MatchQuality::Matched { fuzzy: Some(reason), .. } => reason.to_string(),
-        _ => "none".to_string(),
-    };
+    let rendered = actual
+        .fuzzy()
+        .map_or_else(|| "none".to_string(), ToString::to_string);
     assert_eq!(rendered, expected, "{ctx}: tolerated difference");
 }
 

--- a/huginn-net-http/src/matcher_api.rs
+++ b/huginn-net-http/src/matcher_api.rs
@@ -7,14 +7,14 @@
 //! but downstream users are free to plug their own.
 
 use crate::observable::{HttpRequestObservation, HttpResponseObservation};
-use crate::output::{Browser, WebServer};
+use crate::output::{Browser, MatchRank, WebServer};
 
 /// Result of matching an [`HttpRequestObservation`] against a database.
 /// `dishonest` is set when the User-Agent does not back the matched signature.
 #[derive(Debug, Clone)]
 pub struct HttpRequestMatch {
     pub browser: Browser,
-    pub quality: f32,
+    pub rank: MatchRank,
     pub dishonest: bool,
 }
 
@@ -23,7 +23,7 @@ pub struct HttpRequestMatch {
 #[derive(Debug, Clone)]
 pub struct HttpResponseMatch {
     pub web_server: WebServer,
-    pub quality: f32,
+    pub rank: MatchRank,
     pub dishonest: bool,
 }
 

--- a/huginn-net-http/src/output/common.rs
+++ b/huginn-net-http/src/output/common.rs
@@ -34,18 +34,60 @@ impl fmt::Display for OsKind {
     }
 }
 
+/// Which tier an HTTP match landed in: `Specific` beats `Generic`.
+///
+/// HTTP signatures have no tolerances: a field that disagrees rejects the
+/// signature, so there is no fuzzy tier here, unlike TCP.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MatchRank {
+    /// Fit against a signature naming a concrete product.
+    Specific,
+    /// Fit against a catch-all signature.
+    Generic,
+}
+
+impl MatchRank {
+    /// Score in `[0.0, 1.0]` for this tier. The ordering is the contract; the
+    /// values are free to be recalibrated.
+    pub fn as_quality(&self) -> f32 {
+        match self {
+            MatchRank::Specific => 1.0,
+            MatchRank::Generic => 0.8,
+        }
+    }
+}
+
 /// Quality classification for an HTTP match.
 ///
-/// - `Matched(score)` a signature was matched with the given quality score
-///   (higher is better, typically in `[0.0, 1.0]`).
+/// - `Matched(rank)` a signature was matched, in the carried tier.
 /// - `NotMatched` the matcher was active but no signature was a viable fit.
 /// - `Disabled` matching was disabled (no matcher plugged in).
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "json", derive(serde::Serialize))]
 pub enum MatchQuality {
-    Matched(f32),
+    Matched(MatchRank),
     NotMatched,
     Disabled,
+}
+
+/// The wire format keeps the tier numeric: `Matched` serializes as its score.
+#[cfg(feature = "json")]
+impl serde::Serialize for MatchQuality {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            MatchQuality::Matched(rank) => serializer.serialize_newtype_variant(
+                "MatchQuality",
+                0,
+                "Matched",
+                &rank.as_quality(),
+            ),
+            MatchQuality::NotMatched => {
+                serializer.serialize_unit_variant("MatchQuality", 1, "NotMatched")
+            }
+            MatchQuality::Disabled => {
+                serializer.serialize_unit_variant("MatchQuality", 2, "Disabled")
+            }
+        }
+    }
 }
 
 /// Represents a browser identified from an HTTP request signature.

--- a/huginn-net-http/src/output/mod.rs
+++ b/huginn-net-http/src/output/mod.rs
@@ -4,7 +4,11 @@ pub mod request;
 #[cfg(feature = "p0f-response")]
 pub mod response;
 
-#[cfg(feature = "json")]
+// Only the request / response outputs stringify a field this way.
+#[cfg(all(
+    feature = "json",
+    any(feature = "p0f-request", feature = "p0f-response")
+))]
 pub(crate) fn serialize_display<T: std::fmt::Display, S: serde::Serializer>(
     val: &T,
     s: S,

--- a/huginn-net-http/src/process/mod.rs
+++ b/huginn-net-http/src/process/mod.rs
@@ -136,7 +136,7 @@ fn build_http_result(
                     (
                         BrowserQualityMatched {
                             browser: Some(req_match.browser.clone()),
-                            quality: MatchQuality::Matched(req_match.quality),
+                            quality: MatchQuality::Matched(req_match.rank.clone()),
                         },
                         Some(notes),
                         Some(req_match),
@@ -191,7 +191,7 @@ fn build_http_result(
                     (
                         WebServerQualityMatched {
                             web_server: Some(resp_match.web_server),
-                            quality: MatchQuality::Matched(resp_match.quality),
+                            quality: MatchQuality::Matched(resp_match.rank),
                         },
                         Some(notes),
                     )

--- a/huginn-net-http/tests/http/ua_os.rs
+++ b/huginn-net-http/tests/http/ua_os.rs
@@ -3,7 +3,7 @@ use huginn_net_http::http::{
 };
 use huginn_net_http::matcher_api::{HttpMatcher, HttpRequestMatch, HttpResponseMatch, UaOsMatch};
 use huginn_net_http::observable::{HttpRequestObservation, HttpResponseObservation};
-use huginn_net_http::output::{Browser, OsKind};
+use huginn_net_http::output::{Browser, MatchRank, OsKind};
 
 struct StubMatcher {
     request: Option<HttpRequestMatch>,
@@ -32,7 +32,7 @@ fn userland(dishonest: bool) -> HttpRequestMatch {
             variant: None,
             kind: OsKind::Specified,
         },
-        quality: 1.0,
+        rank: MatchRank::Specific,
         dishonest,
     }
 }
@@ -45,7 +45,7 @@ fn os_signature() -> HttpRequestMatch {
             variant: None,
             kind: OsKind::Specified,
         },
-        quality: 1.0,
+        rank: MatchRank::Specific,
         dishonest: false,
     }
 }

--- a/huginn-net-tcp/src/matcher_api.rs
+++ b/huginn-net-tcp/src/matcher_api.rs
@@ -10,21 +10,17 @@
 //! trait.
 
 use crate::observable::TcpObservation;
-use crate::output::{FuzzyReason, OperativeSystem};
+use crate::output::{MatchRank, OperativeSystem};
 
 /// A matched OS for a single observed TCP fingerprint.
-///
-/// `quality` is a similarity score in `[0.0, 1.0]`, where `1.0` is a perfect
-/// match. The exact scoring is up to the matcher implementer, but it must rank
-/// an exact match above one that needed a tolerance.
 #[derive(Debug, Clone)]
 pub struct TcpMatch {
     /// Operating system / application identified by the matcher.
     pub os: OperativeSystem,
-    /// Quality of the match, in `[0.0, 1.0]`.
-    pub quality: f32,
-    /// Set when the match only holds because a tolerance was applied.
-    pub fuzzy: Option<FuzzyReason>,
+    /// Tier the match landed in, carrying the tolerance that was applied when
+    /// the fit is not exact. Implementers must report a stretched fit as
+    /// [`MatchRank::Fuzzy`] rather than as an exact one.
+    pub rank: MatchRank,
     /// Hop distance reported in `Dist:` (signature hops, or `guess_dist`).
     pub dist: u8,
     /// Winning signature used a randomised TTL (`nnn-` / `bad_ttl`).

--- a/huginn-net-tcp/src/output/common.rs
+++ b/huginn-net-tcp/src/output/common.rs
@@ -85,30 +85,56 @@ impl fmt::Display for FuzzyReason {
     }
 }
 
+/// Which tier a match landed in, in preference order: `Specific` beats
+/// `Generic`, and both beat `Fuzzy`.
+///
+/// The tier and the tolerance are the same fact, so they are one value: a match
+/// is fuzzy exactly when there is a [`FuzzyReason`] to report, which makes a
+/// "perfect fuzzy match" unrepresentable.
+///
+/// Distinct from [`OsKind`], which describes the matched *label* rather than
+/// the fit: a fuzzy match against a specified signature is `Fuzzy` here and
+/// `Specified` there.
+#[derive(Clone, Debug, PartialEq)]
+pub enum MatchRank {
+    /// Exact fit against a signature naming a concrete product.
+    Specific,
+    /// Exact fit against a catch-all signature.
+    Generic,
+    /// Only holds because the carried tolerance was applied. The matched
+    /// product is still the best explanation available, but it was not an
+    /// exact fit.
+    Fuzzy(FuzzyReason),
+}
+
+impl MatchRank {
+    /// Score in `[0.0, 1.0]` for this tier. The ordering is the contract; the
+    /// values are free to be recalibrated.
+    pub fn as_quality(&self) -> f32 {
+        match self {
+            MatchRank::Specific => 1.0,
+            MatchRank::Generic => 0.8,
+            MatchRank::Fuzzy(_) => 0.5,
+        }
+    }
+
+    /// The tolerance that was applied, or `None` for an exact fit.
+    pub fn fuzzy(&self) -> Option<&FuzzyReason> {
+        match self {
+            MatchRank::Specific | MatchRank::Generic => None,
+            MatchRank::Fuzzy(reason) => Some(reason),
+        }
+    }
+}
+
 /// Outcome of matching an observation against a fingerprint database.
 ///
 /// Independent of any specific database type so that consumers of this
 /// crate don't need to depend on `huginn-net-db`.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "json", derive(serde::Serialize))]
 pub enum MatchQuality {
-    /// A signature matched.
-    Matched {
-        /// Which tier the match landed in, as a number in `[0.0, 1.0]`: an
-        /// exact fit against a signature naming a concrete product scores
-        /// highest, a catch-all signature lower, and a match that needed a
-        /// tolerance lowest. The ordering is the contract; the values are free
-        /// to be recalibrated.
-        quality: f32,
-        /// Set when the match only holds because a tolerance was applied. The
-        /// matched product is still the best explanation available, but it was
-        /// not an exact fit.
-        #[cfg_attr(
-            feature = "json",
-            serde(serialize_with = "super::serialize_optional_display")
-        )]
-        fuzzy: Option<FuzzyReason>,
-    },
+    /// A signature matched, in the carried tier.
+    Matched(MatchRank),
     /// A matcher was attached but no signature matched the observation.
     NotMatched,
     /// No matcher was attached, so matching was skipped entirely.
@@ -116,9 +142,38 @@ pub enum MatchQuality {
 }
 
 impl MatchQuality {
-    /// A match that fit every field exactly.
-    pub fn exact(quality: f32) -> Self {
-        MatchQuality::Matched { quality, fuzzy: None }
+    /// The tolerance the winning signature needed, if any. `None` for an exact
+    /// fit and for every non-match.
+    pub fn fuzzy(&self) -> Option<&FuzzyReason> {
+        match self {
+            MatchQuality::Matched(rank) => rank.fuzzy(),
+            MatchQuality::NotMatched | MatchQuality::Disabled => None,
+        }
+    }
+}
+
+/// The wire format keeps the tier numeric: `Matched` serializes as a
+/// `quality` score plus a stringified `fuzzy`.
+#[cfg(feature = "json")]
+impl serde::Serialize for MatchQuality {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStructVariant;
+
+        match self {
+            MatchQuality::Matched(rank) => {
+                let mut variant =
+                    serializer.serialize_struct_variant("MatchQuality", 0, "Matched", 2)?;
+                variant.serialize_field("quality", &rank.as_quality())?;
+                variant.serialize_field("fuzzy", &rank.fuzzy().map(ToString::to_string))?;
+                variant.end()
+            }
+            MatchQuality::NotMatched => {
+                serializer.serialize_unit_variant("MatchQuality", 1, "NotMatched")
+            }
+            MatchQuality::Disabled => {
+                serializer.serialize_unit_variant("MatchQuality", 2, "Disabled")
+            }
+        }
     }
 }
 
@@ -177,7 +232,7 @@ impl OSQualityMatched {
         {
             flags.push("generic".to_string());
         }
-        if let MatchQuality::Matched { fuzzy: Some(reason), .. } = &self.quality {
+        if let Some(reason) = self.quality.fuzzy() {
             flags.push(format!("fuzzy ({reason})"));
         }
         if self.random_ttl {

--- a/huginn-net-tcp/src/output/mod.rs
+++ b/huginn-net-tcp/src/output/mod.rs
@@ -8,23 +8,13 @@ pub mod syn_ack;
 #[cfg(feature = "uptime")]
 pub mod uptime;
 
-#[cfg(feature = "json")]
+// Only the SYN / SYN+ACK outputs stringify a field this way.
+#[cfg(all(feature = "json", any(feature = "syn", feature = "syn-ack")))]
 pub(crate) fn serialize_display<T: std::fmt::Display, S: serde::Serializer>(
     val: &T,
     s: S,
 ) -> Result<S::Ok, S::Error> {
     s.serialize_str(&val.to_string())
-}
-
-#[cfg(feature = "json")]
-pub(crate) fn serialize_optional_display<T: std::fmt::Display, S: serde::Serializer>(
-    val: &Option<T>,
-    s: S,
-) -> Result<S::Ok, S::Error> {
-    match val {
-        Some(val) => s.serialize_some(&val.to_string()),
-        None => s.serialize_none(),
-    }
 }
 
 pub use common::*;

--- a/huginn-net-tcp/src/output/mod.rs
+++ b/huginn-net-tcp/src/output/mod.rs
@@ -8,7 +8,6 @@ pub mod syn_ack;
 #[cfg(feature = "uptime")]
 pub mod uptime;
 
-// Only the SYN / SYN+ACK outputs stringify a field this way.
 #[cfg(all(feature = "json", any(feature = "syn", feature = "syn-ack")))]
 pub(crate) fn serialize_display<T: std::fmt::Display, S: serde::Serializer>(
     val: &T,

--- a/huginn-net-tcp/src/process/mod.rs
+++ b/huginn-net-tcp/src/process/mod.rs
@@ -16,7 +16,7 @@ use crate::output::SynAckTCPOutput;
 use crate::output::SynTCPOutput;
 use crate::output::{IpPort, TcpAnalysisResult};
 #[cfg(feature = "mtu")]
-use crate::output::{MTUOutput, MTUQualityMatched};
+use crate::output::{MTUOutput, MTUQualityMatched, MatchRank};
 #[cfg(feature = "uptime")]
 use crate::output::{UptimeOutput, UptimeRole};
 use pnet::packet::ipv4::Ipv4Packet;
@@ -331,7 +331,7 @@ where
         Some(m) => match call(m) {
             Some(found) => OSQualityMatched {
                 os: Some(found.os),
-                quality: MatchQuality::Matched { quality: found.quality, fuzzy: found.fuzzy },
+                quality: MatchQuality::Matched(found.rank),
                 dist: found.dist,
                 random_ttl: found.random_ttl,
                 excess_dist: found.excess_dist,
@@ -347,9 +347,10 @@ where
 fn classify_mtu_match(matcher: Option<&dyn TcpMatcher>, mtu: u16) -> MTUQualityMatched {
     match matcher {
         Some(m) => match m.match_mtu(mtu) {
-            Some(found) => {
-                MTUQualityMatched { link: Some(found.link), quality: MatchQuality::exact(1.0) }
-            }
+            Some(found) => MTUQualityMatched {
+                link: Some(found.link),
+                quality: MatchQuality::Matched(MatchRank::Specific),
+            },
             None => MTUQualityMatched { link: None, quality: MatchQuality::NotMatched },
         },
         None => MTUQualityMatched { link: None, quality: MatchQuality::Disabled },

--- a/huginn-net/src/analyzer/matchers.rs
+++ b/huginn-net/src/analyzer/matchers.rs
@@ -29,6 +29,8 @@ use huginn_net_tcp::observable::ObservableTcp;
 use huginn_net_tcp::output::MTUQualityMatched;
 #[cfg(any(feature = "tcp-syn", feature = "tcp-syn-ack", feature = "tcp-mtu"))]
 use huginn_net_tcp::output::MatchQuality as TcpMatchQuality;
+#[cfg(all(feature = "db", feature = "tcp-mtu"))]
+use huginn_net_tcp::output::MatchRank as TcpMatchRank;
 #[cfg(any(feature = "tcp-syn", feature = "tcp-syn-ack"))]
 use huginn_net_tcp::output::OSQualityMatched;
 
@@ -100,7 +102,8 @@ impl<'a> HuginnNet<'a> {
                 method: match_mtu(*mtu),
                 success: found => MTUQualityMatched {
                     link: Some(found.link),
-                    quality: TcpMatchQuality::exact(1.0),
+                    // An MTU lookup is an exact table hit or nothing.
+                    quality: TcpMatchQuality::Matched(TcpMatchRank::Specific),
                 },
                 failure: MTUQualityMatched {
                     link: None,
@@ -130,10 +133,7 @@ impl<'a> HuginnNet<'a> {
                 method: match_tcp_request(obs),
                 success: found => OSQualityMatched {
                     os: Some(found.os),
-                    quality: TcpMatchQuality::Matched {
-                        quality: found.quality,
-                        fuzzy: found.fuzzy,
-                    },
+                    quality: TcpMatchQuality::Matched(found.rank),
                     dist: found.dist,
                     random_ttl: found.random_ttl,
                     excess_dist: found.excess_dist,
@@ -160,10 +160,7 @@ impl<'a> HuginnNet<'a> {
                 method: match_tcp_response(obs),
                 success: found => OSQualityMatched {
                     os: Some(found.os),
-                    quality: TcpMatchQuality::Matched {
-                        quality: found.quality,
-                        fuzzy: found.fuzzy,
-                    },
+                    quality: TcpMatchQuality::Matched(found.rank),
                     dist: found.dist,
                     random_ttl: found.random_ttl,
                     excess_dist: found.excess_dist,
@@ -200,7 +197,7 @@ impl<'a> HuginnNet<'a> {
                     (
                         BrowserQualityMatched {
                             browser: Some(found.browser.clone()),
-                            quality: HttpMatchQuality::Matched(found.quality),
+                            quality: HttpMatchQuality::Matched(found.rank.clone()),
                         },
                         Some(notes),
                         Some(found),
@@ -277,7 +274,7 @@ impl<'a> HuginnNet<'a> {
                     (
                         WebServerQualityMatched {
                             web_server: Some(found.web_server),
-                            quality: HttpMatchQuality::Matched(found.quality),
+                            quality: HttpMatchQuality::Matched(found.rank),
                         },
                         Some(notes),
                     )

--- a/huginn-net/src/lib.rs
+++ b/huginn-net/src/lib.rs
@@ -72,7 +72,8 @@ pub use huginn_net_tcp::output::SynTCPOutput;
 #[cfg(feature = "tcp-mtu")]
 pub use huginn_net_tcp::output::{MTUOutput, MTUQualityMatched};
 pub use huginn_net_tcp::output::{
-    MatchQuality as TcpMatchQuality, OperativeSystem, OsKind as TcpOsKind,
+    MatchQuality as TcpMatchQuality, MatchRank as TcpMatchRank, OperativeSystem,
+    OsKind as TcpOsKind,
 };
 #[cfg(feature = "tcp-uptime")]
 pub use huginn_net_tcp::output::{UptimeOutput, UptimeRole};
@@ -85,7 +86,8 @@ pub use huginn_net_http::observable::ObservableHttpRequest;
 #[cfg(feature = "http-p0f-response")]
 pub use huginn_net_http::observable::ObservableHttpResponse;
 pub use huginn_net_http::output::{
-    Browser, MatchQuality as HttpMatchQuality, OsKind as HttpOsKind, WebServer,
+    Browser, MatchQuality as HttpMatchQuality, MatchRank as HttpMatchRank, OsKind as HttpOsKind,
+    WebServer,
 };
 #[cfg(feature = "http-p0f-request")]
 pub use huginn_net_http::output::{BrowserQualityMatched, HttpRequestOutput};

--- a/huginn-net/src/matcher.rs
+++ b/huginn-net/src/matcher.rs
@@ -6,7 +6,7 @@
 ///
 /// ```rust
 /// use huginn_net::quality_match;
-/// # use huginn_net_tcp::output::{MatchQuality, OSQualityMatched};
+/// # use huginn_net_tcp::output::{MatchQuality, MatchRank, OSQualityMatched};
 /// # struct Config { matcher_enabled: bool }
 /// # struct Matcher;
 /// # let config = Config { matcher_enabled: true };
@@ -14,10 +14,10 @@
 /// let quality = quality_match!(
 ///     enabled: config.matcher_enabled,
 ///     matcher: matcher,
-///     call: matcher => None::<(String, f32)>,
-///     matched: (name, quality) => OSQualityMatched {
+///     call: matcher => None::<(String, MatchRank)>,
+///     matched: (name, rank) => OSQualityMatched {
 ///         os: None, // real code: Some(OperativeSystem::from(label))
-///         quality: MatchQuality::exact(quality),
+///         quality: MatchQuality::Matched(rank),
 ///         dist: 0,
 ///         random_ttl: false,
 ///         excess_dist: false,
@@ -73,7 +73,7 @@ macro_rules! quality_match {
 ///
 /// ```rust
 /// use huginn_net::{simple_quality_match, quality_match};
-/// # use huginn_net_tcp::output::{MTUQualityMatched, MatchQuality};
+/// # use huginn_net_tcp::output::{MTUQualityMatched, MatchQuality, MatchRank};
 /// # struct Config { matcher_enabled: bool }
 /// # struct Matcher;
 /// # impl Matcher {
@@ -89,7 +89,7 @@ macro_rules! quality_match {
 ///     method: match_mtu(observable_mtu.value),
 ///     success: found => MTUQualityMatched {
 ///         link: Some(found.link),
-///         quality: MatchQuality::exact(1.0),
+///         quality: MatchQuality::Matched(MatchRank::Specific),
 ///     },
 ///     failure: MTUQualityMatched {
 ///         link: None,

--- a/huginn-net/tests/analyzer/smoke.rs
+++ b/huginn-net/tests/analyzer/smoke.rs
@@ -6,7 +6,9 @@
 //! that the umbrella crate correctly wires and combines both protocols in a
 //! single `FingerprintResult`.
 
-use huginn_net::{Database, HuginnNet, NotCheckedReason, TcpMatchQuality, UaOsAgreement};
+use huginn_net::{
+    Database, HuginnNet, NotCheckedReason, TcpMatchQuality, TcpMatchRank, UaOsAgreement,
+};
 use huginn_net_http::output::MatchQuality as HttpMatchQuality;
 use huginn_net_tcp::tcp::{Quirk, QuirkSet};
 use std::path::Path;
@@ -47,7 +49,7 @@ fn e2e_tcp_syn_and_mtu_are_identified() {
         .unwrap_or_else(|| panic!("expected an OS match for the first SYN"));
     assert_eq!(os.name, "Mac OS X", "first SYN OS name");
     match &first_syn.os_matched.quality {
-        TcpMatchQuality::Matched { fuzzy: Some(reason), .. } => {
+        TcpMatchQuality::Matched(TcpMatchRank::Fuzzy(reason)) => {
             assert_eq!(reason.missing_quirks, QuirkSet::from([Quirk::NonZeroID]));
             assert_eq!(reason.added_quirks, QuirkSet::from([Quirk::Ecn]));
             assert_eq!(

--- a/scripts/feature-matrix.json
+++ b/scripts/feature-matrix.json
@@ -15,10 +15,12 @@
     { "crate": "huginn-net-tcp",  "features": "syn,mtu,uptime" },
     { "crate": "huginn-net-tcp",  "features": "syn-ack,mtu,uptime" },
     { "crate": "huginn-net-tcp",  "features": "full", "with_tests": true, "with_bench": true },
+    { "crate": "huginn-net-tcp",  "features": "json" },
 
     { "crate": "huginn-net-tls",  "features": "" },
     { "crate": "huginn-net-tls",  "features": "stable-v1" },
     { "crate": "huginn-net-tls",  "features": "full" },
+    { "crate": "huginn-net-tls",  "features": "json" },
 
     { "crate": "huginn-net-db",   "features": "" },
     { "crate": "huginn-net-db",   "features": "tcp" },
@@ -33,6 +35,7 @@
     { "crate": "huginn-net-http", "features": "p0f-request,akamai" },
     { "crate": "huginn-net-http", "features": "p0f-response,akamai" },
     { "crate": "huginn-net-http", "features": "full", "with_tests": true, "with_bench": true },
+    { "crate": "huginn-net-http", "features": "json" },
 
     { "crate": "huginn-net",      "features": "" },
     { "crate": "huginn-net",      "features": "db" },
@@ -48,5 +51,6 @@
     { "crate": "huginn-net",      "features": "db,tcp-syn,tcp-syn-ack,tcp-mtu,tcp-uptime,http-p0f-response" },
     { "crate": "huginn-net",      "features": "db,tcp-syn,tcp-syn-ack,tcp-mtu,tcp-uptime,http-p0f-request,http-p0f-response" },
     { "crate": "huginn-net",      "features": "tls-stable-v1" },
-    { "crate": "huginn-net",      "features": "full", "with_tests": true }
+    { "crate": "huginn-net",      "features": "full", "with_tests": true },
+    { "crate": "huginn-net",      "features": "json" }
 ]


### PR DESCRIPTION
The matcher no longer collapses the match tier into an f32: DatabaseMatch / TcpMatch / Http*Match now carry MatchRank (Specific | Generic | Fuzzy(reason)), and HTTP cannot construct fuzzy because NoFuzziness is uninhabited.

MatchQuality::Matched(rank) replaces Matched { quality, fuzzy } / Matched(f32), so invalid states like exact(0.3) or an exact match with fuzzy: Some(..) can no longer be built.

as_quality() is only used for Display/JSON; the wire format is unchanged. The feature matrix now covers json alone (dead code in serialize_display when serde is on without protocol features).